### PR TITLE
Store users with Hive instead of shared preferences

### DIFF
--- a/lib/components/AlbumImage.dart
+++ b/lib/components/AlbumImage.dart
@@ -36,7 +36,7 @@ class AlbumImage extends StatelessWidget {
             try {
               return CachedNetworkImage(
                 imageUrl:
-                    "${jellyfinApiData.baseUrlFromVariable}/Items/$itemId/Images/Primary?format=webp&MaxWidth=$physicalWidth&MaxHeight=$physicalHeight",
+                    "${jellyfinApiData.currentUser.baseUrl}/Items/$itemId/Images/Primary?format=webp&MaxWidth=$physicalWidth&MaxHeight=$physicalHeight",
                 fit: BoxFit.cover,
                 placeholder: (context, url) => Container(
                   color: Theme.of(context).cardColor,

--- a/lib/components/DownloadsErrorScreen/DownloadErrorListTile.dart
+++ b/lib/components/DownloadsErrorScreen/DownloadErrorListTile.dart
@@ -3,7 +3,6 @@ import 'package:flutter_downloader/flutter_downloader.dart';
 import 'package:get_it/get_it.dart';
 
 import '../../services/DownloadsHelper.dart';
-import '../../models/JellyfinModels.dart';
 import '../AlbumImage.dart';
 
 class DownloadErrorListTile extends StatelessWidget {

--- a/lib/components/DownloadsScreen/DownloadedAlbumsList.dart
+++ b/lib/components/DownloadsScreen/DownloadedAlbumsList.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 import 'package:hive/hive.dart';
 
-import '../errorSnackbar.dart';
 import '../../services/DownloadsHelper.dart';
 import '../../services/processArtist.dart';
 import '../AlbumImage.dart';

--- a/lib/components/MusicScreen/MusicScreenTabView.dart
+++ b/lib/components/MusicScreen/MusicScreenTabView.dart
@@ -40,18 +40,15 @@ class _MusicScreenTabViewState extends State<MusicScreenTabView>
   @override
   void initState() {
     super.initState();
-    jellyfinApiData.getView().then((view) {
-      albumViewFuture = jellyfinApiData.getItems(
-        // If no parent item is specified, we should set the whole music library as the parent item (for getting all albums/playlists)
-        parentItem: widget.parentItem == null ? view : widget.parentItem,
-        includeItemTypes: _includeItemTypes(widget.tabContentType),
-        sortBy: "SortName",
-        searchTerm: widget.searchTerm,
-      );
-
-      // We need to run setState to rebuild the widget with this new data
-      setState(() {});
-    });
+    albumViewFuture = jellyfinApiData.getItems(
+      // If no parent item is specified, we should set the whole music library as the parent item (for getting all albums/playlists)
+      parentItem: widget.parentItem == null
+          ? jellyfinApiData.currentUser.view
+          : widget.parentItem,
+      includeItemTypes: _includeItemTypes(widget.tabContentType),
+      sortBy: "SortName",
+      searchTerm: widget.searchTerm,
+    );
   }
 
   @override

--- a/lib/components/PlayerScreen/ProgressSlider.dart
+++ b/lib/components/PlayerScreen/ProgressSlider.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:math';
 
 import 'package:audio_service/audio_service.dart';
 import 'package:flutter/material.dart';

--- a/lib/components/ServerSelector/ServerSelectorForm.dart
+++ b/lib/components/ServerSelector/ServerSelectorForm.dart
@@ -73,7 +73,7 @@ class _ServerSelectorFormState extends State<ServerSelectorForm> {
                             keyboardType: TextInputType.url,
                             autofillHints: [AutofillHints.url],
                             textInputAction: TextInputAction.done,
-                            onFieldSubmitted: (_) async => await sendForm(),
+                            onFieldSubmitted: (_) => sendForm(),
                             validator: (value) {
                               // TODO: Check if a server exists on the given IP during this validation?
                               if (value.isEmpty) {
@@ -98,7 +98,7 @@ class _ServerSelectorFormState extends State<ServerSelectorForm> {
               FractionallySizedBox(
                 widthFactor: 0.9,
                 child: RaisedButton(
-                  onPressed: () async => await sendForm(),
+                  onPressed: () => sendForm(),
                   child: Text("Next"),
                 ),
               )
@@ -109,11 +109,11 @@ class _ServerSelectorFormState extends State<ServerSelectorForm> {
     );
   }
 
-  Future<void> sendForm() async {
+  void sendForm() {
     if (_formKey.currentState.validate()) {
       // If the fields are validated, save them to the API
       _formKey.currentState.save();
-      await jellyfinApiData.saveBaseUrl(_protocol, _address);
+      jellyfinApiData.baseUrlTemp = "$_protocol://$_address";
       // Go to user selection
       Navigator.of(context).pushNamed("/login/userSelector");
     }

--- a/lib/components/ViewSelector/ViewList.dart
+++ b/lib/components/ViewSelector/ViewList.dart
@@ -84,7 +84,8 @@ class _ViewListState extends State<ViewList> {
                     JellyfinApiData jellyfinApiData =
                         GetIt.instance<JellyfinApiData>();
                     try {
-                      jellyfinApiData.saveView(snapshot.data[index]);
+                      jellyfinApiData.saveView(snapshot.data[index],
+                          jellyfinApiData.currentUser.userDetails.user.id);
                       Navigator.of(context)
                           .pushNamedAndRemoveUntil("/music", (route) => false);
                     } catch (e) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -64,6 +64,25 @@ Future<void> setupHive() async {
   Hive.registerAdapter(MediaStreamAdapter());
   Hive.registerAdapter(AuthenticationResultAdapter());
   Hive.registerAdapter(FinampUserAdapter());
+  Hive.registerAdapter(UserDtoAdapter());
+  Hive.registerAdapter(SessionInfoAdapter());
+  Hive.registerAdapter(UserConfigurationAdapter());
+  Hive.registerAdapter(UserPolicyAdapter());
+  Hive.registerAdapter(AccessScheduleAdapter());
+  Hive.registerAdapter(PlayerStateInfoAdapter());
+  Hive.registerAdapter(SessionUserInfoAdapter());
+  Hive.registerAdapter(ClientCapabilitiesAdapter());
+  Hive.registerAdapter(DeviceProfileAdapter());
+  Hive.registerAdapter(DeviceIdentificationAdapter());
+  Hive.registerAdapter(HttpHeaderInfoAdapter());
+  Hive.registerAdapter(XmlAttributeAdapter());
+  Hive.registerAdapter(DirectPlayProfileAdapter());
+  Hive.registerAdapter(TranscodingProfileAdapter());
+  Hive.registerAdapter(ContainerProfileAdapter());
+  Hive.registerAdapter(ProfileConditionAdapter());
+  Hive.registerAdapter(CodecProfileAdapter());
+  Hive.registerAdapter(ResponseProfileAdapter());
+  Hive.registerAdapter(SubtitleProfileAdapter());
   await Future.wait([
     Hive.openBox<DownloadedAlbum>("DownloadedAlbums"),
     Hive.openBox<DownloadedSong>("DownloadedItems"),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,6 +21,7 @@ import 'services/AudioServiceHelper.dart';
 import 'services/JellyfinApiData.dart';
 import 'services/DownloadsHelper.dart';
 import 'models/JellyfinModels.dart';
+import 'models/FinampModels.dart';
 
 void main() async {
   _setupLogging();
@@ -61,11 +62,14 @@ Future<void> setupHive() async {
   Hive.registerAdapter(DownloadedAlbumAdapter());
   Hive.registerAdapter(MediaSourceInfoAdapter());
   Hive.registerAdapter(MediaStreamAdapter());
-  // await GetIt.instance<FinampBoxes>().setup();
+  Hive.registerAdapter(AuthenticationResultAdapter());
+  Hive.registerAdapter(FinampUserAdapter());
   await Future.wait([
     Hive.openBox<DownloadedAlbum>("DownloadedAlbums"),
     Hive.openBox<DownloadedSong>("DownloadedItems"),
-    Hive.openBox<DownloadedSong>("DownloadIds")
+    Hive.openBox<DownloadedSong>("DownloadIds"),
+    Hive.openBox<FinampUser>("FinampUsers"),
+    Hive.openBox<String>("CurrentUserId"),
   ]);
 }
 

--- a/lib/models/FinampModels.dart
+++ b/lib/models/FinampModels.dart
@@ -1,0 +1,21 @@
+import 'package:hive/hive.dart';
+
+import 'JellyfinModels.dart';
+
+part 'FinampModels.g.dart';
+
+@HiveType(typeId: 8)
+class FinampUser {
+  FinampUser({
+    this.baseUrl,
+    this.userDetails,
+    this.view,
+  });
+
+  @HiveField(0)
+  String baseUrl;
+  @HiveField(1)
+  AuthenticationResult userDetails;
+  @HiveField(2)
+  BaseItemDto view;
+}

--- a/lib/models/FinampModels.g.dart
+++ b/lib/models/FinampModels.g.dart
@@ -1,0 +1,46 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'FinampModels.dart';
+
+// **************************************************************************
+// TypeAdapterGenerator
+// **************************************************************************
+
+class FinampUserAdapter extends TypeAdapter<FinampUser> {
+  @override
+  final int typeId = 8;
+
+  @override
+  FinampUser read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return FinampUser()
+      ..baseUrl = fields[0] as String
+      ..userDetails = fields[1] as AuthenticationResult
+      ..view = fields[2] as BaseItemDto;
+  }
+
+  @override
+  void write(BinaryWriter writer, FinampUser obj) {
+    writer
+      ..writeByte(3)
+      ..writeByte(0)
+      ..write(obj.baseUrl)
+      ..writeByte(1)
+      ..write(obj.userDetails)
+      ..writeByte(2)
+      ..write(obj.view);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is FinampUserAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/lib/models/FinampModels.g.dart
+++ b/lib/models/FinampModels.g.dart
@@ -16,10 +16,11 @@ class FinampUserAdapter extends TypeAdapter<FinampUser> {
     final fields = <int, dynamic>{
       for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
     };
-    return FinampUser()
-      ..baseUrl = fields[0] as String
-      ..userDetails = fields[1] as AuthenticationResult
-      ..view = fields[2] as BaseItemDto;
+    return FinampUser(
+      baseUrl: fields[0] as String,
+      userDetails: fields[1] as AuthenticationResult,
+      view: fields[2] as BaseItemDto,
+    );
   }
 
   @override

--- a/lib/models/JellyfinModels.dart
+++ b/lib/models/JellyfinModels.dart
@@ -187,13 +187,18 @@ class AccessSchedule {
 }
 
 @JsonSerializable(fieldRename: FieldRename.pascal, explicitToJson: true)
+@HiveType(typeId: 7)
 class AuthenticationResult {
   AuthenticationResult(
       this.user, this.sessionInfo, this.accessToken, this.serverId);
 
+  @HiveField(0)
   final UserDto user;
+  @HiveField(1)
   final SessionInfo sessionInfo;
+  @HiveField(2)
   final String accessToken;
+  @HiveField(3)
   final String serverId;
 
   factory AuthenticationResult.fromJson(Map<String, dynamic> json) =>

--- a/lib/models/JellyfinModels.dart
+++ b/lib/models/JellyfinModels.dart
@@ -4,6 +4,7 @@ import 'package:json_annotation/json_annotation.dart';
 part 'JellyfinModels.g.dart';
 
 @JsonSerializable(fieldRename: FieldRename.pascal, explicitToJson: true)
+@HiveType(typeId: 9)
 class UserDto {
   UserDto(
       this.name,
@@ -23,21 +24,37 @@ class UserDto {
       this.policy,
       this.primaryImageAspectRatio);
 
+  @HiveField(0)
   final String name;
+  @HiveField(1)
   final String serverId;
+  @HiveField(2)
   final String serverName;
+  @HiveField(3)
   final String connectUserName;
+  @HiveField(4)
   final String connectLinkType;
+  @HiveField(5)
   final String id;
+  @HiveField(6)
   final String primaryImageTag;
+  @HiveField(7)
   final bool hasPassword;
+  @HiveField(8)
   final bool hasConfiguredPassword;
+  @HiveField(9)
   final bool hasConfiguredEasyPassword;
+  @HiveField(10)
   final bool enableAutoLogin;
+  @HiveField(11)
   final String lastLoginDate;
+  @HiveField(12)
   final String lastActivityDate;
+  @HiveField(13)
   final UserConfiguration configuration;
+  @HiveField(14)
   final UserPolicy policy;
+  @HiveField(15)
   final double primaryImageAspectRatio;
 
   factory UserDto.fromJson(Map<String, dynamic> json) =>
@@ -46,6 +63,7 @@ class UserDto {
 }
 
 @JsonSerializable(fieldRename: FieldRename.pascal, explicitToJson: true)
+@HiveType(typeId: 11)
 class UserConfiguration {
   UserConfiguration(
       this.audioLanguagePreference,
@@ -64,20 +82,35 @@ class UserConfiguration {
       this.rememberSubtitleSelections,
       this.enableNextEpisodeAutoPlay);
 
+  @HiveField(0)
   final String audioLanguagePreference;
+  @HiveField(1)
   final bool playDefaultAudioTrack;
+  @HiveField(2)
   final String subtitleLanguagePreference;
+  @HiveField(3)
   final bool displayMissingEpisodes;
+  @HiveField(4)
   final List<String> groupedFolders;
+  @HiveField(5)
   final String subtitleMode;
+  @HiveField(6)
   final bool displayCollectionsView;
+  @HiveField(7)
   final bool enableLocalPassword;
+  @HiveField(8)
   final List<String> orderedViews;
+  @HiveField(9)
   final List<String> latestItemsExcludes;
+  @HiveField(10)
   final List<String> myMediaExcludes;
+  @HiveField(11)
   final bool hidePlayedInLatest;
+  @HiveField(12)
   final bool rememberAudioSelections;
+  @HiveField(13)
   final bool rememberSubtitleSelections;
+  @HiveField(14)
   final bool enableNextEpisodeAutoPlay;
 
   factory UserConfiguration.fromJson(Map<String, dynamic> json) =>
@@ -86,6 +119,7 @@ class UserConfiguration {
 }
 
 @JsonSerializable(fieldRename: FieldRename.pascal, explicitToJson: true)
+@HiveType(typeId: 12)
 class UserPolicy {
   UserPolicy(
       this.isAdministrator,
@@ -128,44 +162,83 @@ class UserPolicy {
       this.excludedSubFolders,
       this.disablePremiumFeatures);
 
+  @HiveField(0)
   final bool isAdministrator;
+  @HiveField(1)
   final bool isHidden;
+  @HiveField(2)
   final bool isHiddenRemotely;
+  @HiveField(3)
   final bool isDisabled;
+  @HiveField(4)
   final int maxParentalRating;
+  @HiveField(5)
   final List<String> blockedTags;
+  @HiveField(6)
   final bool enableUserPreferenceAccess;
+  @HiveField(7)
   final List<AccessSchedule> accessSchedules;
+  @HiveField(8)
   final List<String> blockUnratedItems;
+  @HiveField(9)
   final bool enableRemoteControlOfOtherUsers;
+  @HiveField(10)
   final bool enableSharedDeviceControl;
+  @HiveField(11)
   final bool enableRemoteAccess;
+  @HiveField(12)
   final bool enableLiveTvManagement;
+  @HiveField(13)
   final bool enableLiveTvAccess;
+  @HiveField(14)
   final bool enableMediaPlayback;
+  @HiveField(15)
   final bool enableAudioPlaybackTranscoding;
+  @HiveField(16)
   final bool enableVideoPlaybackTranscoding;
+  @HiveField(17)
   final bool enablePlaybackRemuxing;
+  @HiveField(18)
   final bool enableContentDeletion;
+  @HiveField(19)
   final List<String> enableContentDeletionFromFolders;
+  @HiveField(20)
   final bool enableContentDownloading;
+  @HiveField(21)
   final bool enableSubtitleDownloading;
+  @HiveField(22)
   final bool enableSubtitleManagement;
+  @HiveField(23)
   final bool enableSyncTranscoding;
+  @HiveField(24)
   final bool enableMediaConversion;
+  @HiveField(25)
   final List<String> enabledDevices;
+  @HiveField(26)
   final bool enableAllDevices;
+  @HiveField(27)
   final List<String> enabledChannels;
+  @HiveField(28)
   final bool enableAllChannels;
+  @HiveField(29)
   final List<String> enabledFolders;
+  @HiveField(30)
   final bool enableAllFolders;
+  @HiveField(31)
   final int invalidLoginAttemptCount;
+  @HiveField(32)
   final bool enablePublicSharing;
+  @HiveField(33)
   final List<String> blockedMediaFolders;
+  @HiveField(34)
   final List<String> blockedChannels;
+  @HiveField(35)
   final int remoteClientBitrateLimit;
+  @HiveField(36)
   final String authenticationProviderId;
+  @HiveField(37)
   final List<String> excludedSubFolders;
+  @HiveField(38)
   final bool disablePremiumFeatures;
 
   factory UserPolicy.fromJson(Map<String, dynamic> json) =>
@@ -173,12 +246,16 @@ class UserPolicy {
   Map<String, dynamic> toJson() => _$UserPolicyToJson(this);
 }
 
-@JsonSerializable()
+@JsonSerializable(fieldRename: FieldRename.pascal, explicitToJson: true)
+@HiveType(typeId: 13)
 class AccessSchedule {
   AccessSchedule(this.dayOfWeek, this.startHour, this.endHour);
 
+  @HiveField(0)
   final String dayOfWeek;
+  @HiveField(1)
   final double startHour;
+  @HiveField(2)
   final double endHour;
 
   factory AccessSchedule.fromJson(Map<String, dynamic> json) =>
@@ -207,6 +284,7 @@ class AuthenticationResult {
 }
 
 @JsonSerializable(fieldRename: FieldRename.pascal, explicitToJson: true)
+@HiveType(typeId: 10)
 class SessionInfo {
   SessionInfo(
       this.playState,
@@ -231,26 +309,47 @@ class SessionInfo {
       this.transcodingInfo,
       this.supportsRemoteControl);
 
+  @HiveField(0)
   final PlayerStateInfo playState;
+  @HiveField(1)
   final List<SessionUserInfo> additionalUsers;
+  @HiveField(2)
   final ClientCapabilities capabilities;
+  @HiveField(3)
   final String remoteEndPoint;
+  @HiveField(4)
   final List<String> playableMediaTypes;
+  @HiveField(5)
   final String playlistItemId;
+  @HiveField(6)
   final String id;
+  @HiveField(7)
   final String serverId;
+  @HiveField(8)
   final String userId;
+  @HiveField(9)
   final String userName;
+  @HiveField(10)
   final String userPrimaryImageTag;
+  @HiveField(11)
   final String client;
+  @HiveField(12)
   final String lastActivityDate;
+  @HiveField(13)
   final String deviceName;
+  @HiveField(14)
   final String deviceType;
+  @HiveField(15)
   final BaseItemDto nowPlayingItem;
+  @HiveField(16)
   final String deviceId;
+  @HiveField(17)
   final String appIconUrl;
+  @HiveField(18)
   final List<String> supportedCommands;
+  @HiveField(19)
   final TranscodingInfo transcodingInfo;
+  @HiveField(20)
   final bool supportsRemoteControl;
 
   factory SessionInfo.fromJson(Map<String, dynamic> json) =>
@@ -321,6 +420,7 @@ class TranscodingInfo {
 }
 
 @JsonSerializable(fieldRename: FieldRename.pascal, explicitToJson: true)
+@HiveType(typeId: 14)
 class PlayerStateInfo {
   PlayerStateInfo(
       this.positionTicks,
@@ -334,15 +434,25 @@ class PlayerStateInfo {
       this.playMethod,
       this.repeatMode);
 
+  @HiveField(0)
   final int positionTicks;
+  @HiveField(1)
   final bool canSeek;
+  @HiveField(2)
   final bool isPaused;
+  @HiveField(3)
   final bool isMuted;
+  @HiveField(4)
   final int volumeLevel;
+  @HiveField(5)
   final int audioStreamIndex;
+  @HiveField(6)
   final int subtitleStreamIndex;
+  @HiveField(7)
   final String mediaSourceId;
+  @HiveField(8)
   final String playMethod;
+  @HiveField(9)
   final String repeatMode;
 
   factory PlayerStateInfo.fromJson(Map<String, dynamic> json) =>
@@ -351,11 +461,15 @@ class PlayerStateInfo {
 }
 
 @JsonSerializable(fieldRename: FieldRename.pascal, explicitToJson: true)
+@HiveType(typeId: 15)
 class SessionUserInfo {
   SessionUserInfo(this.userId, this.userName, this.userInternalId);
 
+  @HiveField(0)
   final String userId;
+  @HiveField(1)
   final String userName;
+  @HiveField(2)
   final int userInternalId;
 
   factory SessionUserInfo.fromJson(Map<String, dynamic> json) =>
@@ -364,6 +478,7 @@ class SessionUserInfo {
 }
 
 @JsonSerializable(fieldRename: FieldRename.pascal, explicitToJson: true)
+@HiveType(typeId: 16)
 class ClientCapabilities {
   ClientCapabilities(
       this.playableMediaTypes,
@@ -377,15 +492,25 @@ class ClientCapabilities {
       this.iconUrl,
       this.appId);
 
+  @HiveField(0)
   final List<String> playableMediaTypes;
+  @HiveField(1)
   final List<String> supportedCommands;
+  @HiveField(2)
   final bool supportsMediaControl;
+  @HiveField(3)
   final String pushToken;
+  @HiveField(4)
   final String pushTokenType;
+  @HiveField(5)
   final bool supportsPersistentIdentifier;
+  @HiveField(6)
   final bool supportsSync;
+  @HiveField(7)
   final DeviceProfile deviceProfile;
+  @HiveField(8)
   final String iconUrl;
+  @HiveField(9)
   final String appId;
 
   factory ClientCapabilities.fromJson(Map<String, dynamic> json) =>
@@ -394,6 +519,7 @@ class ClientCapabilities {
 }
 
 @JsonSerializable(fieldRename: FieldRename.pascal, explicitToJson: true)
+@HiveType(typeId: 17)
 class DeviceProfile {
   DeviceProfile(
       this.name,
@@ -436,44 +562,83 @@ class DeviceProfile {
       this.responseProfiles,
       this.subtitleProfiles);
 
+  @HiveField(0)
   final String name;
+  @HiveField(1)
   final String id;
+  @HiveField(2)
   final DeviceIdentification identification;
+  @HiveField(3)
   final String friendlyName;
+  @HiveField(4)
   final String manufacturer;
+  @HiveField(5)
   final String manufacturerUrl;
+  @HiveField(6)
   final String modelName;
+  @HiveField(7)
   final String modelDescription;
+  @HiveField(8)
   final String modelNumber;
+  @HiveField(9)
   final String modelUrl;
+  @HiveField(10)
   final String serialNumber;
+  @HiveField(11)
   final bool enableAlbumArtInDidl;
+  @HiveField(12)
   final bool enableSingleAlbumArtLimit;
+  @HiveField(13)
   final bool enableSingleSubtitleLimit;
+  @HiveField(14)
   final String supportedMediaTypes;
+  @HiveField(15)
   final String userId;
+  @HiveField(16)
   final String albumArtPn;
+  @HiveField(17)
   final int maxAlbumArtWidth;
+  @HiveField(18)
   final int maxAlbumArtHeight;
+  @HiveField(19)
   final int maxIconWidth;
+  @HiveField(20)
   final int maxIconHeight;
+  @HiveField(21)
   final int maxStreamingBitrate;
+  @HiveField(22)
   final int maxStaticBitrate;
+  @HiveField(23)
   final int musicStreamingTranscodingBitrate;
+  @HiveField(24)
   final int maxStaticMusicBitrate;
+  @HiveField(25)
   final String sonyAggregationFlags;
+  @HiveField(26)
   final String protocolInfo;
+  @HiveField(27)
   final int timelineOffsetSeconds;
+  @HiveField(28)
   final bool requiresPlainVideoItems;
+  @HiveField(29)
   final bool requiresPlainFolders;
+  @HiveField(30)
   final bool enableMSMediaReceiverRegistrar;
+  @HiveField(31)
   final bool ignoreTranscodeByteRangeRequests;
+  @HiveField(32)
   final List<XmlAttribute> xmlRootAttributes;
+  @HiveField(33)
   final List<DirectPlayProfile> directPlayProfiles;
+  @HiveField(34)
   final List<TranscodingProfile> transcodingProfiles;
+  @HiveField(35)
   final List<ContainerProfile> containerProfiles;
+  @HiveField(36)
   final List<CodecProfile> codecProfiles;
+  @HiveField(37)
   final List<ResponseProfile> responseProfiles;
+  @HiveField(38)
   final List<SubtitleProfile> subtitleProfiles;
 
   factory DeviceProfile.fromJson(Map<String, dynamic> json) =>
@@ -482,6 +647,7 @@ class DeviceProfile {
 }
 
 @JsonSerializable(fieldRename: FieldRename.pascal, explicitToJson: true)
+@HiveType(typeId: 18)
 class DeviceIdentification {
   DeviceIdentification(
       this.friendlyName,
@@ -495,15 +661,25 @@ class DeviceIdentification {
       this.manufacturerUrl,
       this.headers);
 
+  @HiveField(0)
   final String friendlyName;
+  @HiveField(1)
   final String modelNumber;
+  @HiveField(2)
   final String serialNumber;
+  @HiveField(3)
   final String modelName;
+  @HiveField(4)
   final String modelDescription;
+  @HiveField(5)
   final String deviceDescription;
+  @HiveField(6)
   final String modelUrl;
+  @HiveField(7)
   final String manufacturer;
+  @HiveField(8)
   final String manufacturerUrl;
+  @HiveField(9)
   final List<HttpHeaderInfo> headers;
 
   factory DeviceIdentification.fromJson(Map<String, dynamic> json) =>
@@ -512,11 +688,15 @@ class DeviceIdentification {
 }
 
 @JsonSerializable(fieldRename: FieldRename.pascal, explicitToJson: true)
+@HiveType(typeId: 19)
 class HttpHeaderInfo {
   HttpHeaderInfo(this.name, this.value, this.match);
 
+  @HiveField(0)
   final String name;
+  @HiveField(1)
   final String value;
+  @HiveField(2)
   final String match;
 
   factory HttpHeaderInfo.fromJson(Map<String, dynamic> json) =>
@@ -525,10 +705,13 @@ class HttpHeaderInfo {
 }
 
 @JsonSerializable(fieldRename: FieldRename.pascal, explicitToJson: true)
+@HiveType(typeId: 20)
 class XmlAttribute {
   XmlAttribute(this.name, this.value);
 
+  @HiveField(0)
   final String name;
+  @HiveField(1)
   final String value;
 
   factory XmlAttribute.fromJson(Map<String, dynamic> json) =>
@@ -537,13 +720,18 @@ class XmlAttribute {
 }
 
 @JsonSerializable(fieldRename: FieldRename.pascal, explicitToJson: true)
+@HiveType(typeId: 21)
 class DirectPlayProfile {
   DirectPlayProfile(
       this.container, this.audioCodec, this.videoCodec, this.type);
 
+  @HiveField(0)
   final String container;
+  @HiveField(1)
   final String audioCodec;
+  @HiveField(2)
   final String videoCodec;
+  @HiveField(3)
   final String type;
 
   factory DirectPlayProfile.fromJson(Map<String, dynamic> json) =>
@@ -552,6 +740,7 @@ class DirectPlayProfile {
 }
 
 @JsonSerializable(fieldRename: FieldRename.pascal, explicitToJson: true)
+@HiveType(typeId: 22)
 class TranscodingProfile {
   TranscodingProfile(
       this.container,
@@ -570,20 +759,35 @@ class TranscodingProfile {
       this.breakOnNonKeyFrames,
       this.manifestSubtitles);
 
+  @HiveField(0)
   final String container;
+  @HiveField(1)
   final String type;
+  @HiveField(2)
   final String videoCodec;
+  @HiveField(3)
   final String audioCodec;
+  @HiveField(4)
   final String protocol;
+  @HiveField(5)
   final bool estimateContentLength;
+  @HiveField(6)
   final bool enableMpegtsM2TsMode;
+  @HiveField(7)
   final String transcodeSeekInfo;
+  @HiveField(8)
   final bool copyTimestamps;
+  @HiveField(9)
   final String context;
+  @HiveField(10)
   final String maxAudioChannels;
+  @HiveField(11)
   final int minSegments;
+  @HiveField(12)
   final int segmentLength;
+  @HiveField(13)
   final bool breakOnNonKeyFrames;
+  @HiveField(14)
   final String manifestSubtitles;
 
   factory TranscodingProfile.fromJson(Map<String, dynamic> json) =>
@@ -592,11 +796,15 @@ class TranscodingProfile {
 }
 
 @JsonSerializable(fieldRename: FieldRename.pascal, explicitToJson: true)
+@HiveType(typeId: 23)
 class ContainerProfile {
   ContainerProfile(this.type, this.conditions, this.container);
 
+  @HiveField(0)
   final String type;
+  @HiveField(1)
   final List<ProfileCondition> conditions;
+  @HiveField(2)
   final String container;
 
   factory ContainerProfile.fromJson(Map<String, dynamic> json) =>
@@ -605,12 +813,17 @@ class ContainerProfile {
 }
 
 @JsonSerializable(fieldRename: FieldRename.pascal, explicitToJson: true)
+@HiveType(typeId: 24)
 class ProfileCondition {
   ProfileCondition(this.condition, this.property, this.value, this.isRequired);
 
+  @HiveField(0)
   final String condition;
+  @HiveField(1)
   final String property;
+  @HiveField(2)
   final String value;
+  @HiveField(3)
   final bool isRequired;
 
   factory ProfileCondition.fromJson(Map<String, dynamic> json) =>
@@ -619,14 +832,20 @@ class ProfileCondition {
 }
 
 @JsonSerializable(fieldRename: FieldRename.pascal, explicitToJson: true)
+@HiveType(typeId: 25)
 class CodecProfile {
   CodecProfile(this.type, this.conditions, this.applyConditions, this.codec,
       this.container);
 
+  @HiveField(0)
   final String type;
+  @HiveField(1)
   final List<ProfileCondition> conditions;
+  @HiveField(2)
   final List<ProfileCondition> applyConditions;
+  @HiveField(3)
   final String codec;
+  @HiveField(4)
   final String container;
 
   factory CodecProfile.fromJson(Map<String, dynamic> json) =>
@@ -635,16 +854,24 @@ class CodecProfile {
 }
 
 @JsonSerializable(fieldRename: FieldRename.pascal, explicitToJson: true)
+@HiveType(typeId: 26)
 class ResponseProfile {
   ResponseProfile(this.container, this.audioCodec, this.videoCodec, this.type,
       this.orgPn, this.mimeType, this.conditions);
 
+  @HiveField(0)
   final String container;
+  @HiveField(1)
   final String audioCodec;
+  @HiveField(2)
   final String videoCodec;
+  @HiveField(3)
   final String type;
+  @HiveField(4)
   final String orgPn;
+  @HiveField(5)
   final String mimeType;
+  @HiveField(6)
   final List<ProfileCondition> conditions;
 
   factory ResponseProfile.fromJson(Map<String, dynamic> json) =>
@@ -653,14 +880,20 @@ class ResponseProfile {
 }
 
 @JsonSerializable(fieldRename: FieldRename.pascal, explicitToJson: true)
+@HiveType(typeId: 27)
 class SubtitleProfile {
   SubtitleProfile(
       this.format, this.method, this.didlMode, this.language, this.container);
 
+  @HiveField(0)
   final String format;
+  @HiveField(1)
   final String method;
+  @HiveField(2)
   final String didlMode;
+  @HiveField(3)
   final String language;
+  @HiveField(4)
   final String container;
 
   factory SubtitleProfile.fromJson(Map<String, dynamic> json) =>

--- a/lib/models/JellyfinModels.g.dart
+++ b/lib/models/JellyfinModels.g.dart
@@ -6,6 +6,349 @@ part of 'JellyfinModels.dart';
 // TypeAdapterGenerator
 // **************************************************************************
 
+class UserDtoAdapter extends TypeAdapter<UserDto> {
+  @override
+  final int typeId = 9;
+
+  @override
+  UserDto read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return UserDto(
+      fields[0] as String,
+      fields[1] as String,
+      fields[2] as String,
+      fields[3] as String,
+      fields[4] as String,
+      fields[5] as String,
+      fields[6] as String,
+      fields[7] as bool,
+      fields[8] as bool,
+      fields[9] as bool,
+      fields[10] as bool,
+      fields[11] as String,
+      fields[12] as String,
+      fields[13] as UserConfiguration,
+      fields[14] as UserPolicy,
+      fields[15] as double,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, UserDto obj) {
+    writer
+      ..writeByte(16)
+      ..writeByte(0)
+      ..write(obj.name)
+      ..writeByte(1)
+      ..write(obj.serverId)
+      ..writeByte(2)
+      ..write(obj.serverName)
+      ..writeByte(3)
+      ..write(obj.connectUserName)
+      ..writeByte(4)
+      ..write(obj.connectLinkType)
+      ..writeByte(5)
+      ..write(obj.id)
+      ..writeByte(6)
+      ..write(obj.primaryImageTag)
+      ..writeByte(7)
+      ..write(obj.hasPassword)
+      ..writeByte(8)
+      ..write(obj.hasConfiguredPassword)
+      ..writeByte(9)
+      ..write(obj.hasConfiguredEasyPassword)
+      ..writeByte(10)
+      ..write(obj.enableAutoLogin)
+      ..writeByte(11)
+      ..write(obj.lastLoginDate)
+      ..writeByte(12)
+      ..write(obj.lastActivityDate)
+      ..writeByte(13)
+      ..write(obj.configuration)
+      ..writeByte(14)
+      ..write(obj.policy)
+      ..writeByte(15)
+      ..write(obj.primaryImageAspectRatio);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is UserDtoAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}
+
+class UserConfigurationAdapter extends TypeAdapter<UserConfiguration> {
+  @override
+  final int typeId = 11;
+
+  @override
+  UserConfiguration read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return UserConfiguration(
+      fields[0] as String,
+      fields[1] as bool,
+      fields[2] as String,
+      fields[3] as bool,
+      (fields[4] as List)?.cast<String>(),
+      fields[5] as String,
+      fields[6] as bool,
+      fields[7] as bool,
+      (fields[8] as List)?.cast<String>(),
+      (fields[9] as List)?.cast<String>(),
+      (fields[10] as List)?.cast<String>(),
+      fields[11] as bool,
+      fields[12] as bool,
+      fields[13] as bool,
+      fields[14] as bool,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, UserConfiguration obj) {
+    writer
+      ..writeByte(15)
+      ..writeByte(0)
+      ..write(obj.audioLanguagePreference)
+      ..writeByte(1)
+      ..write(obj.playDefaultAudioTrack)
+      ..writeByte(2)
+      ..write(obj.subtitleLanguagePreference)
+      ..writeByte(3)
+      ..write(obj.displayMissingEpisodes)
+      ..writeByte(4)
+      ..write(obj.groupedFolders)
+      ..writeByte(5)
+      ..write(obj.subtitleMode)
+      ..writeByte(6)
+      ..write(obj.displayCollectionsView)
+      ..writeByte(7)
+      ..write(obj.enableLocalPassword)
+      ..writeByte(8)
+      ..write(obj.orderedViews)
+      ..writeByte(9)
+      ..write(obj.latestItemsExcludes)
+      ..writeByte(10)
+      ..write(obj.myMediaExcludes)
+      ..writeByte(11)
+      ..write(obj.hidePlayedInLatest)
+      ..writeByte(12)
+      ..write(obj.rememberAudioSelections)
+      ..writeByte(13)
+      ..write(obj.rememberSubtitleSelections)
+      ..writeByte(14)
+      ..write(obj.enableNextEpisodeAutoPlay);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is UserConfigurationAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}
+
+class UserPolicyAdapter extends TypeAdapter<UserPolicy> {
+  @override
+  final int typeId = 12;
+
+  @override
+  UserPolicy read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return UserPolicy(
+      fields[0] as bool,
+      fields[1] as bool,
+      fields[2] as bool,
+      fields[3] as bool,
+      fields[4] as int,
+      (fields[5] as List)?.cast<String>(),
+      fields[6] as bool,
+      (fields[7] as List)?.cast<AccessSchedule>(),
+      (fields[8] as List)?.cast<String>(),
+      fields[9] as bool,
+      fields[10] as bool,
+      fields[11] as bool,
+      fields[12] as bool,
+      fields[13] as bool,
+      fields[14] as bool,
+      fields[15] as bool,
+      fields[16] as bool,
+      fields[17] as bool,
+      fields[18] as bool,
+      (fields[19] as List)?.cast<String>(),
+      fields[20] as bool,
+      fields[21] as bool,
+      fields[22] as bool,
+      fields[23] as bool,
+      fields[24] as bool,
+      (fields[25] as List)?.cast<String>(),
+      fields[26] as bool,
+      (fields[27] as List)?.cast<String>(),
+      fields[28] as bool,
+      (fields[29] as List)?.cast<String>(),
+      fields[30] as bool,
+      fields[31] as int,
+      fields[32] as bool,
+      (fields[33] as List)?.cast<String>(),
+      (fields[34] as List)?.cast<String>(),
+      fields[35] as int,
+      fields[36] as String,
+      (fields[37] as List)?.cast<String>(),
+      fields[38] as bool,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, UserPolicy obj) {
+    writer
+      ..writeByte(39)
+      ..writeByte(0)
+      ..write(obj.isAdministrator)
+      ..writeByte(1)
+      ..write(obj.isHidden)
+      ..writeByte(2)
+      ..write(obj.isHiddenRemotely)
+      ..writeByte(3)
+      ..write(obj.isDisabled)
+      ..writeByte(4)
+      ..write(obj.maxParentalRating)
+      ..writeByte(5)
+      ..write(obj.blockedTags)
+      ..writeByte(6)
+      ..write(obj.enableUserPreferenceAccess)
+      ..writeByte(7)
+      ..write(obj.accessSchedules)
+      ..writeByte(8)
+      ..write(obj.blockUnratedItems)
+      ..writeByte(9)
+      ..write(obj.enableRemoteControlOfOtherUsers)
+      ..writeByte(10)
+      ..write(obj.enableSharedDeviceControl)
+      ..writeByte(11)
+      ..write(obj.enableRemoteAccess)
+      ..writeByte(12)
+      ..write(obj.enableLiveTvManagement)
+      ..writeByte(13)
+      ..write(obj.enableLiveTvAccess)
+      ..writeByte(14)
+      ..write(obj.enableMediaPlayback)
+      ..writeByte(15)
+      ..write(obj.enableAudioPlaybackTranscoding)
+      ..writeByte(16)
+      ..write(obj.enableVideoPlaybackTranscoding)
+      ..writeByte(17)
+      ..write(obj.enablePlaybackRemuxing)
+      ..writeByte(18)
+      ..write(obj.enableContentDeletion)
+      ..writeByte(19)
+      ..write(obj.enableContentDeletionFromFolders)
+      ..writeByte(20)
+      ..write(obj.enableContentDownloading)
+      ..writeByte(21)
+      ..write(obj.enableSubtitleDownloading)
+      ..writeByte(22)
+      ..write(obj.enableSubtitleManagement)
+      ..writeByte(23)
+      ..write(obj.enableSyncTranscoding)
+      ..writeByte(24)
+      ..write(obj.enableMediaConversion)
+      ..writeByte(25)
+      ..write(obj.enabledDevices)
+      ..writeByte(26)
+      ..write(obj.enableAllDevices)
+      ..writeByte(27)
+      ..write(obj.enabledChannels)
+      ..writeByte(28)
+      ..write(obj.enableAllChannels)
+      ..writeByte(29)
+      ..write(obj.enabledFolders)
+      ..writeByte(30)
+      ..write(obj.enableAllFolders)
+      ..writeByte(31)
+      ..write(obj.invalidLoginAttemptCount)
+      ..writeByte(32)
+      ..write(obj.enablePublicSharing)
+      ..writeByte(33)
+      ..write(obj.blockedMediaFolders)
+      ..writeByte(34)
+      ..write(obj.blockedChannels)
+      ..writeByte(35)
+      ..write(obj.remoteClientBitrateLimit)
+      ..writeByte(36)
+      ..write(obj.authenticationProviderId)
+      ..writeByte(37)
+      ..write(obj.excludedSubFolders)
+      ..writeByte(38)
+      ..write(obj.disablePremiumFeatures);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is UserPolicyAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}
+
+class AccessScheduleAdapter extends TypeAdapter<AccessSchedule> {
+  @override
+  final int typeId = 13;
+
+  @override
+  AccessSchedule read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return AccessSchedule(
+      fields[0] as String,
+      fields[1] as double,
+      fields[2] as double,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, AccessSchedule obj) {
+    writer
+      ..writeByte(3)
+      ..writeByte(0)
+      ..write(obj.dayOfWeek)
+      ..writeByte(1)
+      ..write(obj.startHour)
+      ..writeByte(2)
+      ..write(obj.endHour);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is AccessScheduleAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}
+
 class AuthenticationResultAdapter extends TypeAdapter<AuthenticationResult> {
   @override
   final int typeId = 7;
@@ -45,6 +388,894 @@ class AuthenticationResultAdapter extends TypeAdapter<AuthenticationResult> {
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is AuthenticationResultAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}
+
+class SessionInfoAdapter extends TypeAdapter<SessionInfo> {
+  @override
+  final int typeId = 10;
+
+  @override
+  SessionInfo read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return SessionInfo(
+      fields[0] as PlayerStateInfo,
+      (fields[1] as List)?.cast<SessionUserInfo>(),
+      fields[2] as ClientCapabilities,
+      fields[3] as String,
+      (fields[4] as List)?.cast<String>(),
+      fields[5] as String,
+      fields[6] as String,
+      fields[7] as String,
+      fields[8] as String,
+      fields[9] as String,
+      fields[10] as String,
+      fields[11] as String,
+      fields[12] as String,
+      fields[13] as String,
+      fields[14] as String,
+      fields[15] as BaseItemDto,
+      fields[16] as String,
+      fields[17] as String,
+      (fields[18] as List)?.cast<String>(),
+      fields[19] as TranscodingInfo,
+      fields[20] as bool,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, SessionInfo obj) {
+    writer
+      ..writeByte(21)
+      ..writeByte(0)
+      ..write(obj.playState)
+      ..writeByte(1)
+      ..write(obj.additionalUsers)
+      ..writeByte(2)
+      ..write(obj.capabilities)
+      ..writeByte(3)
+      ..write(obj.remoteEndPoint)
+      ..writeByte(4)
+      ..write(obj.playableMediaTypes)
+      ..writeByte(5)
+      ..write(obj.playlistItemId)
+      ..writeByte(6)
+      ..write(obj.id)
+      ..writeByte(7)
+      ..write(obj.serverId)
+      ..writeByte(8)
+      ..write(obj.userId)
+      ..writeByte(9)
+      ..write(obj.userName)
+      ..writeByte(10)
+      ..write(obj.userPrimaryImageTag)
+      ..writeByte(11)
+      ..write(obj.client)
+      ..writeByte(12)
+      ..write(obj.lastActivityDate)
+      ..writeByte(13)
+      ..write(obj.deviceName)
+      ..writeByte(14)
+      ..write(obj.deviceType)
+      ..writeByte(15)
+      ..write(obj.nowPlayingItem)
+      ..writeByte(16)
+      ..write(obj.deviceId)
+      ..writeByte(17)
+      ..write(obj.appIconUrl)
+      ..writeByte(18)
+      ..write(obj.supportedCommands)
+      ..writeByte(19)
+      ..write(obj.transcodingInfo)
+      ..writeByte(20)
+      ..write(obj.supportsRemoteControl);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SessionInfoAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}
+
+class PlayerStateInfoAdapter extends TypeAdapter<PlayerStateInfo> {
+  @override
+  final int typeId = 14;
+
+  @override
+  PlayerStateInfo read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return PlayerStateInfo(
+      fields[0] as int,
+      fields[1] as bool,
+      fields[2] as bool,
+      fields[3] as bool,
+      fields[4] as int,
+      fields[5] as int,
+      fields[6] as int,
+      fields[7] as String,
+      fields[8] as String,
+      fields[9] as String,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, PlayerStateInfo obj) {
+    writer
+      ..writeByte(10)
+      ..writeByte(0)
+      ..write(obj.positionTicks)
+      ..writeByte(1)
+      ..write(obj.canSeek)
+      ..writeByte(2)
+      ..write(obj.isPaused)
+      ..writeByte(3)
+      ..write(obj.isMuted)
+      ..writeByte(4)
+      ..write(obj.volumeLevel)
+      ..writeByte(5)
+      ..write(obj.audioStreamIndex)
+      ..writeByte(6)
+      ..write(obj.subtitleStreamIndex)
+      ..writeByte(7)
+      ..write(obj.mediaSourceId)
+      ..writeByte(8)
+      ..write(obj.playMethod)
+      ..writeByte(9)
+      ..write(obj.repeatMode);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is PlayerStateInfoAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}
+
+class SessionUserInfoAdapter extends TypeAdapter<SessionUserInfo> {
+  @override
+  final int typeId = 15;
+
+  @override
+  SessionUserInfo read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return SessionUserInfo(
+      fields[0] as String,
+      fields[1] as String,
+      fields[2] as int,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, SessionUserInfo obj) {
+    writer
+      ..writeByte(3)
+      ..writeByte(0)
+      ..write(obj.userId)
+      ..writeByte(1)
+      ..write(obj.userName)
+      ..writeByte(2)
+      ..write(obj.userInternalId);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SessionUserInfoAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}
+
+class ClientCapabilitiesAdapter extends TypeAdapter<ClientCapabilities> {
+  @override
+  final int typeId = 16;
+
+  @override
+  ClientCapabilities read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return ClientCapabilities(
+      (fields[0] as List)?.cast<String>(),
+      (fields[1] as List)?.cast<String>(),
+      fields[2] as bool,
+      fields[3] as String,
+      fields[4] as String,
+      fields[5] as bool,
+      fields[6] as bool,
+      fields[7] as DeviceProfile,
+      fields[8] as String,
+      fields[9] as String,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, ClientCapabilities obj) {
+    writer
+      ..writeByte(10)
+      ..writeByte(0)
+      ..write(obj.playableMediaTypes)
+      ..writeByte(1)
+      ..write(obj.supportedCommands)
+      ..writeByte(2)
+      ..write(obj.supportsMediaControl)
+      ..writeByte(3)
+      ..write(obj.pushToken)
+      ..writeByte(4)
+      ..write(obj.pushTokenType)
+      ..writeByte(5)
+      ..write(obj.supportsPersistentIdentifier)
+      ..writeByte(6)
+      ..write(obj.supportsSync)
+      ..writeByte(7)
+      ..write(obj.deviceProfile)
+      ..writeByte(8)
+      ..write(obj.iconUrl)
+      ..writeByte(9)
+      ..write(obj.appId);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ClientCapabilitiesAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}
+
+class DeviceProfileAdapter extends TypeAdapter<DeviceProfile> {
+  @override
+  final int typeId = 17;
+
+  @override
+  DeviceProfile read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return DeviceProfile(
+      fields[0] as String,
+      fields[1] as String,
+      fields[2] as DeviceIdentification,
+      fields[3] as String,
+      fields[4] as String,
+      fields[5] as String,
+      fields[6] as String,
+      fields[7] as String,
+      fields[8] as String,
+      fields[9] as String,
+      fields[10] as String,
+      fields[11] as bool,
+      fields[12] as bool,
+      fields[13] as bool,
+      fields[14] as String,
+      fields[15] as String,
+      fields[16] as String,
+      fields[17] as int,
+      fields[18] as int,
+      fields[19] as int,
+      fields[20] as int,
+      fields[21] as int,
+      fields[22] as int,
+      fields[23] as int,
+      fields[24] as int,
+      fields[25] as String,
+      fields[26] as String,
+      fields[27] as int,
+      fields[28] as bool,
+      fields[29] as bool,
+      fields[30] as bool,
+      fields[31] as bool,
+      (fields[32] as List)?.cast<XmlAttribute>(),
+      (fields[33] as List)?.cast<DirectPlayProfile>(),
+      (fields[34] as List)?.cast<TranscodingProfile>(),
+      (fields[35] as List)?.cast<ContainerProfile>(),
+      (fields[36] as List)?.cast<CodecProfile>(),
+      (fields[37] as List)?.cast<ResponseProfile>(),
+      (fields[38] as List)?.cast<SubtitleProfile>(),
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, DeviceProfile obj) {
+    writer
+      ..writeByte(39)
+      ..writeByte(0)
+      ..write(obj.name)
+      ..writeByte(1)
+      ..write(obj.id)
+      ..writeByte(2)
+      ..write(obj.identification)
+      ..writeByte(3)
+      ..write(obj.friendlyName)
+      ..writeByte(4)
+      ..write(obj.manufacturer)
+      ..writeByte(5)
+      ..write(obj.manufacturerUrl)
+      ..writeByte(6)
+      ..write(obj.modelName)
+      ..writeByte(7)
+      ..write(obj.modelDescription)
+      ..writeByte(8)
+      ..write(obj.modelNumber)
+      ..writeByte(9)
+      ..write(obj.modelUrl)
+      ..writeByte(10)
+      ..write(obj.serialNumber)
+      ..writeByte(11)
+      ..write(obj.enableAlbumArtInDidl)
+      ..writeByte(12)
+      ..write(obj.enableSingleAlbumArtLimit)
+      ..writeByte(13)
+      ..write(obj.enableSingleSubtitleLimit)
+      ..writeByte(14)
+      ..write(obj.supportedMediaTypes)
+      ..writeByte(15)
+      ..write(obj.userId)
+      ..writeByte(16)
+      ..write(obj.albumArtPn)
+      ..writeByte(17)
+      ..write(obj.maxAlbumArtWidth)
+      ..writeByte(18)
+      ..write(obj.maxAlbumArtHeight)
+      ..writeByte(19)
+      ..write(obj.maxIconWidth)
+      ..writeByte(20)
+      ..write(obj.maxIconHeight)
+      ..writeByte(21)
+      ..write(obj.maxStreamingBitrate)
+      ..writeByte(22)
+      ..write(obj.maxStaticBitrate)
+      ..writeByte(23)
+      ..write(obj.musicStreamingTranscodingBitrate)
+      ..writeByte(24)
+      ..write(obj.maxStaticMusicBitrate)
+      ..writeByte(25)
+      ..write(obj.sonyAggregationFlags)
+      ..writeByte(26)
+      ..write(obj.protocolInfo)
+      ..writeByte(27)
+      ..write(obj.timelineOffsetSeconds)
+      ..writeByte(28)
+      ..write(obj.requiresPlainVideoItems)
+      ..writeByte(29)
+      ..write(obj.requiresPlainFolders)
+      ..writeByte(30)
+      ..write(obj.enableMSMediaReceiverRegistrar)
+      ..writeByte(31)
+      ..write(obj.ignoreTranscodeByteRangeRequests)
+      ..writeByte(32)
+      ..write(obj.xmlRootAttributes)
+      ..writeByte(33)
+      ..write(obj.directPlayProfiles)
+      ..writeByte(34)
+      ..write(obj.transcodingProfiles)
+      ..writeByte(35)
+      ..write(obj.containerProfiles)
+      ..writeByte(36)
+      ..write(obj.codecProfiles)
+      ..writeByte(37)
+      ..write(obj.responseProfiles)
+      ..writeByte(38)
+      ..write(obj.subtitleProfiles);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is DeviceProfileAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}
+
+class DeviceIdentificationAdapter extends TypeAdapter<DeviceIdentification> {
+  @override
+  final int typeId = 18;
+
+  @override
+  DeviceIdentification read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return DeviceIdentification(
+      fields[0] as String,
+      fields[1] as String,
+      fields[2] as String,
+      fields[3] as String,
+      fields[4] as String,
+      fields[5] as String,
+      fields[6] as String,
+      fields[7] as String,
+      fields[8] as String,
+      (fields[9] as List)?.cast<HttpHeaderInfo>(),
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, DeviceIdentification obj) {
+    writer
+      ..writeByte(10)
+      ..writeByte(0)
+      ..write(obj.friendlyName)
+      ..writeByte(1)
+      ..write(obj.modelNumber)
+      ..writeByte(2)
+      ..write(obj.serialNumber)
+      ..writeByte(3)
+      ..write(obj.modelName)
+      ..writeByte(4)
+      ..write(obj.modelDescription)
+      ..writeByte(5)
+      ..write(obj.deviceDescription)
+      ..writeByte(6)
+      ..write(obj.modelUrl)
+      ..writeByte(7)
+      ..write(obj.manufacturer)
+      ..writeByte(8)
+      ..write(obj.manufacturerUrl)
+      ..writeByte(9)
+      ..write(obj.headers);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is DeviceIdentificationAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}
+
+class HttpHeaderInfoAdapter extends TypeAdapter<HttpHeaderInfo> {
+  @override
+  final int typeId = 19;
+
+  @override
+  HttpHeaderInfo read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return HttpHeaderInfo(
+      fields[0] as String,
+      fields[1] as String,
+      fields[2] as String,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, HttpHeaderInfo obj) {
+    writer
+      ..writeByte(3)
+      ..writeByte(0)
+      ..write(obj.name)
+      ..writeByte(1)
+      ..write(obj.value)
+      ..writeByte(2)
+      ..write(obj.match);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is HttpHeaderInfoAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}
+
+class XmlAttributeAdapter extends TypeAdapter<XmlAttribute> {
+  @override
+  final int typeId = 20;
+
+  @override
+  XmlAttribute read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return XmlAttribute(
+      fields[0] as String,
+      fields[1] as String,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, XmlAttribute obj) {
+    writer
+      ..writeByte(2)
+      ..writeByte(0)
+      ..write(obj.name)
+      ..writeByte(1)
+      ..write(obj.value);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is XmlAttributeAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}
+
+class DirectPlayProfileAdapter extends TypeAdapter<DirectPlayProfile> {
+  @override
+  final int typeId = 21;
+
+  @override
+  DirectPlayProfile read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return DirectPlayProfile(
+      fields[0] as String,
+      fields[1] as String,
+      fields[2] as String,
+      fields[3] as String,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, DirectPlayProfile obj) {
+    writer
+      ..writeByte(4)
+      ..writeByte(0)
+      ..write(obj.container)
+      ..writeByte(1)
+      ..write(obj.audioCodec)
+      ..writeByte(2)
+      ..write(obj.videoCodec)
+      ..writeByte(3)
+      ..write(obj.type);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is DirectPlayProfileAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}
+
+class TranscodingProfileAdapter extends TypeAdapter<TranscodingProfile> {
+  @override
+  final int typeId = 22;
+
+  @override
+  TranscodingProfile read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return TranscodingProfile(
+      fields[0] as String,
+      fields[1] as String,
+      fields[2] as String,
+      fields[3] as String,
+      fields[4] as String,
+      fields[5] as bool,
+      fields[6] as bool,
+      fields[7] as String,
+      fields[8] as bool,
+      fields[9] as String,
+      fields[10] as String,
+      fields[11] as int,
+      fields[12] as int,
+      fields[13] as bool,
+      fields[14] as String,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, TranscodingProfile obj) {
+    writer
+      ..writeByte(15)
+      ..writeByte(0)
+      ..write(obj.container)
+      ..writeByte(1)
+      ..write(obj.type)
+      ..writeByte(2)
+      ..write(obj.videoCodec)
+      ..writeByte(3)
+      ..write(obj.audioCodec)
+      ..writeByte(4)
+      ..write(obj.protocol)
+      ..writeByte(5)
+      ..write(obj.estimateContentLength)
+      ..writeByte(6)
+      ..write(obj.enableMpegtsM2TsMode)
+      ..writeByte(7)
+      ..write(obj.transcodeSeekInfo)
+      ..writeByte(8)
+      ..write(obj.copyTimestamps)
+      ..writeByte(9)
+      ..write(obj.context)
+      ..writeByte(10)
+      ..write(obj.maxAudioChannels)
+      ..writeByte(11)
+      ..write(obj.minSegments)
+      ..writeByte(12)
+      ..write(obj.segmentLength)
+      ..writeByte(13)
+      ..write(obj.breakOnNonKeyFrames)
+      ..writeByte(14)
+      ..write(obj.manifestSubtitles);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is TranscodingProfileAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}
+
+class ContainerProfileAdapter extends TypeAdapter<ContainerProfile> {
+  @override
+  final int typeId = 23;
+
+  @override
+  ContainerProfile read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return ContainerProfile(
+      fields[0] as String,
+      (fields[1] as List)?.cast<ProfileCondition>(),
+      fields[2] as String,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, ContainerProfile obj) {
+    writer
+      ..writeByte(3)
+      ..writeByte(0)
+      ..write(obj.type)
+      ..writeByte(1)
+      ..write(obj.conditions)
+      ..writeByte(2)
+      ..write(obj.container);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ContainerProfileAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}
+
+class ProfileConditionAdapter extends TypeAdapter<ProfileCondition> {
+  @override
+  final int typeId = 24;
+
+  @override
+  ProfileCondition read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return ProfileCondition(
+      fields[0] as String,
+      fields[1] as String,
+      fields[2] as String,
+      fields[3] as bool,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, ProfileCondition obj) {
+    writer
+      ..writeByte(4)
+      ..writeByte(0)
+      ..write(obj.condition)
+      ..writeByte(1)
+      ..write(obj.property)
+      ..writeByte(2)
+      ..write(obj.value)
+      ..writeByte(3)
+      ..write(obj.isRequired);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ProfileConditionAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}
+
+class CodecProfileAdapter extends TypeAdapter<CodecProfile> {
+  @override
+  final int typeId = 25;
+
+  @override
+  CodecProfile read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return CodecProfile(
+      fields[0] as String,
+      (fields[1] as List)?.cast<ProfileCondition>(),
+      (fields[2] as List)?.cast<ProfileCondition>(),
+      fields[3] as String,
+      fields[4] as String,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, CodecProfile obj) {
+    writer
+      ..writeByte(5)
+      ..writeByte(0)
+      ..write(obj.type)
+      ..writeByte(1)
+      ..write(obj.conditions)
+      ..writeByte(2)
+      ..write(obj.applyConditions)
+      ..writeByte(3)
+      ..write(obj.codec)
+      ..writeByte(4)
+      ..write(obj.container);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CodecProfileAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}
+
+class ResponseProfileAdapter extends TypeAdapter<ResponseProfile> {
+  @override
+  final int typeId = 26;
+
+  @override
+  ResponseProfile read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return ResponseProfile(
+      fields[0] as String,
+      fields[1] as String,
+      fields[2] as String,
+      fields[3] as String,
+      fields[4] as String,
+      fields[5] as String,
+      (fields[6] as List)?.cast<ProfileCondition>(),
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, ResponseProfile obj) {
+    writer
+      ..writeByte(7)
+      ..writeByte(0)
+      ..write(obj.container)
+      ..writeByte(1)
+      ..write(obj.audioCodec)
+      ..writeByte(2)
+      ..write(obj.videoCodec)
+      ..writeByte(3)
+      ..write(obj.type)
+      ..writeByte(4)
+      ..write(obj.orgPn)
+      ..writeByte(5)
+      ..write(obj.mimeType)
+      ..writeByte(6)
+      ..write(obj.conditions);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ResponseProfileAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}
+
+class SubtitleProfileAdapter extends TypeAdapter<SubtitleProfile> {
+  @override
+  final int typeId = 27;
+
+  @override
+  SubtitleProfile read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return SubtitleProfile(
+      fields[0] as String,
+      fields[1] as String,
+      fields[2] as String,
+      fields[3] as String,
+      fields[4] as String,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, SubtitleProfile obj) {
+    writer
+      ..writeByte(5)
+      ..writeByte(0)
+      ..write(obj.format)
+      ..writeByte(1)
+      ..write(obj.method)
+      ..writeByte(2)
+      ..write(obj.didlMode)
+      ..writeByte(3)
+      ..write(obj.language)
+      ..writeByte(4)
+      ..write(obj.container);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SubtitleProfileAdapter &&
           runtimeType == other.runtimeType &&
           typeId == other.typeId;
 }
@@ -1083,17 +2314,17 @@ Map<String, dynamic> _$UserPolicyToJson(UserPolicy instance) =>
 
 AccessSchedule _$AccessScheduleFromJson(Map<String, dynamic> json) {
   return AccessSchedule(
-    json['dayOfWeek'] as String,
-    (json['startHour'] as num)?.toDouble(),
-    (json['endHour'] as num)?.toDouble(),
+    json['DayOfWeek'] as String,
+    (json['StartHour'] as num)?.toDouble(),
+    (json['EndHour'] as num)?.toDouble(),
   );
 }
 
 Map<String, dynamic> _$AccessScheduleToJson(AccessSchedule instance) =>
     <String, dynamic>{
-      'dayOfWeek': instance.dayOfWeek,
-      'startHour': instance.startHour,
-      'endHour': instance.endHour,
+      'DayOfWeek': instance.dayOfWeek,
+      'StartHour': instance.startHour,
+      'EndHour': instance.endHour,
     };
 
 AuthenticationResult _$AuthenticationResultFromJson(Map<String, dynamic> json) {

--- a/lib/models/JellyfinModels.g.dart
+++ b/lib/models/JellyfinModels.g.dart
@@ -6,6 +6,49 @@ part of 'JellyfinModels.dart';
 // TypeAdapterGenerator
 // **************************************************************************
 
+class AuthenticationResultAdapter extends TypeAdapter<AuthenticationResult> {
+  @override
+  final int typeId = 7;
+
+  @override
+  AuthenticationResult read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return AuthenticationResult(
+      fields[0] as UserDto,
+      fields[1] as SessionInfo,
+      fields[2] as String,
+      fields[3] as String,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, AuthenticationResult obj) {
+    writer
+      ..writeByte(4)
+      ..writeByte(0)
+      ..write(obj.user)
+      ..writeByte(1)
+      ..write(obj.sessionInfo)
+      ..writeByte(2)
+      ..write(obj.accessToken)
+      ..writeByte(3)
+      ..write(obj.serverId);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is AuthenticationResultAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}
+
 class BaseItemDtoAdapter extends TypeAdapter<BaseItemDto> {
   @override
   final int typeId = 0;

--- a/lib/screens/SplashScreen.dart
+++ b/lib/screens/SplashScreen.dart
@@ -3,7 +3,6 @@ import 'package:get_it/get_it.dart';
 
 import '../services/JellyfinApiData.dart';
 import '../screens/ServerSelector.dart';
-import '../screens/UserSelector.dart';
 import '../screens/MusicScreen.dart';
 import '../screens/ViewSelector.dart';
 

--- a/lib/screens/SplashScreen.dart
+++ b/lib/screens/SplashScreen.dart
@@ -7,53 +7,22 @@ import '../screens/UserSelector.dart';
 import '../screens/MusicScreen.dart';
 import '../screens/ViewSelector.dart';
 
-class SplashScreen extends StatefulWidget {
+class SplashScreen extends StatelessWidget {
   SplashScreen({Key key}) : super(key: key);
 
   @override
-  _SplashScreenState createState() => _SplashScreenState();
-}
-
-class _SplashScreenState extends State<SplashScreen> {
-  List<Future> splashScreenFutures;
-  JellyfinApiData jellyfinApiData = GetIt.instance<JellyfinApiData>();
-
-  @override
-  void initState() {
-    super.initState();
-    splashScreenFutures = [
-      jellyfinApiData.getBaseUrl(),
-      jellyfinApiData.getCurrentUser(),
-      jellyfinApiData.getView()
-    ];
-  }
-
-  @override
   Widget build(BuildContext context) {
-    return FutureBuilder(
-      future: Future.wait(splashScreenFutures),
-      builder: (context, snapshot) {
-        // snapshot.data[0]: baseUrl
-        // snapshot.data[1]: getCurrentUser
-        // snapshot.data[2]: getView
-        if (snapshot.hasData) {
-          if (snapshot.data[0] == null) {
-            print("No saved base URL. Going to server selector.");
-            return ServerSelector();
-          } else if (snapshot.data[1] == null) {
-            print("No saved user. Going to user selector.");
-            return UserSelector();
-          } else if (snapshot.data[2] == null) {
-            print("No saved view. Going to view selector.");
-            return ViewSelector();
-          } else {
-            print("Base URL, user, and view exist. Going to music screen.");
-            return MusicScreen();
-          }
-        } else {
-          return Scaffold();
-        }
-      },
-    );
+    JellyfinApiData jellyfinApiData = GetIt.instance<JellyfinApiData>();
+
+    if (jellyfinApiData.currentUser == null) {
+      print("No saved user. Going to server selector.");
+      return ServerSelector();
+    } else if (jellyfinApiData.currentUser.view == null) {
+      print("No saved view. Going to view selector.");
+      return ViewSelector();
+    } else {
+      print("User and view exist. Going to music screen.");
+      return MusicScreen();
+    }
   }
 }

--- a/lib/services/AudioServiceHelper.dart
+++ b/lib/services/AudioServiceHelper.dart
@@ -20,7 +20,6 @@ class AudioServiceHelper {
       return Future.error(
           "startAtIndex is bigger than the itemList! ($startAtIndex > ${itemList.length})");
     }
-    String baseUrl = await _jellyfinApiData.getBaseUrl();
 
     // List<MediaItem> queue =
     //     await Future.wait(itemList.map((BaseItemDto item) async {
@@ -48,7 +47,7 @@ class AudioServiceHelper {
         album: itemList[i].album,
         artist: itemList[i].albumArtist,
         artUri:
-            "$baseUrl/Items/${itemList[i].parentId}/Images/Primary?format=jpg",
+            "${_jellyfinApiData.currentUser.baseUrl}/Items/${itemList[i].parentId}/Images/Primary?format=jpg",
         title: itemList[i].name,
         extras: {"parentId": itemList[i].parentId},
         // Jellyfin returns microseconds * 10 for some reason

--- a/lib/services/DownloadsHelper.dart
+++ b/lib/services/DownloadsHelper.dart
@@ -22,7 +22,6 @@ class DownloadsHelper {
   Future<void> addDownloads(
       {List<BaseItemDto> items, BaseItemDto parent}) async {
     Directory songDir = await _getSongDir();
-    String baseUrl = await _jellyfinApiData.getBaseUrl();
 
     for (final item in items) {
       if (downloadedItemsBox.containsKey(item.id)) {
@@ -40,7 +39,8 @@ class DownloadsHelper {
             parent.id, DownloadedAlbum(album: parent, children: []));
       }
 
-      String songUrl = baseUrl + "/Items/${item.id}/File";
+      String songUrl =
+          _jellyfinApiData.currentUser.baseUrl + "/Items/${item.id}/File";
 
       List<MediaSourceInfo> mediaSourceInfo =
           await _jellyfinApiData.getPlaybackInfo(item.id);

--- a/lib/services/DownloadsHelper.dart
+++ b/lib/services/DownloadsHelper.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter_downloader/flutter_downloader.dart';
 import 'package:get_it/get_it.dart';
 import 'package:hive/hive.dart';

--- a/lib/services/JellyfinApi.dart
+++ b/lib/services/JellyfinApi.dart
@@ -96,16 +96,24 @@ abstract class JellyfinApi extends ChopperService {
       interceptors: [
         /// Gets baseUrl from SharedPreferences.
         (Request request) async {
-          SharedPreferences sharedPreferences =
-              await SharedPreferences.getInstance();
-          String authHeader = await getAuthHeader();
-          String tokenHeader = await getTokenHeader();
+          JellyfinApiData jellyfinApiData = GetIt.instance<JellyfinApiData>();
+
+          List<String> headerFutures =
+              await Future.wait([getAuthHeader(), getTokenHeader()]);
+          String authHeader = headerFutures[0];
+          String tokenHeader = headerFutures[1];
+
+          // If baseUrlTemp is null, use the baseUrl of the current user.
+          // If baseUrlTemp is set, we're setting up a new user and should use it instead.
+          String baseUrl = jellyfinApiData.baseUrlTemp == null
+              ? jellyfinApiData.currentUser.baseUrl
+              : jellyfinApiData.baseUrlTemp;
 
           // tokenHeader will be null if the user isn't logged in.
           // If we send a null tokenHeader while logging in, the login will always fail.
           if (tokenHeader == null) {
             return request.copyWith(
-              baseUrl: sharedPreferences.getString('baseUrl'),
+              baseUrl: baseUrl,
               headers: {
                 "Content-Type": "application/json",
                 "X-Emby-Authorization": authHeader,
@@ -113,7 +121,7 @@ abstract class JellyfinApi extends ChopperService {
             );
           } else {
             return request.copyWith(
-              baseUrl: sharedPreferences.getString('baseUrl'),
+              baseUrl: baseUrl,
               headers: {
                 "Content-Type": "application/json",
                 "X-Emby-Authorization": authHeader,
@@ -140,12 +148,12 @@ abstract class JellyfinApi extends ChopperService {
 /// Creates the X-Emby-Authorization header
 Future<String> getAuthHeader() async {
   JellyfinApiData jellyfinApiData = GetIt.instance<JellyfinApiData>();
-  AuthenticationResult currentUser = await jellyfinApiData.getCurrentUser();
 
   String authHeader = "MediaBrowser ";
 
-  if (currentUser != null) {
-    authHeader = authHeader + 'UserId="${currentUser.user.id}", ';
+  if (jellyfinApiData.currentUser != null) {
+    authHeader = authHeader +
+        'UserId="${jellyfinApiData.currentUser.userDetails.user.id}", ';
   }
 
   authHeader = authHeader + 'Client="Finamp", ';
@@ -171,11 +179,10 @@ Future<String> getAuthHeader() async {
 /// Creates the X-Emby-Token header
 Future<String> getTokenHeader() async {
   JellyfinApiData jellyfinApiData = GetIt.instance<JellyfinApiData>();
-  AuthenticationResult currentUser = await jellyfinApiData.getCurrentUser();
 
-  if (currentUser == null) {
+  if (jellyfinApiData.currentUser == null) {
     return null;
   } else {
-    return currentUser.accessToken;
+    return jellyfinApiData.currentUser.userDetails.accessToken;
   }
 }

--- a/lib/services/JellyfinApi.dart
+++ b/lib/services/JellyfinApi.dart
@@ -5,7 +5,6 @@ import 'package:chopper/chopper.dart';
 import 'package:device_info/device_info.dart';
 import 'package:get_it/get_it.dart';
 import 'package:package_info/package_info.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 import '../models/JellyfinModels.dart';
 import 'JellyfinApiData.dart';

--- a/lib/services/JellyfinApiData.dart
+++ b/lib/services/JellyfinApiData.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'dart:io' show Platform;
 
 import 'package:chopper/chopper.dart';
@@ -7,7 +6,6 @@ import 'package:finamp/models/JellyfinModels.dart';
 import 'package:flutter/material.dart';
 import 'package:hive/hive.dart';
 import 'package:package_info/package_info.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 import 'JellyfinApi.dart';
 import '../models/FinampModels.dart';

--- a/lib/services/MusicPlayerBackgroundTask.dart
+++ b/lib/services/MusicPlayerBackgroundTask.dart
@@ -319,14 +319,12 @@ class MusicPlayerBackgroundTask extends BackgroundAudioTask {
         return AudioSource.uri(Uri.file(
             "${appDir.path}/songs/${mediaItem.id}.${offlineMediaSourceInfo.container}"));
       } else {
-        String baseUrl = await jellyfinApiData.getBaseUrl();
-        return AudioSource.uri(
-            Uri.parse("$baseUrl/Audio/${mediaItem.id}/stream?static=true"));
+        return AudioSource.uri(Uri.parse(
+            "${jellyfinApiData.currentUser.baseUrl}/Audio/${mediaItem.id}/stream?static=true"));
       }
     } else {
-      String baseUrl = await jellyfinApiData.getBaseUrl();
-      return AudioSource.uri(
-          Uri.parse("$baseUrl/Audio/${mediaItem.id}/stream?static=true"));
+      return AudioSource.uri(Uri.parse(
+          "${jellyfinApiData.currentUser.baseUrl}/Audio/${mediaItem.id}/stream?static=true"));
     }
   }
 

--- a/lib/services/MusicPlayerBackgroundTask.dart
+++ b/lib/services/MusicPlayerBackgroundTask.dart
@@ -25,8 +25,6 @@ class MusicPlayerBackgroundTask extends BackgroundAudioTask {
   AudioProcessingState _skipState;
   StreamSubscription<PlaybackEvent> _eventSubscription;
   Box<DownloadedSong> _downloadedItemsBox;
-  Box<DownloadedAlbum> _downloadedAlbumsBox;
-  Box<DownloadedSong> _downloadIdsBox;
   DateTime _lastUpdateTime;
 
   @override
@@ -40,8 +38,6 @@ class MusicPlayerBackgroundTask extends BackgroundAudioTask {
     // Set up Hive in this isolate
     await setupHive();
     _downloadedItemsBox = Hive.box("DownloadedItems");
-    _downloadedAlbumsBox = Hive.box("DownloadedAlbums");
-    _downloadIdsBox = Hive.box("DownloadIds");
 
     // Initialise FlutterDownloader in this isolate (only needed to check if file download is complete)
     await FlutterDownloader.initialize();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -611,48 +611,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.24.1"
-  shared_preferences:
-    dependency: "direct main"
-    description:
-      name: shared_preferences
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.5.12+4"
-  shared_preferences_linux:
-    dependency: transitive
-    description:
-      name: shared_preferences_linux
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.0.2+4"
-  shared_preferences_macos:
-    dependency: transitive
-    description:
-      name: shared_preferences_macos
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.0.1+11"
-  shared_preferences_platform_interface:
-    dependency: transitive
-    description:
-      name: shared_preferences_platform_interface
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.4"
-  shared_preferences_web:
-    dependency: transitive
-    description:
-      name: shared_preferences_web
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.1.2+7"
-  shared_preferences_windows:
-    dependency: transitive
-    description:
-      name: shared_preferences_windows
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.0.2+3"
   shelf:
     dependency: transitive
     description:
@@ -679,13 +637,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.99"
-  sliver_fab:
-    dependency: "direct main"
-    description:
-      name: sliver_fab
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.0"
   source_gen:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,9 +28,7 @@ dependencies:
   device_info: '>=0.4.2+7 <2.0.0'
   package_info: '>=0.4.3 <2.0.0'
   chopper: ^3.0.3
-  shared_preferences: '>=0.5.10 <2.0.0'
   get_it: ^5.0.0
-  sliver_fab: ^1.0.0
   cached_network_image: ^2.3.2+1
   just_audio: ^0.6.12
   audio_service: ^0.16.2


### PR DESCRIPTION
Instead of using SharedPreferences, store users in a Hive box. This is less jank, as we don't have to convert user data to JSON. Hive is faster and easier to use. MusicScreenTabView is a good example of this. With SharedPreferences, we needed to use a really janky method to get the user's view before getting the items.

This Hive setup will also make multiple users/servers easy, which means that #10 can be closed.