### PR TITLE
Display current library name on app bar in music screen

### DIFF
--- a/lib/screens/MusicScreen.dart
+++ b/lib/screens/MusicScreen.dart
@@ -124,7 +124,7 @@ class _MusicScreenState extends State<MusicScreen>
                             hintText: "Search",
                           ),
                         )
-                      : const Text("Music"),
+                      : Text(_jellyfinApiData.currentUser?.currentView!.name ?? "Music"),
                   bottom: TabBar(
                     controller: _tabController,
                     tabs: finampSettings.showTabs.entries

--- a/lib/screens/MusicScreen.dart
+++ b/lib/screens/MusicScreen.dart
@@ -124,7 +124,7 @@ class _MusicScreenState extends State<MusicScreen>
                             hintText: "Search",
                           ),
                         )
-                      : Text(_jellyfinApiData.currentUser?.currentView!.name ?? "Music"),
+                      : Text(_jellyfinApiData.currentUser?.currentView?.name ?? "Music"),
                   bottom: TabBar(
                     controller: _tabController,
                     tabs: finampSettings.showTabs.entries


### PR DESCRIPTION
Fixes #98.
Preview: 

https://user-images.githubusercontent.com/46846000/130363954-43f33c46-efb1-4320-9877-0baea1bc0ae2.mp4

