### PR TITLE
Add disc number headers on album screen

### DIFF
--- a/lib/components/AlbumScreen/AlbumScreenContent.dart
+++ b/lib/components/AlbumScreen/AlbumScreenContent.dart
@@ -54,10 +54,7 @@ class AlbumScreenContent extends StatelessWidget {
                         || children[index - 1].parentIndexNumber != item.parentIndexNumber)
                     && parent.type != "Playlist")
                     Padding(
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: 16.0,
-                          vertical: 16.0
-                      ),
+                      padding: const EdgeInsets.fromLTRB(16.0, 16.0, 16.0, 0.0),
                       child: Text(
                         "Disc " + item.parentIndexNumber.toString(),
                         style: const TextStyle(fontSize: 24.0)

--- a/lib/components/AlbumScreen/AlbumScreenContent.dart
+++ b/lib/components/AlbumScreen/AlbumScreenContent.dart
@@ -1,6 +1,4 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/painting.dart';
 
 import '../../models/JellyfinModels.dart';
 import '../../services/FinampSettingsHelper.dart';

--- a/lib/components/AlbumScreen/AlbumScreenContent.dart
+++ b/lib/components/AlbumScreen/AlbumScreenContent.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 import '../../models/JellyfinModels.dart';
@@ -45,11 +46,30 @@ class AlbumScreenContent extends StatelessWidget {
             delegate:
                 SliverChildBuilderDelegate((BuildContext context, int index) {
               final BaseItemDto item = children[index];
-              return SongListTile(
-                item: item,
-                children: children,
-                index: index,
-                parentId: parent.id,
+              return Column(
+                children: [
+                  if (item.parentIndexNumber != null
+                    && (index == 0
+                        || children[index - 1].parentIndexNumber != item.parentIndexNumber)
+                    && parent.type != "Playlist")
+                    Padding(
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 16.0,
+                          vertical: 16.0
+                      ),
+                      child: Text(
+                        "Disc " + item.parentIndexNumber.toString(),
+                        style: const TextStyle(fontSize: 16.0)
+                      ),
+                    ),
+                  SongListTile(
+                    item: item,
+                    children: children,
+                    index: index,
+                    parentId: parent.id,
+                  ),
+                ],
+                crossAxisAlignment: CrossAxisAlignment.start,
               );
             }, childCount: children.length),
           ),

--- a/lib/components/AlbumScreen/AlbumScreenContent.dart
+++ b/lib/components/AlbumScreen/AlbumScreenContent.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/painting.dart';
 
 import '../../models/JellyfinModels.dart';
 import '../../services/FinampSettingsHelper.dart';
@@ -59,7 +60,7 @@ class AlbumScreenContent extends StatelessWidget {
                       ),
                       child: Text(
                         "Disc " + item.parentIndexNumber.toString(),
-                        style: const TextStyle(fontSize: 16.0)
+                        style: const TextStyle(fontSize: 24.0)
                       ),
                     ),
                   SongListTile(

--- a/lib/components/AlbumScreen/SongListTile.dart
+++ b/lib/components/AlbumScreen/SongListTile.dart
@@ -92,7 +92,8 @@ class _SongListTileState extends State<SongListTile> {
                           : null,
                   ),
                 ),
-              ]
+              ],
+              style: const TextStyle(fontSize: 16.0)
             ),
           );
         },


### PR DESCRIPTION
Disc numbers requested in #80 (first suggested style).
This PR add disc numbers as headers between songs. If Jellyfin doesn't return `parentIndexNumber` (assumed to be the disc number: https://github.com/jellyfin/jellyfin-web/blob/38f486339f191af50215532cb86679f53efd0aec/src/controllers/itemDetails/index.js#L1422), the headers won't be displayed.

I have also increased the song title font size a bit - 04912eef0712391e13701d20fc1bd292d600be3c from #127 has decreased it and I haven't noticed it until now.

![20210914_201634](https://user-images.githubusercontent.com/46846000/133312063-ead2f069-6372-442e-8b6e-2d864cbfdbf4.jpg)
![20210914_201648](https://user-images.githubusercontent.com/46846000/133312065-fbbfc288-09fd-4d74-b1aa-d5544bee77d1.jpg)
