### PR TITLE
Partially fix downloading on Android by upgrading flutter_downloader to 1.7.1

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -334,7 +334,7 @@ packages:
       name: flutter_downloader
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.7.1"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:


### PR DESCRIPTION
Fixes #137.
Relevant upstream discussion: https://github.com/fluttercommunity/flutter_downloader/issues/533#issuecomment-939214932 
Quick testing on Android 10:
- app dir: **works**
- internal storage: **works**
- external storage: `FileSystemException: Creation failed, path = '/storage/08E9-351C/Music/Illenium' (OS Error: Permission denied, errno = 13)`

Android 11:
- app dir: **works**
- internal storage: `FileSystemException: Creation failed, path = '/storage/emulated/0/Music/Illenium' (OS Error: Permission denied, errno = 13)`
- external storage: `FileSystemException: Creation failed, path = '/storage/17E7-3C16/Music/Illenium' (OS Error: Permission denied, errno = 13)`

It's not perfect, but it's miles better than on 1.7.0 where none of above works.