### PR TITLE
Add album name on player screen

### DIFF
--- a/lib/components/PlayerScreen/SongName.dart
+++ b/lib/components/PlayerScreen/SongName.dart
@@ -4,7 +4,7 @@ import 'package:get_it/get_it.dart';
 
 import '../../services/MusicPlayerBackgroundTask.dart';
 
-/// Creates some text that shows the song's name and the artist.
+/// Creates some text that shows the song's name, album and the artist.
 class SongName extends StatelessWidget {
   const SongName({Key? key}) : super(key: key);
 
@@ -19,6 +19,12 @@ class SongName extends StatelessWidget {
 
         return Column(
           children: [
+            Text(
+              mediaItem == null ? "No Album" : mediaItem.album ?? "No Album",
+              style: TextStyle(color: Colors.white.withOpacity(0.6)),
+              textAlign: TextAlign.center,
+            ),
+            const Padding(padding: EdgeInsets.symmetric(vertical: 2)),
             Text(
               mediaItem == null ? "No Item" : mediaItem.title,
               style: const TextStyle(fontSize: 24, fontWeight: FontWeight.w600),


### PR DESCRIPTION
Another small addition. It might seem a bit pointless because there's album art already (hopefully making clear which album the song belongs to), but I was thinking about adding an `onTap` callback later, showing the album screen when tapped. 
Same could be done with artist name, but I'm not sure how this would work when there are multiple artists, some of whom don't have their entry in Artists tab (Album Artists, according to JF web client).

![Screenshot_20211031-204829_Finamp](https://user-images.githubusercontent.com/46846000/139599424-ee9085f9-6491-4d05-93f0-bcb335725214.png)

