### PR TITLE
Add library selection button in settings

### DIFF
--- a/lib/components/SettingsScreen/LogoutListTile.dart
+++ b/lib/components/SettingsScreen/LogoutListTile.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 
 import '../../services/JellyfinApiData.dart';
+import '../../services/FinampSettingsHelper.dart';
 import '../../services/MusicPlayerBackgroundTask.dart';
 import '../errorSnackbar.dart';
 
@@ -11,19 +12,26 @@ class LogoutListTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ListTile(
-      leading: const Icon(
+      leading: Icon(
         Icons.logout,
-        color: Colors.red,
+        color:
+            FinampSettingsHelper.finampSettings.isOffline ? null : Colors.red,
       ),
-      title: const Text(
+      title: Text(
         "Log out",
-        style: TextStyle(
-          color: Colors.red,
-        ),
+        style: FinampSettingsHelper.finampSettings.isOffline
+            ? null
+            : const TextStyle(
+                color: Colors.red,
+              ),
       ),
-      subtitle: Text("Downloaded songs will not be deleted",
-          style:
-              Theme.of(context).textTheme.caption?.copyWith(color: Colors.red)),
+      subtitle: FinampSettingsHelper.finampSettings.isOffline
+          ? const Text("Not available in offline mode")
+          : const Text(
+              "Downloaded songs will not be deleted",
+              style: TextStyle(color: Colors.red),
+            ),
+      enabled: !FinampSettingsHelper.finampSettings.isOffline,
       onTap: () {
         showDialog(
           context: context,

--- a/lib/screens/SettingsScreen.dart
+++ b/lib/screens/SettingsScreen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:package_info/package_info.dart';
 
+import '../services/FinampSettingsHelper.dart';
 import '../components/SettingsScreen/LogoutListTile.dart';
 
 class SettingsScreen extends StatelessWidget {
@@ -57,7 +58,10 @@ class SettingsScreen extends StatelessWidget {
             ListTile(
               leading: const Icon(Icons.library_music),
               title: const Text("Select Music Libraries"),
-              subtitle: const Text("Server connection is required"),
+              subtitle: FinampSettingsHelper.finampSettings.isOffline
+                  ? const Text("Not available in offline mode")
+                  : null,
+              enabled: !FinampSettingsHelper.finampSettings.isOffline,
               onTap: () => Navigator.of(context).pushNamed("/settings/views"),
             ),
             const LogoutListTile(),

--- a/lib/screens/SettingsScreen.dart
+++ b/lib/screens/SettingsScreen.dart
@@ -54,6 +54,12 @@ class SettingsScreen extends StatelessWidget {
               title: const Text("Layout"),
               onTap: () => Navigator.of(context).pushNamed("/settings/layout"),
             ),
+            ListTile(
+              leading: const Icon(Icons.library_music),
+              title: const Text("Select Music Libraries"),
+              subtitle: const Text("Server connection is required"),
+              onTap: () => Navigator.of(context).pushNamed("/settings/views"),
+            ),
             const LogoutListTile(),
           ],
         ),


### PR DESCRIPTION
This PR allows user to select libraries after initial setup without wiping app data. No further explanation needed, here's a video anyway:

https://user-images.githubusercontent.com/46846000/142790308-d952537e-05de-4458-889f-237b949c6bdc.mp4



