### PR TITLE
Skip music library selection if there's only one available during setup

### DIFF
--- a/lib/screens/ViewSelector.dart
+++ b/lib/screens/ViewSelector.dart
@@ -65,7 +65,7 @@ class _ViewSelectorState extends State<ViewSelector> {
               if (_views.isEmpty) {
                 _views.addEntries(snapshot.data!
                     .where((element) => element.collectionType != "playlists")
-                    .map((e) => MapEntry(e, false)));
+                    .map((e) => MapEntry(e, e.collectionType == "music")));
               }
 
               return Scrollbar(


### PR DESCRIPTION
Fixes #42.
This might cause issues when user has one `music` library and one or more for audiobooks (of type `books` afaik), as the audiobook library wouldn't get selected. I see three solutions:
- Ignore this, as there's no explicit support for audiobooks in Finamp anyway (yet).
- Start with music library only and make user aware of selector in settings (#148). Maybe mention it in a toast?
- Disable selector skip if any library with type `books` exists.