### PR TITLE
Fixed bug where url for images would break if Jellyfin is published w…

### DIFF
--- a/lib/services/JellyfinApiData.dart
+++ b/lib/services/JellyfinApiData.dart
@@ -401,17 +401,18 @@ class JellyfinApiData {
 
     if (imageId != null) {
       final parsedBaseUrl = Uri.parse(currentUser!.baseUrl);
-
+      List<String> builtPath = new List<String>.from(parsedBaseUrl.pathSegments);
+      builtPath.addAll([
+        "Items",
+        imageId,
+        "Images",
+        "Primary",
+      ]);
       return Uri(
           host: parsedBaseUrl.host,
           port: parsedBaseUrl.port,
           scheme: parsedBaseUrl.scheme,
-          pathSegments: [
-            "Items",
-            imageId,
-            "Images",
-            "Primary",
-          ],
+          pathSegments: builtPath,
           queryParameters: {
             "format": "jpg",
             "quality": quality.toString(),


### PR DESCRIPTION
tldr; fix image downloads from urls with a path. Example :  https://www.url.com/jellyfin

If a jellyfin instance is published on a url with a path (example www.website.com/media). images won't download using the current JellyfinAPiData.

I added some code that will get the pathSegments of the parsedBaseUrl and then append the path segments to retrieve the image.

My dart skills are not great. So if you want to disregard this request and fix it yourself writing differently, I won't mind.

(PS:  Full disclosure, I didn't test what happens if the url path segments are empty in the baseUrl)