### PR TITLE
When shuffle is pressed, shuffling items list before sending it to audioService 

### DIFF
--- a/lib/components/AlbumScreen/AlbumScreenContentFlexibleSpaceBar.dart
+++ b/lib/components/AlbumScreen/AlbumScreenContentFlexibleSpaceBar.dart
@@ -64,10 +64,13 @@ class AlbumScreenContentFlexibleSpaceBar extends StatelessWidget {
                     Expanded(
                       child: ElevatedButton.icon(
                           onPressed: () =>
-                              audioServiceHelper.replaceQueueWithItem(
-                                itemList: items,
-                                shuffle: true,
-                              ),
+                          {
+                            items.shuffle(),
+                            audioServiceHelper.replaceQueueWithItem(
+                              itemList: items,
+                              shuffle: true,
+                            )
+                          },
                           icon: const Icon(Icons.shuffle),
                           label: const Text("SHUFFLE")),
                     ),


### PR DESCRIPTION
This should fix this issue: https://github.com/UnicornsOnLSD/finamp/issues/61

Seems like the audio service only shuffles next songs that are in the queue and not existing ones. Shuffling the list before hand ensures that the first song gets shuffled as well.