### PR TITLE
Matched sorting behaviour to the one that is in the jellyfin web client.

### DIFF
--- a/lib/components/LayoutSettingsScreen/ContentGridViewCrossAxisCountListTile.dart
+++ b/lib/components/LayoutSettingsScreen/ContentGridViewCrossAxisCountListTile.dart
@@ -4,11 +4,8 @@ import '../../services/FinampSettingsHelper.dart';
 
 enum ContentGridViewCrossAxisCountType {
   portrait,
-  landscape,
-}
+  landscape;
 
-extension ContentGridViewCrossAxisCountTypeExtension
-    on ContentGridViewCrossAxisCountType {
   /// Human-readable version of the [ContentGridViewCrossAxisCountType]. For
   /// example, toString() on [ContentGridViewCrossAxisCountType.portrait],
   /// toString() would return "ContentGridViewCrossAxisCountType.portrait". With

--- a/lib/components/LayoutSettingsScreen/ContentGridViewCrossAxisCountListTile.dart
+++ b/lib/components/LayoutSettingsScreen/ContentGridViewCrossAxisCountListTile.dart
@@ -10,7 +10,8 @@ enum ContentGridViewCrossAxisCountType {
   /// example, toString() on [ContentGridViewCrossAxisCountType.portrait],
   /// toString() would return "ContentGridViewCrossAxisCountType.portrait". With
   /// this function, the same input would return "Portrait".
-  String get humanReadableName => _humanReadableName(this);
+  @override
+  String toString() => _humanReadableName(this);
 
   String _humanReadableName(
       ContentGridViewCrossAxisCountType contentGridViewCrossAxisCountType) {
@@ -60,9 +61,9 @@ class _ContentGridViewCrossAxisCountListTileState
   @override
   Widget build(BuildContext context) {
     return ListTile(
-      title: Text("${widget.type.humanReadableName} Grid Cross-Axis Count"),
+      title: Text("${widget.type.toString()} Grid Cross-Axis Count"),
       subtitle: Text(
-          "Amount of grid tiles to use per-row when ${widget.type.humanReadableName.toLowerCase()}."),
+          "Amount of grid tiles to use per-row when ${widget.type.toString().toLowerCase()}."),
       trailing: SizedBox(
         width: 50 * MediaQuery.of(context).textScaleFactor,
         child: TextField(

--- a/lib/components/LayoutSettingsScreen/ContentViewTypeDropdownListTile.dart
+++ b/lib/components/LayoutSettingsScreen/ContentViewTypeDropdownListTile.dart
@@ -19,7 +19,7 @@ class ContentViewTypeDropdownListTile extends StatelessWidget {
             value: box.get("FinampSettings")?.contentViewType,
             items: ContentViewType.values
                 .map((e) => DropdownMenuItem<ContentViewType>(
-                      child: Text(e.humanReadableName),
+                      child: Text(e.toString()),
                       value: e,
                     ))
                 .toList(),

--- a/lib/components/MusicScreen/MusicScreenTabView.dart
+++ b/lib/components/MusicScreen/MusicScreenTabView.dart
@@ -89,8 +89,8 @@ class _MusicScreenTabViewState extends State<MusicScreenTabView>
                         ? "ProductionYear"
                         : "SortName"
             : widget.sortBy?.jellyfinName(widget.tabContentType),
-        sortOrder: widget.sortOrder?.humanReadableName ??
-            SortOrder.ascending.humanReadableName,
+        sortOrder: widget.sortOrder?.toString() ??
+            SortOrder.ascending.toString(),
         searchTerm: widget.searchTerm,
         // If this is the genres tab, tell getItems to get genres.
         isGenres: widget.tabContentType == TabContentType.genres,

--- a/lib/components/MusicScreen/MusicScreenTabView.dart
+++ b/lib/components/MusicScreen/MusicScreenTabView.dart
@@ -80,7 +80,7 @@ class _MusicScreenTabViewState extends State<MusicScreenTabView>
         // artist view. If it's null, sort by "SortName". If it isn't null, check
         // if the parentItem is a MusicArtist. If it is, sort by year. Otherwise,
         // sort by SortName. If widget.sortBy is set, it is used instead.
-        sortBy: widget.sortBy?.jellyfinName == null
+        sortBy: widget.sortBy?.jellyfinName(widget.tabContentType) == null
             ? widget.tabContentType == TabContentType.songs
                 ? "Album,SortName"
                 : widget.parentItem == null
@@ -88,7 +88,7 @@ class _MusicScreenTabViewState extends State<MusicScreenTabView>
                     : widget.parentItem?.type == "MusicArtist"
                         ? "ProductionYear"
                         : "SortName"
-            : widget.sortBy?.jellyfinName,
+            : widget.sortBy?.jellyfinName(widget.tabContentType),
         sortOrder: widget.sortOrder?.humanReadableName ??
             SortOrder.ascending.humanReadableName,
         searchTerm: widget.searchTerm,

--- a/lib/components/MusicScreen/SortByMenuButton.dart
+++ b/lib/components/MusicScreen/SortByMenuButton.dart
@@ -14,7 +14,7 @@ class SortByMenuButton extends StatelessWidget {
       itemBuilder: (context) => <PopupMenuEntry<SortBy>>[
         PopupMenuItem(
           child: Text(
-            SortBy.sortName.humanReadableName,
+            SortBy.sortName.toString(),
             style: TextStyle(
               color:
                   FinampSettingsHelper.finampSettings.sortBy == SortBy.sortName
@@ -26,7 +26,7 @@ class SortByMenuButton extends StatelessWidget {
         ),
         PopupMenuItem(
           child: Text(
-            SortBy.albumArtist.humanReadableName,
+            SortBy.albumArtist.toString(),
             style: TextStyle(
               color: FinampSettingsHelper.finampSettings.sortBy ==
                       SortBy.albumArtist
@@ -38,7 +38,7 @@ class SortByMenuButton extends StatelessWidget {
         ),
         PopupMenuItem(
           child: Text(
-            SortBy.communityRating.humanReadableName,
+            SortBy.communityRating.toString(),
             style: TextStyle(
               color: FinampSettingsHelper.finampSettings.sortBy ==
                       SortBy.communityRating
@@ -50,7 +50,7 @@ class SortByMenuButton extends StatelessWidget {
         ),
         PopupMenuItem(
           child: Text(
-            SortBy.criticRating.humanReadableName,
+            SortBy.criticRating.toString(),
             style: TextStyle(
               color: FinampSettingsHelper.finampSettings.sortBy ==
                       SortBy.criticRating
@@ -62,7 +62,7 @@ class SortByMenuButton extends StatelessWidget {
         ),
         PopupMenuItem(
           child: Text(
-            SortBy.dateCreated.humanReadableName,
+            SortBy.dateCreated.toString(),
             style: TextStyle(
               color: FinampSettingsHelper.finampSettings.sortBy ==
                       SortBy.dateCreated
@@ -74,7 +74,7 @@ class SortByMenuButton extends StatelessWidget {
         ),
         PopupMenuItem(
           child: Text(
-            SortBy.premiereDate.humanReadableName,
+            SortBy.premiereDate.toString(),
             style: TextStyle(
               color: FinampSettingsHelper.finampSettings.sortBy ==
                       SortBy.premiereDate
@@ -86,7 +86,7 @@ class SortByMenuButton extends StatelessWidget {
         ),
         PopupMenuItem(
           child: Text(
-            SortBy.random.humanReadableName,
+            SortBy.random.toString(),
             style: TextStyle(
               color: FinampSettingsHelper.finampSettings.sortBy == SortBy.random
                   ? Theme.of(context).colorScheme.secondary

--- a/lib/components/TabsSettingsScreen/HideTabToggle.dart
+++ b/lib/components/TabsSettingsScreen/HideTabToggle.dart
@@ -18,7 +18,7 @@ class HideTabToggle extends StatelessWidget {
       valueListenable: FinampSettingsHelper.finampSettingsListener,
       builder: (_, box, __) {
         return SwitchListTile(
-          title: Text('Show ' + tabContentType.humanReadableName),
+          title: Text('Show ' + tabContentType.toString()),
           // This should never be null, but it gets set to true if it is.
           value: FinampSettingsHelper
                   .finampSettings.showTabs[this.tabContentType] ??

--- a/lib/models/FinampModels.dart
+++ b/lib/models/FinampModels.dart
@@ -366,10 +366,8 @@ enum TabContentType {
   genres,
 
   @HiveField(4)
-  songs,
-}
+  songs;
 
-extension TabContentTypeExtension on TabContentType {
   /// Human-readable version of the [TabContentType]. For example, toString() on
   /// [TabContentType.songs], toString() would return "TabContentType.songs".
   /// With this function, the same input would return "Songs".
@@ -397,10 +395,8 @@ enum ContentViewType {
   list,
 
   @HiveField(1)
-  grid,
-}
+  grid;
 
-extension ContentViewTypeExtension on ContentViewType {
   /// Human-readable version of this enum. I've written longer descriptions on
   /// enums like [TabContentType], and I can't be bothered to copy and paste it
   /// again.

--- a/lib/models/FinampModels.dart
+++ b/lib/models/FinampModels.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:hive/hive.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:logging/logging.dart';
@@ -371,7 +369,8 @@ enum TabContentType {
   /// Human-readable version of the [TabContentType]. For example, toString() on
   /// [TabContentType.songs], toString() would return "TabContentType.songs".
   /// With this function, the same input would return "Songs".
-  String get humanReadableName => _humanReadableName(this);
+  @override
+  String toString() => _humanReadableName(this);
 
   String _humanReadableName(TabContentType tabContentType) {
     switch (tabContentType) {
@@ -400,7 +399,8 @@ enum ContentViewType {
   /// Human-readable version of this enum. I've written longer descriptions on
   /// enums like [TabContentType], and I can't be bothered to copy and paste it
   /// again.
-  String get humanReadableName => _humanReadableName(this);
+  @override
+  String toString() => _humanReadableName(this);
 
   String _humanReadableName(ContentViewType contentViewType) {
     switch (contentViewType) {

--- a/lib/models/JellyfinModels.dart
+++ b/lib/models/JellyfinModels.dart
@@ -3308,10 +3308,8 @@ enum SortBy {
   revenue,
 
   @HiveField(14)
-  runtime,
-}
+  runtime;
 
-extension SortByExtension on SortBy {
   /// Human-readable version of the [SortBy]. For example, toString() on
   /// [SortBy.album], toString() would return "SortBy.album". With this
   /// function, the same input would return "Album".
@@ -3468,6 +3466,8 @@ extension SortByExtension on SortBy {
         return "Runtime,AlbumArtist,Album,SortName";
     }
   }
+
+
 }
 
 /// Enum for sort orders.

--- a/lib/models/JellyfinModels.dart
+++ b/lib/models/JellyfinModels.dart
@@ -3313,7 +3313,8 @@ enum SortBy {
   /// Human-readable version of the [SortBy]. For example, toString() on
   /// [SortBy.album], toString() would return "SortBy.album". With this
   /// function, the same input would return "Album".
-  String get humanReadableName => _humanReadableName(this);
+  @override
+  String toString() => _humanReadableName(this);
 
   /// Name used by Jellyfin in API requests.
   String jellyfinName(TabContentType contentType){
@@ -3484,7 +3485,8 @@ enum SortOrder {
   /// this function, the same input would return "Ascending". This function is
   /// also used in Jellyfin API calls, but another function will be needed when
   /// localisation support is added.
-  String get humanReadableName => _humanReadableName(this);
+  @override
+  String toString() => _humanReadableName(this);
 
   String _humanReadableName(SortOrder sortOrder) {
     switch (sortOrder) {

--- a/lib/models/JellyfinModels.dart
+++ b/lib/models/JellyfinModels.dart
@@ -7,6 +7,7 @@
 ///
 /// These classes should be correct with Jellyfin 10.7.5
 
+import 'package:finamp/models/FinampModels.dart';
 import 'package:hive/hive.dart';
 import 'package:json_annotation/json_annotation.dart';
 
@@ -3317,7 +3318,16 @@ extension SortByExtension on SortBy {
   String get humanReadableName => _humanReadableName(this);
 
   /// Name used by Jellyfin in API requests.
-  String get jellyfinName => _jellyfinName(this);
+  String jellyfinName(TabContentType contentType){
+    switch (contentType){
+      case TabContentType.albums:
+        return _jellyfinNameMusicAlbums(this);
+      case TabContentType.songs:
+        return _jellyfinNameSongs(this);
+      default:
+        return _jellyfinName(this);
+    }
+  }
 
   String _humanReadableName(SortBy sortBy) {
     switch (sortBy) {
@@ -3386,6 +3396,76 @@ extension SortByExtension on SortBy {
         return "Revenue";
       case SortBy.runtime:
         return "Runtime";
+    }
+  }
+
+  String _jellyfinNameMusicAlbums(SortBy sortBy){
+    switch (sortBy) {
+      case SortBy.album:
+        return "Album";
+      case SortBy.albumArtist:
+        return "AlbumArtist,SortName";
+      case SortBy.artist:
+        return "Artist";
+      case SortBy.budget:
+        return "Budget";
+      case SortBy.communityRating:
+        return "CommunityRating,SortName";
+      case SortBy.criticRating:
+        return "CriticRating,SortName";
+      case SortBy.dateCreated:
+        return "DateCreated,SortName";
+      case SortBy.datePlayed:
+        return "DatePlayed";
+      case SortBy.playCount:
+        return "PlayCount";
+      case SortBy.premiereDate:
+        return "PremiereDate";
+      case SortBy.productionYear:
+        return "ProductionYear,PremiereDate,SortName";
+      case SortBy.sortName:
+        return "SortName";
+      case SortBy.random:
+        return "Random,SortName";
+      case SortBy.revenue:
+        return "Revenue";
+      case SortBy.runtime:
+        return "Runtime";
+    }
+  }
+
+  String _jellyfinNameSongs(SortBy sortBy) {
+    switch (sortBy) {
+      case SortBy.album:
+        return "Album,SortName";
+      case SortBy.albumArtist:
+        return "AlbumArtist,Album,SortName";
+      case SortBy.artist:
+        return "Artist,Album,SortName";
+      case SortBy.budget:
+        return "Budget";
+      case SortBy.communityRating:
+        return "CommunityRating";
+      case SortBy.criticRating:
+        return "CriticRating";
+      case SortBy.dateCreated:
+        return "DateCreated,SortName";
+      case SortBy.datePlayed:
+        return "DatePlayed,SortName";
+      case SortBy.playCount:
+        return "PlayCount,SortName";
+      case SortBy.premiereDate:
+        return "PremiereDate,AlbumArtist,Album,SortName";
+      case SortBy.productionYear:
+        return "ProductionYear";
+      case SortBy.sortName:
+        return "Name";
+      case SortBy.random:
+        return "Random";
+      case SortBy.revenue:
+        return "Revenue";
+      case SortBy.runtime:
+        return "Runtime,AlbumArtist,Album,SortName";
     }
   }
 }

--- a/lib/models/JellyfinModels.dart
+++ b/lib/models/JellyfinModels.dart
@@ -3477,10 +3477,8 @@ enum SortOrder {
   ascending,
 
   @HiveField(1)
-  descending,
-}
+  descending;
 
-extension SortOrderExtension on SortOrder {
   /// Human-readable version of the [SortOrder]. For example, toString() on
   /// [SortOrder.ascending], toString() would return "SortOrder.ascending". With
   /// this function, the same input would return "Ascending". This function is

--- a/lib/screens/MusicScreen.dart
+++ b/lib/screens/MusicScreen.dart
@@ -137,7 +137,7 @@ class _MusicScreenState extends State<MusicScreen>
                     tabs: finampSettings.showTabs.entries
                         .where((element) => element.value)
                         .map((e) =>
-                            Tab(text: e.key.humanReadableName.toUpperCase()))
+                            Tab(text: e.key.toString().toUpperCase()))
                         .toList(),
                     isScrollable: true,
                   ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 0.6.1+17
 
 environment:
-  sdk: ">=2.13.0 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Web Client behavior:
Albums - https://github.com/jellyfin/jellyfin-web/blob/master/src/controllers/music/musicalbums.js#L243
Songs - https://github.com/jellyfin/jellyfin-web/blob/master/src/controllers/music/songs.js#L157

The Web Client does not have sorting for Artists, Playlists or Genres. The current finamp app provides sorting for all categories.
The Web Client also has different sort options for Albums and Songs. The current finamp app has the same sorting options.
If you want, I can make the behavior exactly as the one in the web client. Let me know in the comments and I'll update this PR accordingly.  
