### PR TITLE
Tap artist or album name to go to its page in library

### DIFF
--- a/lib/components/AlbumScreen/ItemInfo.dart
+++ b/lib/components/AlbumScreen/ItemInfo.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
 
 import '../../models/JellyfinModels.dart';
+import '../../screens/ArtistScreen.dart';
+import '../../services/JellyfinApiData.dart';
 import '../../services/processArtist.dart';
 import '../printDuration.dart';
 
@@ -22,7 +25,7 @@ class ItemInfo extends StatelessWidget {
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
         if (item.type != "Playlist")
-          _iconAndText(Icons.person, processArtist(item.albumArtist)),
+          _artistIconAndText(item, context),
         _iconAndText(Icons.music_note, "${itemSongs.toString()} Songs"),
         _iconAndText(
             Icons.timer,
@@ -59,5 +62,15 @@ Widget _iconAndText(IconData iconData, String text) {
         )
       ],
     ),
+  );
+}
+
+Widget _artistIconAndText(BaseItemDto album, BuildContext context) {
+  final jellyfinApiData = GetIt.instance<JellyfinApiData>();
+  return GestureDetector(
+      onTap: () => jellyfinApiData.getItemById(album.albumArtists!.first.id).then(
+        (artist) => Navigator.of(context).pushNamed(ArtistScreen.routeName, arguments: artist)
+      ),
+      child: _iconAndText(Icons.person, processArtist(album.albumArtist)),
   );
 }

--- a/lib/components/AlbumScreen/ItemInfo.dart
+++ b/lib/components/AlbumScreen/ItemInfo.dart
@@ -24,8 +24,7 @@ class ItemInfo extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
-        if (item.type != "Playlist")
-          _artistIconAndText(item, context),
+        if (item.type != "Playlist") _artistIconAndText(item, context),
         _iconAndText(Icons.music_note, "${itemSongs.toString()} Songs"),
         _iconAndText(
             Icons.timer,
@@ -68,9 +67,9 @@ Widget _iconAndText(IconData iconData, String text) {
 Widget _artistIconAndText(BaseItemDto album, BuildContext context) {
   final jellyfinApiData = GetIt.instance<JellyfinApiData>();
   return GestureDetector(
-      onTap: () => jellyfinApiData.getItemById(album.albumArtists!.first.id).then(
-        (artist) => Navigator.of(context).pushNamed(ArtistScreen.routeName, arguments: artist)
-      ),
-      child: _iconAndText(Icons.person, processArtist(album.albumArtist)),
+    onTap: () => jellyfinApiData.getItemById(album.albumArtists!.first.id).then(
+        (artist) => Navigator.of(context)
+            .pushNamed(ArtistScreen.routeName, arguments: artist)),
+    child: _iconAndText(Icons.person, processArtist(album.albumArtist)),
   );
 }

--- a/lib/components/PlayerScreen/SongName.dart
+++ b/lib/components/PlayerScreen/SongName.dart
@@ -6,6 +6,7 @@ import 'package:get_it/get_it.dart';
 
 import '../../screens/AlbumScreen.dart';
 import '../../screens/ArtistScreen.dart';
+import '../../services/FinampSettingsHelper.dart';
 import '../../services/JellyfinApiData.dart';
 import '../../services/MusicPlayerBackgroundTask.dart';
 
@@ -32,10 +33,16 @@ class SongName extends StatelessWidget {
                   text: e.name,
                   style: TextStyle(color: Colors.white.withOpacity(0.6)),
                   recognizer: TapGestureRecognizer()
-                    ..onTap = () => jellyfinApiData.getItemById(e.id).then(
-                        (artist) => Navigator.of(context).popAndPushNamed(
-                            ArtistScreen.routeName,
-                            arguments: artist))))
+                    ..onTap = () {
+                      // Offline artists aren't implemented yet so we return if
+                      // offline
+                      if (FinampSettingsHelper.finampSettings.isOffline) return;
+
+                      jellyfinApiData.getItemById(e.id).then((artist) =>
+                          Navigator.of(context).popAndPushNamed(
+                              ArtistScreen.routeName,
+                              arguments: artist));
+                    }))
               .forEach((artistTextSpan) {
             separatedArtistTextSpans.add(artistTextSpan);
             separatedArtistTextSpans.add(TextSpan(

--- a/lib/components/PlayerScreen/SongName.dart
+++ b/lib/components/PlayerScreen/SongName.dart
@@ -30,7 +30,7 @@ class SongName extends StatelessWidget {
           style: TextStyle(color: Colors.white.withOpacity(0.6)),
           recognizer: TapGestureRecognizer()..onTap = () =>
             jellyfinApiData.getItemById(e.id).then(
-              (artist) => Navigator.of(context).pushNamed(ArtistScreen.routeName, arguments: artist)
+              (artist) => Navigator.of(context).popAndPushNamed(ArtistScreen.routeName, arguments: artist)
             )
         )).forEach((artistTextSpan) {
           separatedArtistTextSpans.add(artistTextSpan);
@@ -48,7 +48,7 @@ class SongName extends StatelessWidget {
             GestureDetector(
               onTap: () => {
                   jellyfinApiData.getItemById(songBaseItemDto.albumId as String).then(
-                    (album) => Navigator.of(context).pushNamed(AlbumScreen.routeName, arguments: album)
+                    (album) => Navigator.of(context).popAndPushNamed(AlbumScreen.routeName, arguments: album)
                   )
               },
               child: Text(

--- a/lib/components/PlayerScreen/SongName.dart
+++ b/lib/components/PlayerScreen/SongName.dart
@@ -1,7 +1,10 @@
 import 'package:audio_service/audio_service.dart';
+import 'package:finamp/models/JellyfinModels.dart';
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 
+import '../../screens/AlbumScreen.dart';
+import '../../services/JellyfinApiData.dart';
 import '../../services/MusicPlayerBackgroundTask.dart';
 
 /// Creates some text that shows the song's name, album and the artist.
@@ -11,6 +14,7 @@ class SongName extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final _audioHandler = GetIt.instance<MusicPlayerBackgroundTask>();
+    final jellyfinApiData = GetIt.instance<JellyfinApiData>();
 
     return StreamBuilder<MediaItem?>(
       stream: _audioHandler.mediaItem,
@@ -19,10 +23,20 @@ class SongName extends StatelessWidget {
 
         return Column(
           children: [
-            Text(
-              mediaItem == null ? "No Album" : mediaItem.album ?? "No Album",
-              style: TextStyle(color: Colors.white.withOpacity(0.6)),
-              textAlign: TextAlign.center,
+            GestureDetector(
+              onTap: () => {
+                if (mediaItem?.extras?["itemJson"] != null)
+                  jellyfinApiData.getItemById(
+                      BaseItemDto.fromJson(mediaItem?.extras?["itemJson"]).albumId as String
+                  ).then((album) =>
+                      Navigator.of(context).pushNamed(AlbumScreen.routeName, arguments: album)
+                  )
+              },
+              child: Text(
+                mediaItem == null ? "No Album" : mediaItem.album ?? "No Album",
+                style: TextStyle(color: Colors.white.withOpacity(0.6)),
+                textAlign: TextAlign.center,
+              ),
             ),
             const Padding(padding: EdgeInsets.symmetric(vertical: 2)),
             Text(


### PR DESCRIPTION
https://user-images.githubusercontent.com/46846000/177649467-d3f34418-1189-4e74-a389-2ec3562d4da8.mp4

Some issues:
- There's no visual indicator that those spots can now be tapped to navigate to artist/album page.
- Janky handling of TextSpans for artists.
- Artist of a song that isn't albumArtist on any album will have empty artist page (last few seconds of video). Web client shows an "appears on" section for such not-album artists, I'm thinking about adding this feature here too:

![obraz](https://user-images.githubusercontent.com/46846000/177650308-e43dce07-d1e0-40d6-b981-432be2b4b720.png)
