### PR TITLE
Add toggleable blurred coverart player background

### DIFF
--- a/lib/components/LayoutSettingsScreen/show_cover_as_player_background_selector.dart
+++ b/lib/components/LayoutSettingsScreen/show_cover_as_player_background_selector.dart
@@ -4,8 +4,8 @@ import 'package:hive/hive.dart';
 import '../../models/finamp_models.dart';
 import '../../services/finamp_settings_helper.dart';
 
-class ShowCoverOnPlayerBackgroundSelector extends StatelessWidget {
-  const ShowCoverOnPlayerBackgroundSelector({Key? key}) : super(key: key);
+class ShowCoverAsPlayerBackgroundSelector extends StatelessWidget {
+  const ShowCoverAsPlayerBackgroundSelector({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -16,9 +16,9 @@ class ShowCoverOnPlayerBackgroundSelector extends StatelessWidget {
           title: const Text("Show Blurred Cover as Player Background"),
           subtitle: const Text(
               "Whether or not to use blurred cover art as background on player screen."),
-          value: FinampSettingsHelper.finampSettings.showCoverPlayerBackground,
+          value: FinampSettingsHelper.finampSettings.showCoverAsPlayerBackground,
           onChanged: (value) =>
-              FinampSettingsHelper.setShowAlbumArtPlayerBackground(value),
+              FinampSettingsHelper.setShowCoverAsPlayerBackground(value),
         );
       },
     );

--- a/lib/components/LayoutSettingsScreen/show_cover_on_player_background_selector.dart
+++ b/lib/components/LayoutSettingsScreen/show_cover_on_player_background_selector.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:hive/hive.dart';
+
+import '../../models/finamp_models.dart';
+import '../../services/finamp_settings_helper.dart';
+
+class ShowCoverOnPlayerBackgroundSelector extends StatelessWidget {
+  const ShowCoverOnPlayerBackgroundSelector({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<Box<FinampSettings>>(
+      valueListenable: FinampSettingsHelper.finampSettingsListener,
+      builder: (_, box, __) {
+        return SwitchListTile(
+          title: const Text("Show Blurred Cover as Player Background"),
+          subtitle: const Text(
+              "Whether or not to use blurred cover art as background on player screen."),
+          value: FinampSettingsHelper.finampSettings.showCoverPlayerBackground,
+          onChanged: (value) =>
+              FinampSettingsHelper.setShowAlbumArtPlayerBackground(value),
+        );
+      },
+    );
+  }
+}

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -66,7 +66,7 @@ class FinampSettings {
     this.showTextOnGridView = _showTextOnGridView,
     this.sleepTimerSeconds = _sleepTimerSeconds,
     required this.downloadLocationsMap,
-    this.showCoverPlayerBackground = false,
+    this.showCoverAsPlayerBackground = false,
   });
 
   @HiveField(0)
@@ -156,7 +156,7 @@ class FinampSettings {
 
   /// Whether or not to use blurred cover art as background on player screen.
   @HiveField(16)
-  bool showCoverPlayerBackground;
+  bool showCoverAsPlayerBackground;
 }
 
 /// Custom storage locations for storing music.

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -129,6 +129,10 @@ class FinampSettings {
   @HiveField(15, defaultValue: {})
   Map<String, DownloadLocation> downloadLocationsMap;
 
+  /// Whether or not to use blurred cover art as background on player screen.
+  @HiveField(16, defaultValue: _showCoverAsPlayerBackground)
+  bool showCoverAsPlayerBackground = _showCoverAsPlayerBackground;
+
   static Future<FinampSettings> create() async {
     final internalSongDir = await getInternalSongDir();
     final downloadLocation = DownloadLocation.create(
@@ -154,10 +158,6 @@ class FinampSettings {
   /// technically throw a StateError, but that should never happen™.
   DownloadLocation get internalSongDir =>
       downloadLocationsMap.values.firstWhere((element) => !element.deletable);
-
-  /// Whether or not to use blurred cover art as background on player screen.
-  @HiveField(16)
-  bool showCoverAsPlayerBackground = _showCoverAsPlayerBackground;
 }
 
 /// Custom storage locations for storing music.

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -41,6 +41,7 @@ const _contentGridViewCrossAxisCountPortrait = 2;
 const _contentGridViewCrossAxisCountLandscape = 3;
 const _showTextOnGridView = true;
 const _sleepTimerSeconds = 1800; // 30 Minutes
+const _showCoverAsPlayerBackground = true;
 
 @HiveType(typeId: 28)
 class FinampSettings {
@@ -66,7 +67,7 @@ class FinampSettings {
     this.showTextOnGridView = _showTextOnGridView,
     this.sleepTimerSeconds = _sleepTimerSeconds,
     required this.downloadLocationsMap,
-    this.showCoverAsPlayerBackground = false,
+    this.showCoverAsPlayerBackground = _showCoverAsPlayerBackground,
   });
 
   @HiveField(0)
@@ -156,7 +157,7 @@ class FinampSettings {
 
   /// Whether or not to use blurred cover art as background on player screen.
   @HiveField(16)
-  bool showCoverAsPlayerBackground;
+  bool showCoverAsPlayerBackground = _showCoverAsPlayerBackground;
 }
 
 /// Custom storage locations for storing music.

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -66,6 +66,7 @@ class FinampSettings {
     this.showTextOnGridView = _showTextOnGridView,
     this.sleepTimerSeconds = _sleepTimerSeconds,
     required this.downloadLocationsMap,
+    this.showCoverPlayerBackground = false,
   });
 
   @HiveField(0)
@@ -152,6 +153,10 @@ class FinampSettings {
   /// technically throw a StateError, but that should never happen™.
   DownloadLocation get internalSongDir =>
       downloadLocationsMap.values.firstWhere((element) => !element.deletable);
+
+  /// Whether or not to use blurred cover art as background on player screen.
+  @HiveField(16)
+  bool showCoverPlayerBackground;
 }
 
 /// Custom storage locations for storing music.

--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -88,7 +88,8 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       downloadLocationsMap: fields[15] == null
           ? {}
           : (fields[15] as Map).cast<String, DownloadLocation>(),
-      showCoverAsPlayerBackground: fields[16] as bool,
+      showCoverAsPlayerBackground:
+          fields[16] == null ? true : fields[16] as bool,
     );
   }
 

--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -88,14 +88,13 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       downloadLocationsMap: fields[15] == null
           ? {}
           : (fields[15] as Map).cast<String, DownloadLocation>(),
-      showCoverAsPlayerBackground: fields[16] as bool,
     );
   }
 
   @override
   void write(BinaryWriter writer, FinampSettings obj) {
     writer
-      ..writeByte(17)
+      ..writeByte(16)
       ..writeByte(0)
       ..write(obj.isOffline)
       ..writeByte(1)
@@ -127,9 +126,7 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       ..writeByte(14)
       ..write(obj.sleepTimerSeconds)
       ..writeByte(15)
-      ..write(obj.downloadLocationsMap)
-      ..writeByte(16)
-      ..write(obj.showCoverAsPlayerBackground);
+      ..write(obj.downloadLocationsMap);
   }
 
   @override

--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -88,13 +88,14 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       downloadLocationsMap: fields[15] == null
           ? {}
           : (fields[15] as Map).cast<String, DownloadLocation>(),
+      showCoverAsPlayerBackground: fields[16] as bool,
     );
   }
 
   @override
   void write(BinaryWriter writer, FinampSettings obj) {
     writer
-      ..writeByte(16)
+      ..writeByte(17)
       ..writeByte(0)
       ..write(obj.isOffline)
       ..writeByte(1)
@@ -126,7 +127,9 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       ..writeByte(14)
       ..write(obj.sleepTimerSeconds)
       ..writeByte(15)
-      ..write(obj.downloadLocationsMap);
+      ..write(obj.downloadLocationsMap)
+      ..writeByte(16)
+      ..write(obj.showCoverAsPlayerBackground);
   }
 
   @override

--- a/lib/screens/layout_settings_screen.dart
+++ b/lib/screens/layout_settings_screen.dart
@@ -5,7 +5,7 @@ import 'tabs_settings_screen.dart';
 import '../components/LayoutSettingsScreen/content_grid_view_cross_axis_count_list_tile.dart';
 import '../components/LayoutSettingsScreen/content_view_type_dropdown_list_tile.dart';
 import '../components/LayoutSettingsScreen/show_text_on_grid_view_selector.dart';
-import 'package:finamp/components/LayoutSettingsScreen/show_cover_on_player_background_selector.dart';
+import '../components/LayoutSettingsScreen/show_cover_as_player_background_selector.dart';
 
 class LayoutSettingsScreen extends StatelessWidget {
   const LayoutSettingsScreen({Key? key}) : super(key: key);
@@ -24,7 +24,7 @@ class LayoutSettingsScreen extends StatelessWidget {
           for (final type in ContentGridViewCrossAxisCountType.values)
             ContentGridViewCrossAxisCountListTile(type: type),
           const ShowTextOnGridViewSelector(),
-          const ShowCoverOnPlayerBackgroundSelector(),
+          const ShowCoverAsPlayerBackgroundSelector(),
           const ThemeSelector(),
           const Divider(),
           ListTile(

--- a/lib/screens/layout_settings_screen.dart
+++ b/lib/screens/layout_settings_screen.dart
@@ -5,6 +5,7 @@ import 'tabs_settings_screen.dart';
 import '../components/LayoutSettingsScreen/content_grid_view_cross_axis_count_list_tile.dart';
 import '../components/LayoutSettingsScreen/content_view_type_dropdown_list_tile.dart';
 import '../components/LayoutSettingsScreen/show_text_on_grid_view_selector.dart';
+import 'package:finamp/components/LayoutSettingsScreen/show_cover_on_player_background_selector.dart';
 
 class LayoutSettingsScreen extends StatelessWidget {
   const LayoutSettingsScreen({Key? key}) : super(key: key);
@@ -23,6 +24,7 @@ class LayoutSettingsScreen extends StatelessWidget {
           for (final type in ContentGridViewCrossAxisCountType.values)
             ContentGridViewCrossAxisCountListTile(type: type),
           const ShowTextOnGridViewSelector(),
+          const ShowCoverOnPlayerBackgroundSelector(),
           const ThemeSelector(),
           const Divider(),
           ListTile(

--- a/lib/screens/player_screen.dart
+++ b/lib/screens/player_screen.dart
@@ -45,14 +45,7 @@ class PlayerScreen extends StatelessWidget {
         body: Stack(
           children: [
             if (FinampSettingsHelper.finampSettings.showCoverAsPlayerBackground)
-              ColorFiltered(
-                colorFilter: ColorFilter.mode(
-                    Theme.of(context).brightness == Brightness.dark
-                        ? Colors.black.withOpacity(0.35)
-                        : Colors.white.withOpacity(0.75),
-                    BlendMode.srcOver),
-                child: const _PlayerScreenBlurHash(),
-              ),
+              const _PlayerScreenBlurHash(),
             SafeArea(
               child: Center(
                 child: Column(
@@ -152,9 +145,16 @@ class _PlayerScreenBlurHash extends StatelessWidget {
             final blurHash = item.imageBlurHashes?.primary?.values.first;
 
             if (blurHash != null) {
-              return BlurHash(
-                hash: blurHash,
-                imageFit: BoxFit.cover,
+              return ColorFiltered(
+                colorFilter: ColorFilter.mode(
+                    Theme.of(context).brightness == Brightness.dark
+                        ? Colors.black.withOpacity(0.35)
+                        : Colors.white.withOpacity(0.75),
+                    BlendMode.srcOver),
+                child: BlurHash(
+                  hash: blurHash,
+                  imageFit: BoxFit.cover,
+                ),
               );
             }
           }

--- a/lib/screens/player_screen.dart
+++ b/lib/screens/player_screen.dart
@@ -2,8 +2,10 @@ import 'package:audio_service/audio_service.dart';
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 import 'package:simple_gesture_detector/simple_gesture_detector.dart';
+import 'dart:ui';
 
 import '../components/PlayerScreen/favourite_button.dart';
+import '../services/finamp_settings_helper.dart';
 import '../services/music_player_background_task.dart';
 import '../models/jellyfin_models.dart';
 import '../components/album_image.dart';
@@ -39,48 +41,73 @@ class PlayerScreen extends StatelessWidget {
         ),
         // Required for sleep timer input
         resizeToAvoidBottomInset: false,
-        body: SafeArea(
-          child: Center(
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-              children: [
-                const Expanded(
-                  child: _PlayerScreenAlbumImage(),
+        body: Stack(
+          children: [
+            if (FinampSettingsHelper.finampSettings.showCoverPlayerBackground)
+            ImageFiltered(
+              imageFilter: ImageFilter.blur(
+                  sigmaX: 100.0,
+                  sigmaY: 100.0,
+                  tileMode: TileMode.mirror
+              ),
+              child: ImageFiltered(
+                imageFilter: ColorFilter.mode(
+                    Theme.of(context).brightness == Brightness.dark
+                    ? Colors.black.withOpacity(0.35)
+                    : Colors.white.withOpacity(0.75),
+                    BlendMode.srcOver
                 ),
-                Expanded(
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 16),
-                    child: Column(
-                      mainAxisSize: MainAxisSize.max,
-                      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                      children: [
-                        const SongName(),
-                        const ProgressSlider(),
-                        const PlayerButtons(),
-                        Stack(
-                          alignment: Alignment.center,
-                          children: const [
-                            Align(
-                              alignment: Alignment.centerLeft,
-                              child: PlaybackMode(),
-                            ),
-                            Align(
+                child: SizedBox(
+                  width: MediaQuery.of(context).size.width,
+                  height: MediaQuery.of(context).size.height,
+                  child: const _PlayerScreenAlbumImage(),
+                )
+              )
+            ),
+            SafeArea(
+              child: Center(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                  children: [
+                    const Expanded(
+                      child: _PlayerScreenAlbumImage(),
+                    ),
+                    Expanded(
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 16),
+                        child: Column(
+                          mainAxisSize: MainAxisSize.max,
+                          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                          children: [
+                            const SongName(),
+                            const ProgressSlider(),
+                            const PlayerButtons(),
+                            Stack(
                               alignment: Alignment.center,
-                              child: FavoriteButton(),
-                            ),
-                            Align(
-                              alignment: Alignment.centerRight,
-                              child: QueueButton(),
+                              children: const [
+                                Align(
+                                  alignment: Alignment.centerLeft,
+                                  child: PlaybackMode(),
+                                ),
+                                Align(
+                                  alignment: Alignment.center,
+                                  child: FavoriteButton(),
+                                ),
+                                Align(
+                                  alignment: Alignment.centerRight,
+                                  child: QueueButton(),
+                                )
+                              ],
                             )
                           ],
-                        )
-                      ],
-                    ),
-                  ),
-                )
-              ],
+                        ),
+                      ),
+                    )
+                  ],
+                ),
+              ),
             ),
-          ),
+          ]
         ),
       ),
     );

--- a/lib/screens/player_screen.dart
+++ b/lib/screens/player_screen.dart
@@ -139,6 +139,7 @@ class _PlayerScreenBlurHash extends StatelessWidget {
     return StreamBuilder<MediaItem?>(
         stream: audioHandler.mediaItem,
         builder: (context, snapshot) {
+          Widget? dynWidget;
           if (snapshot.hasData) {
             final item =
                 BaseItemDto.fromJson(snapshot.data!.extras!["itemJson"]);
@@ -146,12 +147,13 @@ class _PlayerScreenBlurHash extends StatelessWidget {
             final blurHash = item.imageBlurHashes?.primary?.values.first;
 
             if (blurHash != null) {
-              return ColorFiltered(
+              dynWidget = ColorFiltered(
                 colorFilter: ColorFilter.mode(
                     Theme.of(context).brightness == Brightness.dark
                         ? Colors.black.withOpacity(0.35)
                         : Colors.white.withOpacity(0.75),
                     BlendMode.srcOver),
+                key: ValueKey<String>(blurHash),
                 child: BlurHash(
                   hash: blurHash,
                   imageFit: BoxFit.cover,
@@ -160,7 +162,12 @@ class _PlayerScreenBlurHash extends StatelessWidget {
             }
           }
 
-          return const SizedBox.shrink();
+          dynWidget ??= const SizedBox.shrink();
+
+          return AnimatedSwitcher(
+            duration: const Duration(milliseconds: 300),
+            child: dynWidget,
+          );
         });
   }
 }

--- a/lib/screens/player_screen.dart
+++ b/lib/screens/player_screen.dart
@@ -127,7 +127,8 @@ class _PlayerScreenAlbumImage extends StatelessWidget {
   }
 }
 
-/// This widget is just an AlbumImage in a StreamBuilder to get the song id.
+/// Same as [_PlayerScreenAlbumImage], but with a BlurHash instead. We also
+/// filter the BlurHash so that it works as a background image.
 class _PlayerScreenBlurHash extends StatelessWidget {
   const _PlayerScreenBlurHash({Key? key}) : super(key: key);
 

--- a/lib/screens/player_screen.dart
+++ b/lib/screens/player_screen.dart
@@ -43,7 +43,7 @@ class PlayerScreen extends StatelessWidget {
         resizeToAvoidBottomInset: false,
         body: Stack(
           children: [
-            if (FinampSettingsHelper.finampSettings.showCoverPlayerBackground)
+            if (FinampSettingsHelper.finampSettings.showCoverAsPlayerBackground)
             ImageFiltered(
               imageFilter: ImageFilter.blur(
                   sigmaX: 100.0,

--- a/lib/services/finamp_settings_helper.dart
+++ b/lib/services/finamp_settings_helper.dart
@@ -158,4 +158,11 @@ class FinampSettingsHelper {
     Hive.box<FinampSettings>("FinampSettings")
         .put("FinampSettings", newFinampSettings);
   }
+
+  static void setShowAlbumArtPlayerBackground(bool showCoverPlayerBackground) {
+    FinampSettings finampSettingsTemp = finampSettings;
+    finampSettingsTemp.showCoverPlayerBackground = showCoverPlayerBackground;
+    Hive.box<FinampSettings>("FinampSettings")
+        .put("FinampSettings", finampSettingsTemp);
+  }
 }

--- a/lib/services/finamp_settings_helper.dart
+++ b/lib/services/finamp_settings_helper.dart
@@ -159,9 +159,9 @@ class FinampSettingsHelper {
         .put("FinampSettings", newFinampSettings);
   }
 
-  static void setShowAlbumArtPlayerBackground(bool showCoverPlayerBackground) {
+  static void setShowCoverAsPlayerBackground(bool showCoverAsPlayerBackground) {
     FinampSettings finampSettingsTemp = finampSettings;
-    finampSettingsTemp.showCoverPlayerBackground = showCoverPlayerBackground;
+    finampSettingsTemp.showCoverAsPlayerBackground = showCoverAsPlayerBackground;
     Hive.box<FinampSettings>("FinampSettings")
         .put("FinampSettings", finampSettingsTemp);
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -57,6 +57,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.4
   path: ^1.8.1
+  flutter_blurhash: ^0.7.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
A bit of eye candy, disabled by default. 2nd row has dark mode, 3rd row has light mode.

Bright cover|Dark cover|Colorful cover
---|---|---
![Screenshot_20220714-011145_Finamp](https://user-images.githubusercontent.com/46846000/178852865-2824e520-3010-4ccd-8d38-b569dd35ab3d.png)|![Screenshot_20220714-011215_Finamp](https://user-images.githubusercontent.com/46846000/178852878-ba796c63-8ef2-4fe5-8f11-bc94d5e869c5.png)|![Screenshot_20220714-011307_Finamp](https://user-images.githubusercontent.com/46846000/178852916-116e0574-0e14-46ef-a554-92994b49a9a3.png)
![Screenshot_20220714-011108_Finamp](https://user-images.githubusercontent.com/46846000/178852850-5b6db508-aba5-4cfe-94b3-233f1244408f.png)|![Screenshot_20220714-011229_Finamp](https://user-images.githubusercontent.com/46846000/178852893-dab37e28-580a-4ee6-86b1-d0fc34788f6c.png)|![Screenshot_20220714-011254_Finamp](https://user-images.githubusercontent.com/46846000/178852932-d8835d98-ff1b-4e42-b757-de80a00fc155.png)

Some issues:
- occasional low contrast, especially with the gray buffer status slider
- enabling this feature isn't saved to disk, tried to follow https://github.com/hivedb/docs/blob/master/custom-objects/generate_adapter.md but got the white screen about broken config
- bottom bar would probably look better transparent, which additionally would fix contrasting with light theme throughout app