### PR TITLE
Show song artists on album screen (and more)

### DIFF
--- a/lib/components/AlbumScreen/album_screen_content.dart
+++ b/lib/components/AlbumScreen/album_screen_content.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_sticky_header/flutter_sticky_header.dart';
 
@@ -73,13 +74,13 @@ class AlbumScreenContent extends StatelessWidget {
                 sliver: _SongsSliverList(
                     childrenForList: childrenOfThisDisc,
                     childrenForQueue: children,
-                    parentId: parent.id),
+                    parent: parent),
               )
           else
             _SongsSliverList(
                 childrenForList: children,
                 childrenForQueue: children,
-                parentId: parent.id),
+                parent: parent),
         ],
       ),
     );
@@ -91,12 +92,12 @@ class _SongsSliverList extends StatelessWidget {
     Key? key,
     required this.childrenForList,
     required this.childrenForQueue,
-    required this.parentId,
+    required this.parent,
   }) : super(key: key);
 
   final List<BaseItemDto> childrenForList;
   final List<BaseItemDto> childrenForQueue;
-  final String? parentId;
+  final BaseItemDto parent;
 
   @override
   Widget build(BuildContext context) {
@@ -112,7 +113,16 @@ class _SongsSliverList extends StatelessWidget {
           item: item,
           children: childrenForQueue,
           index: index + indexOffset,
-          parentId: parentId,
+          parentId: parent.id,
+          // show artists except for this one scenario
+          showArtists: !(
+            // we're on album screen (todo: isn't this whole widget used for playlists too?)
+            true
+            // "hide song artists if they're the same as album artists" == true
+            && true
+            // song artists == album artists
+            && listEquals(parent.albumArtists?.map((e) => e.name).toList(), item.artists)
+          )
         );
       }, childCount: childrenForList.length),
     );

--- a/lib/components/AlbumScreen/album_screen_content.dart
+++ b/lib/components/AlbumScreen/album_screen_content.dart
@@ -4,6 +4,7 @@ import 'package:flutter_sticky_header/flutter_sticky_header.dart';
 
 import '../../models/jellyfin_models.dart';
 import '../../services/finamp_settings_helper.dart';
+import '../../components/favourite_button.dart';
 import 'album_screen_content_flexible_space_bar.dart';
 import 'download_button.dart';
 import 'song_list_tile.dart';
@@ -55,6 +56,7 @@ class AlbumScreenContent extends StatelessWidget {
               if (parent.type == "Playlist" &&
                   !FinampSettingsHelper.finampSettings.isOffline)
                 PlaylistNameEditButton(playlist: parent),
+              FavoriteButton(item: parent),
               DownloadButton(parent: parent, items: children)
             ],
           ),

--- a/lib/components/AlbumScreen/album_screen_content.dart
+++ b/lib/components/AlbumScreen/album_screen_content.dart
@@ -116,12 +116,14 @@ class _SongsSliverList extends StatelessWidget {
           parentId: parent.id,
           // show artists except for this one scenario
           showArtists: !(
-            // we're on album screen (todo: isn't this whole widget used for playlists too?)
-            true
+            // we're on album screen
+            parent.type == "MusicAlbum"
             // "hide song artists if they're the same as album artists" == true
-            && true
+            && FinampSettingsHelper.finampSettings
+                .hideSongArtistsIfSameAsAlbumArtists
             // song artists == album artists
-            && setEquals(parent.albumArtists?.map((e) => e.name).toSet(), item.artists?.toSet())
+            && setEquals(parent.albumArtists?.map((e) => e.name).toSet(),
+                item.artists?.toSet())
           )
         );
       }, childCount: childrenForList.length),

--- a/lib/components/AlbumScreen/album_screen_content.dart
+++ b/lib/components/AlbumScreen/album_screen_content.dart
@@ -121,7 +121,7 @@ class _SongsSliverList extends StatelessWidget {
             // "hide song artists if they're the same as album artists" == true
             && true
             // song artists == album artists
-            && listEquals(parent.albumArtists?.map((e) => e.name).toList(), item.artists)
+            && setEquals(parent.albumArtists?.map((e) => e.name).toSet(), item.artists?.toSet())
           )
         );
       }, childCount: childrenForList.length),

--- a/lib/components/AlbumScreen/song_list_tile.dart
+++ b/lib/components/AlbumScreen/song_list_tile.dart
@@ -11,6 +11,7 @@ import '../../services/process_artist.dart';
 import '../../services/music_player_background_task.dart';
 import '../../screens/album_screen.dart';
 import '../../screens/add_to_playlist_screen.dart';
+import '../PlayerScreen/favourite_button.dart'; // todo: move it to components
 import '../album_image.dart';
 import '../print_duration.dart';
 import '../error_snackbar.dart';
@@ -42,6 +43,7 @@ class SongListTile extends StatefulWidget {
     this.index,
     this.parentId,
     this.isSong = false,
+    this.showArtists = true,
   }) : super(key: key);
 
   final BaseItemDto item;
@@ -49,6 +51,7 @@ class SongListTile extends StatefulWidget {
   final int? index;
   final bool isSong;
   final String? parentId;
+  final bool showArtists;
 
   @override
   State<SongListTile> createState() => _SongListTileState();
@@ -100,16 +103,38 @@ class _SongListTileState extends State<SongListTile> {
           );
         },
       ),
-      subtitle: Text(widget.isSong
-          ? processArtist(
-              mutableItem.artists?.join(", ") ?? mutableItem.albumArtist)
-          : printDuration(
-              Duration(
-                  microseconds: (mutableItem.runTimeTicks == null
-                      ? 0
-                      : mutableItem.runTimeTicks! ~/ 10)),
-            )),
-      trailing: DownloadedIndicator(item: mutableItem),
+      subtitle:
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                DownloadedIndicator(item: mutableItem),
+                RichText(
+                  text: TextSpan(
+                    text: printDuration(
+                        Duration(
+                            microseconds: (mutableItem.runTimeTicks == null
+                                ? 0
+                                : mutableItem.runTimeTicks! ~/ 10)
+                        )
+                    ),
+                    style: TextStyle(color: Theme.of(context).textTheme.bodyText2?.color?.withOpacity(0.8)),
+                    children: [
+                      if (widget.showArtists) TextSpan(
+                        text: " · ${processArtist(
+                          mutableItem.artists?.join(", ")
+                          ?? mutableItem.albumArtist // todo: artists can go past favorite button
+                        )}",
+                        style: TextStyle(color: Theme.of(context).disabledColor),
+                      )
+                    ]
+                  ),
+                )
+              ],
+            ),
+      trailing: FavoriteButton(
+        item: mutableItem,
+        onlyIfFav: true,
+      ),
       onTap: () {
         _audioServiceHelper.replaceQueueWithItem(
           itemList: widget.children ?? [mutableItem],

--- a/lib/components/AlbumScreen/song_list_tile.dart
+++ b/lib/components/AlbumScreen/song_list_tile.dart
@@ -11,7 +11,7 @@ import '../../services/process_artist.dart';
 import '../../services/music_player_background_task.dart';
 import '../../screens/album_screen.dart';
 import '../../screens/add_to_playlist_screen.dart';
-import '../PlayerScreen/favourite_button.dart'; // todo: move it to components
+import '../favourite_button.dart';
 import '../album_image.dart';
 import '../print_duration.dart';
 import '../error_snackbar.dart';

--- a/lib/components/AlbumScreen/song_list_tile.dart
+++ b/lib/components/AlbumScreen/song_list_tile.dart
@@ -103,34 +103,42 @@ class _SongListTileState extends State<SongListTile> {
           );
         },
       ),
-      subtitle:
-            Row(
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                DownloadedIndicator(item: mutableItem),
-                RichText(
-                  text: TextSpan(
+      subtitle: Row(
+        children: [
+          Transform.translate(
+              offset: const Offset(-3, 0),
+              child: DownloadedIndicator(item: mutableItem)
+          ),
+          Expanded(
+            child: RichText(
+              text: TextSpan(
+                children: [
+                  TextSpan(
                     text: printDuration(
-                        Duration(
-                            microseconds: (mutableItem.runTimeTicks == null
-                                ? 0
-                                : mutableItem.runTimeTicks! ~/ 10)
-                        )
-                    ),
-                    style: TextStyle(color: Theme.of(context).textTheme.bodyText2?.color?.withOpacity(0.8)),
-                    children: [
-                      if (widget.showArtists) TextSpan(
-                        text: " · ${processArtist(
-                          mutableItem.artists?.join(", ")
-                          ?? mutableItem.albumArtist // todo: artists can go past favorite button
-                        )}",
-                        style: TextStyle(color: Theme.of(context).disabledColor),
+                      Duration(
+                        microseconds: (mutableItem.runTimeTicks == null
+                        ? 0
+                        : mutableItem.runTimeTicks! ~/ 10)
                       )
-                    ]
+                    ),
+                    style: TextStyle(color:
+                      Theme.of(context).textTheme
+                        .bodyText2?.color?.withOpacity(0.7)),
                   ),
-                )
-              ],
+                  if (widget.showArtists) TextSpan(
+                    text: " · ${processArtist(
+                      mutableItem.artists?.join(", ")
+                      ?? mutableItem.albumArtist
+                    )}",
+                    style: TextStyle(color: Theme.of(context).disabledColor),
+                  )
+                ],
+              ),
+              overflow: TextOverflow.ellipsis,
             ),
+          ),
+        ],
+      ),
       trailing: FavoriteButton(
         item: mutableItem,
         onlyIfFav: true,

--- a/lib/components/AlbumScreen/song_list_tile.dart
+++ b/lib/components/AlbumScreen/song_list_tile.dart
@@ -226,14 +226,14 @@ class _SongListTileState extends State<SongListTile> {
                 ? const PopupMenuItem<SongListTileMenuItems>(
                     value: SongListTileMenuItems.removeFavourite,
                     child: ListTile(
-                      leading: Icon(Icons.star_border),
+                      leading: Icon(Icons.favorite_border),
                       title: Text("Remove Favourite"),
                     ),
                   )
                 : const PopupMenuItem<SongListTileMenuItems>(
                     value: SongListTileMenuItems.addFavourite,
                     child: ListTile(
-                      leading: Icon(Icons.star),
+                      leading: Icon(Icons.favorite),
                       title: Text("Add Favourite"),
                     ),
                   ),

--- a/lib/components/LayoutSettingsScreen/hide_song_artists_if_same_as_album_artists_selector.dart
+++ b/lib/components/LayoutSettingsScreen/hide_song_artists_if_same_as_album_artists_selector.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:hive/hive.dart';
+
+import '../../models/finamp_models.dart';
+import '../../services/finamp_settings_helper.dart';
+
+class HideSongArtistsIfSameAsAlbumArtistsSelector extends StatelessWidget {
+  const HideSongArtistsIfSameAsAlbumArtistsSelector({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<Box<FinampSettings>>(
+      valueListenable: FinampSettingsHelper.finampSettingsListener,
+      builder: (_, box, __) {
+        return SwitchListTile(
+          title: const Text("Hide Song Artists if same as Album Artists"),
+          subtitle: const Text(
+              "Whether or not to hide song artists on album screen if they don't differ from album artists."),
+          value: FinampSettingsHelper.finampSettings.hideSongArtistsIfSameAsAlbumArtists,
+          onChanged: (value) =>
+              FinampSettingsHelper.setHideSongArtistsIfSameAsAlbumArtists(value),
+        );
+      },
+    );
+  }
+}

--- a/lib/components/MusicScreen/album_item.dart
+++ b/lib/components/MusicScreen/album_item.dart
@@ -113,14 +113,14 @@ class _AlbumItemState extends State<AlbumItem> {
                   ? const PopupMenuItem<_AlbumListTileMenuItems>(
                       value: _AlbumListTileMenuItems.removeFavourite,
                       child: ListTile(
-                        leading: Icon(Icons.star_border),
+                        leading: Icon(Icons.favorite_border),
                         title: Text("Remove Favourite"),
                       ),
                     )
                   : const PopupMenuItem<_AlbumListTileMenuItems>(
                       value: _AlbumListTileMenuItems.addFavourite,
                       child: ListTile(
-                        leading: Icon(Icons.star),
+                        leading: Icon(Icons.favorite),
                         title: Text("Add Favourite"),
                       ),
                     ),

--- a/lib/components/MusicScreen/artist_item_list_tile.dart
+++ b/lib/components/MusicScreen/artist_item_list_tile.dart
@@ -75,14 +75,14 @@ class _ArtistListTileState extends State<ArtistListTile> {
                   ? const PopupMenuItem<ArtistListTileMenuItems>(
                       value: ArtistListTileMenuItems.removeFromFavourite,
                       child: ListTile(
-                        leading: Icon(Icons.star_border),
+                        leading: Icon(Icons.favorite_border),
                         title: Text("Remove Favourite"),
                       ),
                     )
                   : const PopupMenuItem<ArtistListTileMenuItems>(
                       value: ArtistListTileMenuItems.addToFavourite,
                       child: ListTile(
-                        leading: Icon(Icons.star),
+                        leading: Icon(Icons.favorite),
                         title: Text("Add Favourite"),
                       ),
                     ),

--- a/lib/components/favourite_button.dart
+++ b/lib/components/favourite_button.dart
@@ -49,7 +49,7 @@ class _FavoriteButtonState extends State<FavoriteButton> {
       return IconButton(
         icon: Icon(
           isFav ? Icons.favorite : Icons.favorite_outline,
-          color: isFav ? Colors.red : Colors.white, // todo: default color from theme
+          color: isFav ? Colors.red : null,
           size: 24.0,
         ),
         onPressed: () async {

--- a/lib/components/favourite_button.dart
+++ b/lib/components/favourite_button.dart
@@ -12,7 +12,7 @@ class FavoriteButton extends StatefulWidget {
     this.onlyIfFav = false
   }) : super(key: key);
 
-  final BaseItemDto item;
+  final BaseItemDto? item;
   final bool onlyIfFav;
 
   @override
@@ -34,8 +34,11 @@ class _FavoriteButtonState extends State<FavoriteButton> {
   Widget build(BuildContext context) {
     final audioHandler = GetIt.instance<MusicPlayerBackgroundTask>();
     final jellyfinApiHelper = GetIt.instance<JellyfinApiHelper>();
-    bool isFav = widget.item.userData!.isFavorite;
+    if (widget.item == null) {
+      return const SizedBox.shrink();
+    }
 
+    bool isFav = widget.item!.userData!.isFavorite;
     if (widget.onlyIfFav) {
       return Icon(
         isFav ? Icons.favorite : null,
@@ -54,15 +57,15 @@ class _FavoriteButtonState extends State<FavoriteButton> {
             UserItemDataDto? newUserData;
             if (isFav) {
               newUserData =
-                await jellyfinApiHelper.removeFavourite(widget.item.id);
+                await jellyfinApiHelper.removeFavourite(widget.item!.id);
             } else {
               newUserData =
-                await jellyfinApiHelper.addFavourite(widget.item.id);
+                await jellyfinApiHelper.addFavourite(widget.item!.id);
             }
             setState(() {
-              widget.item.userData = newUserData;
+              widget.item!.userData = newUserData;
               audioHandler.mediaItem.valueOrNull!.extras!['itemJson'] =
-                  widget.item.toJson();
+                  widget.item!.toJson();
             });
           } catch (e) {
             errorSnackbar(e, context);

--- a/lib/components/favourite_button.dart
+++ b/lib/components/favourite_button.dart
@@ -9,11 +9,13 @@ class FavoriteButton extends StatefulWidget {
   const FavoriteButton({
     Key? key,
     required this.item,
-    this.onlyIfFav = false
+    this.onlyIfFav = false,
+    this.inPlayer = false
   }) : super(key: key);
 
   final BaseItemDto? item;
   final bool onlyIfFav;
+  final bool inPlayer;
 
   @override
   State<FavoriteButton> createState() => _FavoriteButtonState();
@@ -64,8 +66,10 @@ class _FavoriteButtonState extends State<FavoriteButton> {
             }
             setState(() {
               widget.item!.userData = newUserData;
-              audioHandler.mediaItem.valueOrNull!.extras!['itemJson'] =
+              if (widget.inPlayer) {
+                audioHandler.mediaItem.valueOrNull!.extras!['itemJson'] =
                   widget.item!.toJson();
+              }
             });
           } catch (e) {
             errorSnackbar(e, context);

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -41,6 +41,7 @@ const _contentGridViewCrossAxisCountPortrait = 2;
 const _contentGridViewCrossAxisCountLandscape = 3;
 const _showTextOnGridView = true;
 const _sleepTimerSeconds = 1800; // 30 Minutes
+const _hideSongArtistsIfSameAsAlbumArtists = true;
 
 @HiveType(typeId: 28)
 class FinampSettings {
@@ -66,6 +67,8 @@ class FinampSettings {
     this.showTextOnGridView = _showTextOnGridView,
     this.sleepTimerSeconds = _sleepTimerSeconds,
     required this.downloadLocationsMap,
+    this.hideSongArtistsIfSameAsAlbumArtists =
+        _hideSongArtistsIfSameAsAlbumArtists,
   });
 
   @HiveField(0)
@@ -126,6 +129,9 @@ class FinampSettings {
 
   @HiveField(15, defaultValue: {})
   Map<String, DownloadLocation> downloadLocationsMap;
+
+  @HiveField(17, defaultValue: _hideSongArtistsIfSameAsAlbumArtists)
+  bool hideSongArtistsIfSameAsAlbumArtists = _hideSongArtistsIfSameAsAlbumArtists;
 
   static Future<FinampSettings> create() async {
     final internalSongDir = await getInternalSongDir();

--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -88,13 +88,15 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       downloadLocationsMap: fields[15] == null
           ? {}
           : (fields[15] as Map).cast<String, DownloadLocation>(),
+      hideSongArtistsIfSameAsAlbumArtists:
+          fields[17] == null ? true : fields[17] as bool,
     );
   }
 
   @override
   void write(BinaryWriter writer, FinampSettings obj) {
     writer
-      ..writeByte(16)
+      ..writeByte(17)
       ..writeByte(0)
       ..write(obj.isOffline)
       ..writeByte(1)
@@ -126,7 +128,9 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       ..writeByte(14)
       ..write(obj.sleepTimerSeconds)
       ..writeByte(15)
-      ..write(obj.downloadLocationsMap);
+      ..write(obj.downloadLocationsMap)
+      ..writeByte(17)
+      ..write(obj.hideSongArtistsIfSameAsAlbumArtists);
   }
 
   @override

--- a/lib/screens/artist_screen.dart
+++ b/lib/screens/artist_screen.dart
@@ -5,6 +5,7 @@ import '../models/finamp_models.dart';
 import '../components/ArtistScreen/artist_download_button.dart';
 import '../components/MusicScreen/music_screen_tab_view.dart';
 import '../components/now_playing_bar.dart';
+import '../components/favourite_button.dart';
 
 class ArtistScreen extends StatelessWidget {
   const ArtistScreen({
@@ -25,7 +26,10 @@ class ArtistScreen extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         title: Text(artist.name ?? "Unknown Name"),
-        actions: [ArtistDownloadButton(artist: artist)],
+        actions: [
+          FavoriteButton(item: artist),
+          ArtistDownloadButton(artist: artist)
+        ],
       ),
       body: MusicScreenTabView(
         tabContentType: TabContentType.albums,

--- a/lib/screens/artist_screen.dart
+++ b/lib/screens/artist_screen.dart
@@ -27,7 +27,8 @@ class ArtistScreen extends StatelessWidget {
       appBar: AppBar(
         title: Text(artist.name ?? "Unknown Name"),
         actions: [
-          FavoriteButton(item: artist),
+          // this screen is also used for genres, which can't be favorited
+          if (artist.type != "MusicGenre") FavoriteButton(item: artist),
           ArtistDownloadButton(artist: artist)
         ],
       ),

--- a/lib/screens/layout_settings_screen.dart
+++ b/lib/screens/layout_settings_screen.dart
@@ -5,6 +5,7 @@ import 'tabs_settings_screen.dart';
 import '../components/LayoutSettingsScreen/content_grid_view_cross_axis_count_list_tile.dart';
 import '../components/LayoutSettingsScreen/content_view_type_dropdown_list_tile.dart';
 import '../components/LayoutSettingsScreen/show_text_on_grid_view_selector.dart';
+import '../components/LayoutSettingsScreen/hide_song_artists_if_same_as_album_artists_selector.dart';
 
 class LayoutSettingsScreen extends StatelessWidget {
   const LayoutSettingsScreen({Key? key}) : super(key: key);
@@ -23,6 +24,7 @@ class LayoutSettingsScreen extends StatelessWidget {
           for (final type in ContentGridViewCrossAxisCountType.values)
             ContentGridViewCrossAxisCountListTile(type: type),
           const ShowTextOnGridViewSelector(),
+          const HideSongArtistsIfSameAsAlbumArtistsSelector(),
           const ThemeSelector(),
           const Divider(),
           ListTile(

--- a/lib/screens/music_screen.dart
+++ b/lib/screens/music_screen.dart
@@ -231,8 +231,8 @@ class _MusicScreenState extends State<MusicScreen>
                           const SortByMenuButton(),
                           IconButton(
                             icon: finampSettings.isFavourite
-                                ? const Icon(Icons.star)
-                                : const Icon(Icons.star_outline),
+                                ? const Icon(Icons.favorite)
+                                : const Icon(Icons.favorite_outline),
                             onPressed: finampSettings.isOffline
                                 ? null
                                 : () => FinampSettingsHelper.setIsFavourite(

--- a/lib/screens/player_screen.dart
+++ b/lib/screens/player_screen.dart
@@ -130,7 +130,8 @@ class _PlayerScreenFavoriteButton extends StatelessWidget {
       builder: (context, snapshot) {
         return FavoriteButton(item: snapshot.data?.extras?["itemJson"] == null
           ? null
-          : BaseItemDto.fromJson(snapshot.data!.extras!["itemJson"])
+          : BaseItemDto.fromJson(snapshot.data!.extras!["itemJson"]),
+          inPlayer: true,
         );
       }
     );

--- a/lib/screens/player_screen.dart
+++ b/lib/screens/player_screen.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 import 'package:simple_gesture_detector/simple_gesture_detector.dart';
 
-import '../components/PlayerScreen/favourite_button.dart';
+import '../components/favourite_button.dart';
 import '../services/music_player_background_task.dart';
 import '../models/jellyfin_models.dart';
 import '../components/album_image.dart';
@@ -64,11 +64,10 @@ class PlayerScreen extends StatelessWidget {
                               alignment: Alignment.centerLeft,
                               child: PlaybackMode(),
                             ),
-                            // todo: pass played item
-                            // Align(
-                            //   alignment: Alignment.center,
-                            //   child: FavoriteButton(),
-                            // ),
+                            Align(
+                              alignment: Alignment.center,
+                              child: _PlayerScreenFavoriteButton(),
+                            ),
                             Align(
                               alignment: Alignment.centerRight,
                               child: QueueButton(),
@@ -116,5 +115,24 @@ class _PlayerScreenAlbumImage extends StatelessWidget {
                   ),
           );
         });
+  }
+}
+
+class _PlayerScreenFavoriteButton extends StatelessWidget {
+  const _PlayerScreenFavoriteButton({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final audioHandler = GetIt.instance<MusicPlayerBackgroundTask>();
+
+    return StreamBuilder<MediaItem?>(
+      stream: audioHandler.mediaItem,
+      builder: (context, snapshot) {
+        return FavoriteButton(item: snapshot.data?.extras?["itemJson"] == null
+          ? null
+          : BaseItemDto.fromJson(snapshot.data!.extras!["itemJson"])
+        );
+      }
+    );
   }
 }

--- a/lib/screens/player_screen.dart
+++ b/lib/screens/player_screen.dart
@@ -64,10 +64,11 @@ class PlayerScreen extends StatelessWidget {
                               alignment: Alignment.centerLeft,
                               child: PlaybackMode(),
                             ),
-                            Align(
-                              alignment: Alignment.center,
-                              child: FavoriteButton(),
-                            ),
+                            // todo: pass played item
+                            // Align(
+                            //   alignment: Alignment.center,
+                            //   child: FavoriteButton(),
+                            // ),
                             Align(
                               alignment: Alignment.centerRight,
                               child: QueueButton(),

--- a/lib/services/finamp_settings_helper.dart
+++ b/lib/services/finamp_settings_helper.dart
@@ -158,4 +158,13 @@ class FinampSettingsHelper {
     Hive.box<FinampSettings>("FinampSettings")
         .put("FinampSettings", newFinampSettings);
   }
+
+  static void setHideSongArtistsIfSameAsAlbumArtists(
+      bool hideSongArtistsIfSameAsAlbumArtists) {
+    FinampSettings finampSettingsTemp = finampSettings;
+    finampSettingsTemp.hideSongArtistsIfSameAsAlbumArtists =
+        hideSongArtistsIfSameAsAlbumArtists;
+    Hive.box<FinampSettings>("FinampSettings")
+        .put("FinampSettings", finampSettingsTemp);
+  }
 }


### PR DESCRIPTION
Fixes #265. By default song artists are hidden if their set matches set of album's artists, but it's configurable (and persists across app restarts, thanks for hint in the other PR about that!).

As discussed in that issue, this PR also reorganizes SongListTile a bit and replaces stars in favorite buttons with hearts. I also added the now a bit more portable favorite button to artist, album and playlist screens.

Album screen|Settings
---|---
![Screenshot_20220723-031707_Finamp](https://user-images.githubusercontent.com/46846000/180584852-2ea78708-7965-409c-98e3-af60f25f2491.png)|![Screenshot_20220723-024024_Finamp](https://user-images.githubusercontent.com/46846000/180583733-ae18fb8e-32f5-4ec1-845d-cf4879e8ab04.png)

