### PR TITLE
Fix retrieval of Android ID

### DIFF
--- a/lib/services/jellyfin_api.dart
+++ b/lib/services/jellyfin_api.dart
@@ -1,5 +1,6 @@
 import 'dart:io' show Platform;
 
+import 'package:android_id/android_id.dart';
 import 'package:chopper/chopper.dart';
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:get_it/get_it.dart';
@@ -422,7 +423,8 @@ Future<String> getAuthHeader() async {
   if (Platform.isAndroid) {
     AndroidDeviceInfo androidDeviceInfo = await deviceInfo.androidInfo;
     authHeader = '${authHeader}Device="${androidDeviceInfo.model}", ';
-    authHeader = '${authHeader}DeviceId="${androidDeviceInfo.androidId}", ';
+    final androidId = await const AndroidId().getId();
+    authHeader = '${authHeader}DeviceId="$androidId", ';
   } else if (Platform.isIOS) {
     IosDeviceInfo iosDeviceInfo = await deviceInfo.iosInfo;
     authHeader = '${authHeader}Device="${iosDeviceInfo.name}", ';

--- a/lib/services/music_player_background_task.dart
+++ b/lib/services/music_player_background_task.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:android_id/android_id.dart';
 import 'package:audio_service/audio_service.dart';
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:finamp/services/downloads_helper.dart';
@@ -502,8 +503,7 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
     // 0.18), the value would be wrong if changed while a song was playing since
     // Hive is bad at multi-isolate stuff.
 
-    final androidDeviceInfo =
-        Platform.isAndroid ? await DeviceInfoPlugin().androidInfo : null;
+    final androidId = Platform.isAndroid ? await const AndroidId().getId() : null;
     final iosDeviceInfo =
         Platform.isIOS ? await DeviceInfoPlugin().iosInfo : null;
 
@@ -523,8 +523,7 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
       pathSegments: builtPath,
       queryParameters: {
         "UserId": _finampUserHelper.currentUser!.id,
-        "DeviceId":
-            androidDeviceInfo?.androidId ?? iosDeviceInfo!.identifierForVendor,
+        "DeviceId": androidId ?? iosDeviceInfo!.identifierForVendor,
         // TODO: Do platform checks for this
         "Container":
             "opus,webm|opus,mp3,aac,m4a|aac,m4a|alac,m4b|aac,flac,webma,webm|webma,wav,ogg",

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -60,6 +60,7 @@ dependencies:
   cupertino_icons: ^1.0.4
   path: ^1.8.1
   flutter_blurhash: ^0.7.0
+  android_id: ^0.0.5
   intl: ^0.17.0
 
 dev_dependencies:


### PR DESCRIPTION
With device_info_plus_platform_interface 2.6.0 (which is a nested dependency of device_info_plus), getting the Android ID is no longer possible. This functionality is now available through the plugin "android_id".