### PR TITLE
Fix pub get failure

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -15,7 +15,7 @@ packages:
     source: sdk
     version: "0.3.2"
   analyzer:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: analyzer
       sha256: b652861553cd3990d8ed361f7979dc6d7053a9ac8843fa73820ab68ce5410139
@@ -782,11 +782,10 @@ packages:
   isar_generator:
     dependency: "direct dev"
     description:
-      path: "packages/isar_generator"
-      ref: "70a5abd2b36d265a2eef0141f98f312a8710e60c"
-      resolved-ref: "70a5abd2b36d265a2eef0141f98f312a8710e60c"
-      url: "https://github.com/ndelanou/isar.git"
-    source: git
+      name: isar_generator
+      sha256: "76c121e1295a30423604f2f819bc255bc79f852f3bc8743a24017df6068ad133"
+      url: "https://pub.dev"
+    source: hosted
     version: "3.1.0+1"
   js:
     dependency: transitive

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -120,14 +120,13 @@ dev_dependencies:
   riverpod_generator: ^2.3.9
   custom_lint:
   riverpod_lint: ^2.3.7
-  # isar_generator requires analyzer <6.0.0 by default, but 6.x.0 doesn't have breaking changes
-  # Using fork of 3.1.0+1 with pubspec updated to analyzer: "^6.0.0"
-  isar_generator:
-    git:
-      url: https://github.com/ndelanou/isar.git
-      ref: 70a5abd2b36d265a2eef0141f98f312a8710e60c
-      path: packages/isar_generator
+  isar_generator: ^3.1.0+1
   msix: ^3.16.7
+
+dependency_overrides:
+  # isar_generator requires analyzer <6.0.0 by default, but 6.x.0 doesn't have breaking changes
+  # Overriding the package version allows us to use the latest version.
+  analyzer: ^6.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
Instead of loading isar_generator from a (now deleted) fork, we can also use a dependency override: isar/isar#1505