### PR TITLE
add opus and flac transcoding

### DIFF
--- a/lib/components/PlayerScreen/feature_chips.dart
+++ b/lib/components/PlayerScreen/feature_chips.dart
@@ -50,7 +50,7 @@ class FeatureState {
       !isDownloaded &&
       (currentTrack?.item.extras?["shouldTranscode"] as bool? ?? false);
   String get container =>
-      isTranscoding ? settings.transcodingSegmentContainer.codec
+      isTranscoding ? settings.transcodingStreamingFormat.codec
           : metadata?.mediaSourceInfo.container ?? "";
   int? get size => isTranscoding ? null : metadata?.mediaSourceInfo.size;
   MediaStream? get audioStream => isTranscoding
@@ -62,7 +62,7 @@ class FeatureState {
   // should have a valid mediaStream, so use that audio-only bitrate instead of the
   // whole-file bitrate.
   int? get bitrate => isTranscoding
-      ? (settings.transcodingSegmentContainer.codec == 'flac' ? null : settings.transcodeBitrate)
+      ? (settings.transcodingStreamingFormat.codec == 'flac' ? null : settings.transcodeBitrate)
       : audioStream?.bitRate ?? metadata?.mediaSourceInfo.bitrate;
   int? get sampleRate => audioStream?.sampleRate;
   int? get bitDepth => audioStream?.bitDepth;

--- a/lib/components/PlayerScreen/feature_chips.dart
+++ b/lib/components/PlayerScreen/feature_chips.dart
@@ -50,7 +50,8 @@ class FeatureState {
       !isDownloaded &&
       (currentTrack?.item.extras?["shouldTranscode"] as bool? ?? false);
   String get container =>
-      isTranscoding ? "aac" : metadata?.mediaSourceInfo.container ?? "";
+      isTranscoding ? settings.transcodingSegmentContainer.container.split('+')[0]
+          : metadata?.mediaSourceInfo.container ?? "";
   int? get size => isTranscoding ? null : metadata?.mediaSourceInfo.size;
   MediaStream? get audioStream => isTranscoding
       ? null
@@ -61,7 +62,7 @@ class FeatureState {
   // should have a valid mediaStream, so use that audio-only bitrate instead of the
   // whole-file bitrate.
   int? get bitrate => isTranscoding
-      ? settings.transcodeBitrate
+      ? (settings.transcodingSegmentContainer.container.split('+')[0] == 'flac' ? null : settings.transcodeBitrate)
       : audioStream?.bitRate ?? metadata?.mediaSourceInfo.bitrate;
   int? get sampleRate => audioStream?.sampleRate;
   int? get bitDepth => audioStream?.bitDepth;
@@ -145,7 +146,7 @@ class FeatureState {
               FeatureProperties(
                 type: feature,
                 text:
-                    "${configuration.features.contains(FinampFeatureChipType.codec) ? container.toUpperCase() : ""}${configuration.features.contains(FinampFeatureChipType.codec) && configuration.features.contains(FinampFeatureChipType.bitRate) ? " @ " : ""}${configuration.features.contains(FinampFeatureChipType.bitRate) && bitrate != null ? AppLocalizations.of(context)!.kiloBitsPerSecondLabel(bitrate! ~/ 1000) : ""}",
+                    "${configuration.features.contains(FinampFeatureChipType.codec) ? container.toUpperCase() : ""}${configuration.features.contains(FinampFeatureChipType.codec) && configuration.features.contains(FinampFeatureChipType.bitRate) && bitrate != null ? " @ " : ""}${configuration.features.contains(FinampFeatureChipType.bitRate) && bitrate != null ? AppLocalizations.of(context)!.kiloBitsPerSecondLabel(bitrate! ~/ 1000) : ""}",
               ),
             );
           }

--- a/lib/components/PlayerScreen/feature_chips.dart
+++ b/lib/components/PlayerScreen/feature_chips.dart
@@ -50,7 +50,7 @@ class FeatureState {
       !isDownloaded &&
       (currentTrack?.item.extras?["shouldTranscode"] as bool? ?? false);
   String get container =>
-      isTranscoding ? settings.transcodingSegmentContainer.container.split('+')[0]
+      isTranscoding ? settings.transcodingSegmentContainer.codec
           : metadata?.mediaSourceInfo.container ?? "";
   int? get size => isTranscoding ? null : metadata?.mediaSourceInfo.size;
   MediaStream? get audioStream => isTranscoding
@@ -62,7 +62,7 @@ class FeatureState {
   // should have a valid mediaStream, so use that audio-only bitrate instead of the
   // whole-file bitrate.
   int? get bitrate => isTranscoding
-      ? (settings.transcodingSegmentContainer.container.split('+')[0] == 'flac' ? null : settings.transcodeBitrate)
+      ? (settings.transcodingSegmentContainer.codec == 'flac' ? null : settings.transcodeBitrate)
       : audioStream?.bitRate ?? metadata?.mediaSourceInfo.bitrate;
   int? get sampleRate => audioStream?.sampleRate;
   int? get bitDepth => audioStream?.bitDepth;

--- a/lib/hive_registrar.g.dart
+++ b/lib/hive_registrar.g.dart
@@ -36,7 +36,7 @@ extension HiveRegistrar on HiveInterface {
     registerAdapter(FinampQueueInfoAdapter());
     registerAdapter(FinampQueueItemAdapter());
     registerAdapter(FinampQueueOrderAdapter());
-    registerAdapter(FinampSegmentContainerAdapter());
+    registerAdapter(FinampTranscodingStreamingFormatAdapter());
     registerAdapter(FinampSettingsAdapter());
     registerAdapter(FinampStorableQueueInfoAdapter());
     registerAdapter(FinampTranscodingCodecAdapter());

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1419,11 +1419,11 @@
     },
     "description": "Localized names of special downloadable collection representing cached images for a certain library."
   },
-  "transcodingStreamingContainerTitle": "Select Transcoding Format",
-  "@transcodingStreamingContainerTitle": {
+  "transcodingStreamingFormatTitle": "Select Transcoding Format",
+  "@transcodingStreamingFormatTitle": {
     "description": "Title for the dropdown that selects the format for transcoded streams"
   },
-  "transcodingStreamingContainerSubtitle": "Select the format to use when streaming transcoded audio. Already queued tracks will not be affected.",
+  "transcodingStreamingFormatSubtitle": "Select the format to use when streaming transcoded audio. Already queued tracks will not be affected.",
   "downloadTranscodeEnableTitle": "Enable Transcoded Downloads",
   "@downloadTranscodeEnableTitle": {
     "description": "Title for Enable Transcoded Downloads dropdown"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -466,7 +466,7 @@
   "@enableTranscodingSubtitle": {},
   "bitrate": "Bitrate",
   "@bitrate": {},
-  "bitrateSubtitle": "A higher bitrate gives higher quality audio at the cost of higher bandwidth. This setting is ignored when the format is set to FLAC+MP4",
+  "bitrateSubtitle": "A higher bitrate gives higher quality audio at the cost of higher bandwidth. Does not apply to lossless codecs, e.g. FLAC",
   "@bitrateSubtitle": {},
   "customLocation": "Custom Location",
   "@customLocation": {},

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -468,7 +468,7 @@
   "@enableTranscodingSubtitle": {},
   "bitrate": "Bitrate",
   "@bitrate": {},
-  "bitrateSubtitle": "A higher bitrate gives higher quality audio at the cost of higher bandwidth.",
+  "bitrateSubtitle": "A higher bitrate gives higher quality audio at the cost of higher bandwidth. This setting is ignored when the format is set to FLAC+MP4",
   "@bitrateSubtitle": {},
   "customLocation": "Custom Location",
   "@customLocation": {},
@@ -1421,11 +1421,11 @@
     },
     "description": "Localized names of special downloadable collection representing cached images for a certain library."
   },
-  "transcodingStreamingContainerTitle": "Select Transcoding Container",
+  "transcodingStreamingContainerTitle": "Select Transcoding Format",
   "@transcodingStreamingContainerTitle": {
-    "description": "Title for the dropdown that selects the container format for transcoded streams"
+    "description": "Title for the dropdown that selects the format for transcoded streams"
   },
-  "transcodingStreamingContainerSubtitle": "Select the segment container to use when streaming transcoded audio. Already queued tracks will not be affected.",
+  "transcodingStreamingContainerSubtitle": "Select the format to use when streaming transcoded audio. Already queued tracks will not be affected.",
   "downloadTranscodeEnableTitle": "Enable Transcoded Downloads",
   "@downloadTranscodeEnableTitle": {
     "description": "Title for Enable Transcoded Downloads dropdown"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -460,8 +460,6 @@
   "@downloadedTracksWillNotBeDeleted": {},
   "areYouSure": "Are you sure?",
   "@areYouSure": {},
-  "jellyfinUsesAACForTranscoding": "Jellyfin uses AAC for transcoding",
-  "@jellyfinUsesAACForTranscoding": {},
   "enableTranscoding": "Enable Transcoding",
   "@enableTranscoding": {},
   "enableTranscodingSubtitle": "Transcodes music streams on the server side.",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -269,7 +269,7 @@ Future<void> setupHive() async {
   Hive.registerAdapter(LyricsAlignmentAdapter());
   Hive.registerAdapter(LyricsFontSizeAdapter());
   Hive.registerAdapter(KeepScreenOnOptionAdapter());
-  Hive.registerAdapter(FinampSegmentContainerAdapter());
+  Hive.registerAdapter(FinampTranscodingStreamingFormatAdapter());
   Hive.registerAdapter(FinampFeatureChipsConfigurationAdapter());
   Hive.registerAdapter(FinampFeatureChipTypeAdapter());
   Hive.registerAdapter(ReleaseDateFormatAdapter());

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -127,7 +127,7 @@ class DefaultSettings {
   static const keepScreenOnWhilePluggedIn = true;
   static const hasDownloadedPlaylistInfo = false;
   static const transcodingSegmentContainer =
-      FinampSegmentContainer.fragmentedMp4;
+      FinampSegmentContainer.aacFragmentedMp4;
   static const featureChipsConfiguration =
       FinampFeatureChipsConfiguration(enabled: true, features: [
     FinampFeatureChipType.playCount,
@@ -2437,9 +2437,13 @@ enum KeepScreenOnOption {
 @HiveType(typeId: 73)
 enum FinampSegmentContainer {
   @HiveField(0)
-  mpegTS("ts"),
+  aacMpegTS("aac+ts"),
   @HiveField(1)
-  fragmentedMp4("mp4");
+  aacFragmentedMp4("aac+mp4"),
+  @HiveField(2)
+  opusFragmentedMp4("opus+mp4"),
+  @HiveField(3)
+  flacFragmentedMp4("flac+mp4");
 
   const FinampSegmentContainer(this.container);
 

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -126,8 +126,8 @@ class DefaultSettings {
   static const keepScreenOnOption = KeepScreenOnOption.whileLyrics;
   static const keepScreenOnWhilePluggedIn = true;
   static const hasDownloadedPlaylistInfo = false;
-  static const transcodingSegmentContainer =
-      FinampSegmentContainer.aacFragmentedMp4;
+  static const transcodingStreamingFormat =
+      FinampTranscodingStreamingFormat.aacFragmentedMp4;
   static const featureChipsConfiguration =
       FinampFeatureChipsConfiguration(enabled: true, features: [
     FinampFeatureChipType.playCount,
@@ -253,8 +253,8 @@ class FinampSettings {
     this.featureChipsConfiguration = DefaultSettings.featureChipsConfiguration,
     this.showCoversOnAlbumScreen = DefaultSettings.showCoversOnAlbumScreen,
     this.hasDownloadedPlaylistInfo = DefaultSettings.hasDownloadedPlaylistInfo,
-    this.transcodingSegmentContainer =
-        DefaultSettings.transcodingSegmentContainer,
+    this.transcodingStreamingFormat =
+        DefaultSettings.transcodingStreamingFormat,
     this.downloadSizeWarningCutoff = DefaultSettings.downloadSizeWarningCutoff,
     this.allowDeleteFromServer = DefaultSettings.allowDeleteFromServer,
     this.oneLineMarqueeTextButton = DefaultSettings.oneLineMarqueeTextButton,
@@ -505,8 +505,8 @@ class FinampSettings {
   @HiveField(74, defaultValue: DefaultSettings.hasDownloadedPlaylistInfo)
   bool hasDownloadedPlaylistInfo;
 
-  @HiveField(75, defaultValue: DefaultSettings.transcodingSegmentContainer)
-  FinampSegmentContainer transcodingSegmentContainer;
+  @HiveField(75, defaultValue: DefaultSettings.transcodingStreamingFormat)
+  FinampTranscodingStreamingFormat transcodingStreamingFormat;
 
   @HiveField(76, defaultValue: DefaultSettings.featureChipsConfiguration)
   FinampFeatureChipsConfiguration featureChipsConfiguration;
@@ -544,7 +544,7 @@ class FinampSettings {
 
   @HiveField(89, defaultValue: DefaultSettings.itemSwipeActionRightToLeft)
   ItemSwipeActions itemSwipeActionRightToLeft;
-  
+
   @HiveField(86, defaultValue: DefaultSettings.audioFadeOutDuration)
   Duration audioFadeOutDuration;
 

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -2443,7 +2443,11 @@ enum FinampSegmentContainer {
   @HiveField(2)
   opusFragmentedMp4("opus", "mp4"),
   @HiveField(3)
-  flacFragmentedMp4("flac", "mp4");
+  flacFragmentedMp4("flac", "mp4"),
+  @HiveField(4)
+  vorbisMpegTS("vorbis", "ts"),
+  @HiveField(5)
+  vorbisFragmentedMp4("vorbis", "mp4");
 
   const FinampSegmentContainer(this.codec, this.container);
 

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -2437,16 +2437,17 @@ enum KeepScreenOnOption {
 @HiveType(typeId: 73)
 enum FinampSegmentContainer {
   @HiveField(0)
-  aacMpegTS("aac+ts"),
+  aacMpegTS("aac", "ts"),
   @HiveField(1)
-  aacFragmentedMp4("aac+mp4"),
+  aacFragmentedMp4("aac", "mp4"),
   @HiveField(2)
-  opusFragmentedMp4("opus+mp4"),
+  opusFragmentedMp4("opus", "mp4"),
   @HiveField(3)
-  flacFragmentedMp4("flac+mp4");
+  flacFragmentedMp4("flac", "mp4");
 
-  const FinampSegmentContainer(this.container);
+  const FinampSegmentContainer(this.codec, this.container);
 
+  final String codec;
   /// The container to use to transport the segments
   final String container;
 }

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -2435,7 +2435,7 @@ enum KeepScreenOnOption {
 }
 
 @HiveType(typeId: 73)
-enum FinampSegmentContainer {
+enum FinampTranscodingStreamingFormat {
   @HiveField(0)
   aacMpegTS("aac", "ts"),
   @HiveField(1)
@@ -2449,7 +2449,7 @@ enum FinampSegmentContainer {
   @HiveField(5)
   vorbisFragmentedMp4("vorbis", "mp4");
 
-  const FinampSegmentContainer(this.codec, this.container);
+  const FinampTranscodingStreamingFormat(this.codec, this.container);
 
   final String codec;
   /// The container to use to transport the segments

--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -1949,6 +1949,10 @@ class FinampTranscodingStreamingFormatAdapter
         return FinampTranscodingStreamingFormat.opusFragmentedMp4;
       case 3:
         return FinampTranscodingStreamingFormat.flacFragmentedMp4;
+      case 4:
+        return FinampTranscodingStreamingFormat.vorbisMpegTS;
+      case 5:
+        return FinampTranscodingStreamingFormat.vorbisFragmentedMp4;
       default:
         return FinampTranscodingStreamingFormat.aacFragmentedMp4;
     }
@@ -1965,6 +1969,10 @@ class FinampTranscodingStreamingFormatAdapter
         writer.writeByte(2);
       case FinampTranscodingStreamingFormat.flacFragmentedMp4:
         writer.writeByte(3);
+      case FinampTranscodingStreamingFormat.vorbisMpegTS:
+        writer.writeByte(4);
+      case FinampTranscodingStreamingFormat.vorbisFragmentedMp4:
+        writer.writeByte(5);
     }
   }
 

--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -1945,8 +1945,12 @@ class FinampSegmentContainerAdapter
         return FinampSegmentContainer.aacMpegTS;
       case 1:
         return FinampSegmentContainer.aacFragmentedMp4;
+      case 2:
+        return FinampSegmentContainer.opusFragmentedMp4;
+      case 3:
+        return FinampSegmentContainer.flacFragmentedMp4;
       default:
-        return FinampSegmentContainer.aacMpegTS;
+        return FinampSegmentContainer.aacFragmentedMp4;
     }
   }
 

--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -203,9 +203,9 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       showCoversOnAlbumScreen: fields[77] == null ? false : fields[77] as bool,
       hasDownloadedPlaylistInfo:
           fields[74] == null ? false : fields[74] as bool,
-      transcodingSegmentContainer: fields[75] == null
-          ? FinampSegmentContainer.aacFragmentedMp4
-          : fields[75] as FinampSegmentContainer,
+      transcodingStreamingFormat: fields[75] == null
+          ? FinampTranscodingStreamingFormat.aacFragmentedMp4
+          : fields[75] as FinampTranscodingStreamingFormat,
       downloadSizeWarningCutoff:
           fields[80] == null ? 150 : (fields[80] as num).toInt(),
       allowDeleteFromServer: fields[81] == null ? false : fields[81] as bool,
@@ -369,7 +369,7 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       ..writeByte(74)
       ..write(obj.hasDownloadedPlaylistInfo)
       ..writeByte(75)
-      ..write(obj.transcodingSegmentContainer)
+      ..write(obj.transcodingStreamingFormat)
       ..writeByte(76)
       ..write(obj.featureChipsConfiguration)
       ..writeByte(77)
@@ -1933,37 +1933,37 @@ class KeepScreenOnOptionAdapter extends TypeAdapter<KeepScreenOnOption> {
           typeId == other.typeId;
 }
 
-class FinampSegmentContainerAdapter
-    extends TypeAdapter<FinampSegmentContainer> {
+class FinampTranscodingStreamingFormatAdapter
+    extends TypeAdapter<FinampTranscodingStreamingFormat> {
   @override
   final int typeId = 73;
 
   @override
-  FinampSegmentContainer read(BinaryReader reader) {
+  FinampTranscodingStreamingFormat read(BinaryReader reader) {
     switch (reader.readByte()) {
       case 0:
-        return FinampSegmentContainer.aacMpegTS;
+        return FinampTranscodingStreamingFormat.aacMpegTS;
       case 1:
-        return FinampSegmentContainer.aacFragmentedMp4;
+        return FinampTranscodingStreamingFormat.aacFragmentedMp4;
       case 2:
-        return FinampSegmentContainer.opusFragmentedMp4;
+        return FinampTranscodingStreamingFormat.opusFragmentedMp4;
       case 3:
-        return FinampSegmentContainer.flacFragmentedMp4;
+        return FinampTranscodingStreamingFormat.flacFragmentedMp4;
       default:
-        return FinampSegmentContainer.aacFragmentedMp4;
+        return FinampTranscodingStreamingFormat.aacFragmentedMp4;
     }
   }
 
   @override
-  void write(BinaryWriter writer, FinampSegmentContainer obj) {
+  void write(BinaryWriter writer, FinampTranscodingStreamingFormat obj) {
     switch (obj) {
-      case FinampSegmentContainer.aacMpegTS:
+      case FinampTranscodingStreamingFormat.aacMpegTS:
         writer.writeByte(0);
-      case FinampSegmentContainer.aacFragmentedMp4:
+      case FinampTranscodingStreamingFormat.aacFragmentedMp4:
         writer.writeByte(1);
-      case FinampSegmentContainer.opusFragmentedMp4:
+      case FinampTranscodingStreamingFormat.opusFragmentedMp4:
         writer.writeByte(2);
-      case FinampSegmentContainer.flacFragmentedMp4:
+      case FinampTranscodingStreamingFormat.flacFragmentedMp4:
         writer.writeByte(3);
     }
   }
@@ -1974,7 +1974,7 @@ class FinampSegmentContainerAdapter
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      other is FinampSegmentContainerAdapter &&
+      other is FinampTranscodingStreamingFormatAdapter &&
           runtimeType == other.runtimeType &&
           typeId == other.typeId;
 }

--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -204,7 +204,7 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       hasDownloadedPlaylistInfo:
           fields[74] == null ? false : fields[74] as bool,
       transcodingSegmentContainer: fields[75] == null
-          ? FinampSegmentContainer.fragmentedMp4
+          ? FinampSegmentContainer.aacFragmentedMp4
           : fields[75] as FinampSegmentContainer,
       downloadSizeWarningCutoff:
           fields[80] == null ? 150 : (fields[80] as num).toInt(),
@@ -1942,21 +1942,25 @@ class FinampSegmentContainerAdapter
   FinampSegmentContainer read(BinaryReader reader) {
     switch (reader.readByte()) {
       case 0:
-        return FinampSegmentContainer.mpegTS;
+        return FinampSegmentContainer.aacMpegTS;
       case 1:
-        return FinampSegmentContainer.fragmentedMp4;
+        return FinampSegmentContainer.aacFragmentedMp4;
       default:
-        return FinampSegmentContainer.mpegTS;
+        return FinampSegmentContainer.aacMpegTS;
     }
   }
 
   @override
   void write(BinaryWriter writer, FinampSegmentContainer obj) {
     switch (obj) {
-      case FinampSegmentContainer.mpegTS:
+      case FinampSegmentContainer.aacMpegTS:
         writer.writeByte(0);
-      case FinampSegmentContainer.fragmentedMp4:
+      case FinampSegmentContainer.aacFragmentedMp4:
         writer.writeByte(1);
+      case FinampSegmentContainer.opusFragmentedMp4:
+        writer.writeByte(2);
+      case FinampSegmentContainer.flacFragmentedMp4:
+        writer.writeByte(3);
     }
   }
 

--- a/lib/screens/transcoding_settings_screen.dart
+++ b/lib/screens/transcoding_settings_screen.dart
@@ -31,8 +31,8 @@ class _TranscodingSettingsScreenState extends State<TranscodingSettingsScreen> {
       body: ListView(
         children: [
           const TranscodeSwitch(),
-          const BitrateSelector(),
           const StreamingTranscodingFormatDropdownListTile(),
+          const BitrateSelector(),
           Divider(),
           const DownloadTranscodeEnableDropdownListTile(),
           const DownloadTranscodeCodecDropdownListTile(),

--- a/lib/screens/transcoding_settings_screen.dart
+++ b/lib/screens/transcoding_settings_screen.dart
@@ -32,7 +32,7 @@ class _TranscodingSettingsScreenState extends State<TranscodingSettingsScreen> {
         children: [
           const TranscodeSwitch(),
           const BitrateSelector(),
-          const StreamingTranscodeSegmentContainerDropdownListTile(),
+          const StreamingTranscodingFormatDropdownListTile(),
           Padding(padding: const EdgeInsets.all(8.0)),
           const DownloadTranscodeEnableDropdownListTile(),
           const DownloadTranscodeCodecDropdownListTile(),
@@ -127,26 +127,26 @@ class DownloadTranscodeCodecDropdownListTile extends ConsumerWidget {
   }
 }
 
-class StreamingTranscodeSegmentContainerDropdownListTile
+class StreamingTranscodingFormatDropdownListTile
     extends ConsumerWidget {
-  const StreamingTranscodeSegmentContainerDropdownListTile({super.key});
+  const StreamingTranscodingFormatDropdownListTile({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return ListTile(
       title: Text(
-          AppLocalizations.of(context)!.transcodingStreamingContainerTitle),
+          AppLocalizations.of(context)!.transcodingStreamingFormatTitle),
       subtitle: Text(
-          AppLocalizations.of(context)!.transcodingStreamingContainerSubtitle),
-      trailing: DropdownButton<FinampSegmentContainer>(
-        value: ref.watch(finampSettingsProvider.transcodingSegmentContainer),
-        items: FinampSegmentContainer.values
-            .map((e) => DropdownMenuItem<FinampSegmentContainer>(
+          AppLocalizations.of(context)!.transcodingStreamingFormatSubtitle),
+      trailing: DropdownButton<FinampTranscodingStreamingFormat>(
+        value: ref.watch(finampSettingsProvider.transcodingStreamingFormat),
+        items: FinampTranscodingStreamingFormat.values
+            .map((e) => DropdownMenuItem<FinampTranscodingStreamingFormat>(
                   value: e,
                   child: Text("${e.codec}+${e.container}".toUpperCase()),
                 ))
             .toList(),
-        onChanged: FinampSetters.setTranscodingSegmentContainer.ifNonNull,
+        onChanged: FinampSetters.setTranscodingStreamingFormat.ifNonNull,
       ),
     );
   }

--- a/lib/screens/transcoding_settings_screen.dart
+++ b/lib/screens/transcoding_settings_screen.dart
@@ -143,7 +143,7 @@ class StreamingTranscodeSegmentContainerDropdownListTile
         items: FinampSegmentContainer.values
             .map((e) => DropdownMenuItem<FinampSegmentContainer>(
                   value: e,
-                  child: Text(e.container.toUpperCase()),
+                  child: Text("${e.codec}+${e.container}".toUpperCase()),
                 ))
             .toList(),
         onChanged: FinampSetters.setTranscodingSegmentContainer.ifNonNull,

--- a/lib/screens/transcoding_settings_screen.dart
+++ b/lib/screens/transcoding_settings_screen.dart
@@ -33,14 +33,7 @@ class _TranscodingSettingsScreenState extends State<TranscodingSettingsScreen> {
           const TranscodeSwitch(),
           const BitrateSelector(),
           const StreamingTranscodeSegmentContainerDropdownListTile(),
-          Padding(
-            padding: const EdgeInsets.all(8.0),
-            child: Text(
-              AppLocalizations.of(context)!.jellyfinUsesAACForTranscoding,
-              style: Theme.of(context).textTheme.bodySmall,
-              textAlign: TextAlign.center,
-            ),
-          ),
+          Padding(padding: const EdgeInsets.all(8.0)),
           const DownloadTranscodeEnableDropdownListTile(),
           const DownloadTranscodeCodecDropdownListTile(),
           const DownloadBitrateSelector(),

--- a/lib/screens/transcoding_settings_screen.dart
+++ b/lib/screens/transcoding_settings_screen.dart
@@ -33,7 +33,7 @@ class _TranscodingSettingsScreenState extends State<TranscodingSettingsScreen> {
           const TranscodeSwitch(),
           const BitrateSelector(),
           const StreamingTranscodingFormatDropdownListTile(),
-          Padding(padding: const EdgeInsets.all(8.0)),
+          Divider(),
           const DownloadTranscodeEnableDropdownListTile(),
           const DownloadTranscodeCodecDropdownListTile(),
           const DownloadBitrateSelector(),

--- a/lib/services/finamp_settings_helper.dart
+++ b/lib/services/finamp_settings_helper.dart
@@ -185,8 +185,8 @@ class FinampSettingsHelper {
 
     finampSettingsTemp.shouldTranscode = DefaultSettings.shouldTranscode;
     FinampSetters.setTranscodeBitrate(DefaultSettings.transcodeBitrate);
-    finampSettingsTemp.transcodingSegmentContainer =
-        DefaultSettings.transcodingSegmentContainer;
+    finampSettingsTemp.transcodingStreamingFormat =
+        DefaultSettings.transcodingStreamingFormat;
     finampSettingsTemp.shouldTranscodeDownloads =
         DefaultSettings.shouldTranscodeDownloads;
     finampSettingsTemp.downloadTranscodingCodec = FinampTranscodingCodec

--- a/lib/services/finamp_settings_helper.g.dart
+++ b/lib/services/finamp_settings_helper.g.dart
@@ -513,11 +513,11 @@ extension FinampSetters on FinampSettingsHelper {
         .put("FinampSettings", finampSettingsTemp);
   }
 
-  static void setTranscodingSegmentContainer(
-      FinampSegmentContainer newTranscodingSegmentContainer) {
+  static void setTranscodingStreamingFormat(
+      FinampTranscodingStreamingFormat newTranscodingStreamingFormat) {
     FinampSettings finampSettingsTemp = FinampSettingsHelper.finampSettings;
-    finampSettingsTemp.transcodingSegmentContainer =
-        newTranscodingSegmentContainer;
+    finampSettingsTemp.transcodingStreamingFormat =
+        newTranscodingStreamingFormat;
     Hive.box<FinampSettings>("FinampSettings")
         .put("FinampSettings", finampSettingsTemp);
   }
@@ -804,9 +804,9 @@ extension FinampSettingsProviderSelectors on StreamProvider<FinampSettings> {
   ProviderListenable<bool> get hasDownloadedPlaylistInfo =>
       finampSettingsProvider
           .select((value) => value.requireValue.hasDownloadedPlaylistInfo);
-  ProviderListenable<FinampSegmentContainer> get transcodingSegmentContainer =>
+  ProviderListenable<FinampTranscodingStreamingFormat> get transcodingStreamingFormat =>
       finampSettingsProvider
-          .select((value) => value.requireValue.transcodingSegmentContainer);
+          .select((value) => value.requireValue.transcodingStreamingFormat);
   ProviderListenable<FinampFeatureChipsConfiguration>
       get featureChipsConfiguration => finampSettingsProvider
           .select((value) => value.requireValue.featureChipsConfiguration);

--- a/lib/services/queue_service.dart
+++ b/lib/services/queue_service.dart
@@ -1161,7 +1161,9 @@ class QueueService {
             .finampSettings.transcodingSegmentContainer.codec,
         // Ideally we'd switch between 44.1/48kHz depending on the source is,
         // realistically it doesn't matter too much
-        "audioSampleRate": "48000",
+        // default to 44100, only use 48000 for opus because opus doesn't support 44100
+        "audioSampleRate": FinampSettingsHelper
+            .finampSettings.transcodingSegmentContainer.codec == 'opus' ? '48000' : '44100',
         "maxAudioBitDepth": "16",
         "audioBitRate":
             FinampSettingsHelper.finampSettings.transcodeBitrate.toString(),

--- a/lib/services/queue_service.dart
+++ b/lib/services/queue_service.dart
@@ -1158,17 +1158,18 @@ class QueueService {
 
       queryParameters.addAll({
         "audioCodec": FinampSettingsHelper
-            .finampSettings.transcodingSegmentContainer.container.split('+')[0],
-        // Ideally we'd use 48kHz when the source is, realistically it doesn't
-        // matter too much
+            .finampSettings.transcodingSegmentContainer.codec,
+        // Ideally we'd switch between 44.1/48kHz depending on the source is,
+        // realistically it doesn't matter too much
         "audioSampleRate": "48000",
         "maxAudioBitDepth": "16",
         "audioBitRate":
             FinampSettingsHelper.finampSettings.transcodeBitrate.toString(),
         "segmentContainer": FinampSettingsHelper
-            .finampSettings.transcodingSegmentContainer.container.split('+')[1],
+            .finampSettings.transcodingSegmentContainer.container,
         "transcodeReasons": "ContainerBitrateExceedsLimit",
       });
+
     } else {
       builtPath.addAll([
         "Items",

--- a/lib/services/queue_service.dart
+++ b/lib/services/queue_service.dart
@@ -1157,15 +1157,16 @@ class QueueService {
       ]);
 
       queryParameters.addAll({
-        "audioCodec": "aac",
+        "audioCodec": FinampSettingsHelper
+            .finampSettings.transcodingSegmentContainer.container.split('+')[0],
         // Ideally we'd use 48kHz when the source is, realistically it doesn't
         // matter too much
-        "audioSampleRate": "44100",
+        "audioSampleRate": "48000",
         "maxAudioBitDepth": "16",
         "audioBitRate":
             FinampSettingsHelper.finampSettings.transcodeBitrate.toString(),
         "segmentContainer": FinampSettingsHelper
-            .finampSettings.transcodingSegmentContainer.container,
+            .finampSettings.transcodingSegmentContainer.container.split('+')[1],
         "transcodeReasons": "ContainerBitrateExceedsLimit",
       });
     } else {

--- a/lib/services/queue_service.dart
+++ b/lib/services/queue_service.dart
@@ -1158,17 +1158,17 @@ class QueueService {
 
       queryParameters.addAll({
         "audioCodec": FinampSettingsHelper
-            .finampSettings.transcodingSegmentContainer.codec,
+            .finampSettings.transcodingStreamingFormat.codec,
         // Ideally we'd switch between 44.1/48kHz depending on the source is,
         // realistically it doesn't matter too much
         // default to 44100, only use 48000 for opus because opus doesn't support 44100
         "audioSampleRate": FinampSettingsHelper
-            .finampSettings.transcodingSegmentContainer.codec == 'opus' ? '48000' : '44100',
+            .finampSettings.transcodingStreamingFormat.codec == 'opus' ? '48000' : '44100',
         "maxAudioBitDepth": "16",
         "audioBitRate":
             FinampSettingsHelper.finampSettings.transcodeBitrate.toString(),
         "segmentContainer": FinampSettingsHelper
-            .finampSettings.transcodingSegmentContainer.container,
+            .finampSettings.transcodingStreamingFormat.container,
         "transcodeReasons": "ContainerBitrateExceedsLimit",
       });
 


### PR DESCRIPTION
Adds opus and flac transcoding using the existing transcoding API.
Tested on Android 16 in Android Studio Simulator.

I am putting the codec and container in the same setting because unlike AAC, opus and flac can only be streamed using mp4 containers and cannot use ts containers.
<img width="297" alt="截圖 2025-04-01 晚上9 53 22" src="https://github.com/user-attachments/assets/6eff958e-054f-40d3-abe5-d955a540bf04" />

fixes #427 
fixes #1124 