### PR TITLE
make volume slider fill in whole width

### DIFF
--- a/lib/menus/output_menu.dart
+++ b/lib/menus/output_menu.dart
@@ -372,7 +372,7 @@ class _VolumeSliderState extends ConsumerState<VolumeSlider> {
                       thumbWidth: 2.0,
                       thumbHeight: 24.0,
                       borderRadius: 8.0,
-                      offsetLeft: -8.0,
+                      offsetLeft: -9.0,
                     ),
                     thumbColor: Colors.white,
                     activeTrackColor: themeColor,


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/b0552b6f-c71e-470c-95d3-5c34f9995b12)
After:
![image](https://github.com/user-attachments/assets/b92bf9eb-b8e1-40e2-a890-6c4cf951f43c)


and for when its 0%
Before:
![image](https://github.com/user-attachments/assets/d0b6dd75-9609-407d-ac2f-209faa5fd5cf)
After:
![image](https://github.com/user-attachments/assets/80facb60-3c56-4314-b31a-fc44f363e63c)
