### PR TITLE
Fix dynamic/album-based gain modes in background

### DIFF
--- a/lib/components/AlbumScreen/track_list_tile.dart
+++ b/lib/components/AlbumScreen/track_list_tile.dart
@@ -642,7 +642,7 @@ class TrackListItemTile extends ConsumerWidget {
     );
     final addSpaceAfterSpecialIcons =
         (downloadedIndicator.isVisible(ref) || (baseItem.hasLyrics ?? false)) && (showDateAdded || showDateLastPlayed);
-      
+
     final showPlaybackProgress = !highlightCurrentTrack && playbackProgress != null && playbackProgress! < 0.99;
 
     return ListTileTheme(

--- a/lib/components/PlaybackHistoryScreen/playback_history_list.dart
+++ b/lib/components/PlaybackHistoryScreen/playback_history_list.dart
@@ -36,7 +36,7 @@ class PlaybackHistoryList extends StatelessWidget {
                     item: group.value[actualIndex].item.baseItem!,
                     isShownInSearchOrHistory: true,
                     highlightCurrentTrack: groupIndex == 0 && index == 0, // only highlight first track
-                    playbackProgress: group.value[actualIndex].playPercentage
+                    playbackProgress: group.value[actualIndex].playPercentage,
                   );
 
                   return index == 0

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -44,6 +44,7 @@ import 'package:finamp/services/ui_overlay_setter_observer.dart';
 import 'package:finamp/services/widget_bindings_observer_provider.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -96,6 +97,8 @@ import 'services/theme_mode_helper.dart';
 import 'setup_logging.dart';
 
 final _mainLog = Logger("Main()");
+
+final providerScopeKey = GlobalKey();
 
 void main() async {
   // If the app has failed, this is set to true. If true, we don't attempt to run the main app since the error app has started.
@@ -298,6 +301,14 @@ Future<void> _setupProviders() async {
 
   DataSourceService.create();
   AutoOffline.startWatching();
+
+  unawaited(
+    Stream.periodic(Duration(seconds: 1)).forEach((_) {
+      if (!SchedulerBinding.instance.framesEnabled) {
+        (providerScopeKey.currentContext as InheritedElement?)?.build();
+      }
+    }),
+  );
 }
 
 Future<void> _setupOSIntegration() async {
@@ -523,6 +534,7 @@ class _FinampState extends State<Finamp> with WindowListener {
   @override
   Widget build(BuildContext context) {
     return UncontrolledProviderScope(
+      key: providerScopeKey,
       container: GetIt.instance<ProviderContainer>(),
       child: GestureDetector(
         onTap: () {

--- a/lib/services/current_track_metadata_provider.dart
+++ b/lib/services/current_track_metadata_provider.dart
@@ -13,6 +13,9 @@ final currentTrackMetadataProvider = AutoDisposeProvider<AsyncValue<MetadataProv
     BaseItemDto? base = itemToPrecache.baseItem;
     if (base != null) {
       ref.listen(metadataProvider(base), (_, __) {});
+      ref.read(
+        metadataProvider(base),
+      ); // forces it even in background https://github.com/rrousselGit/riverpod/issues/2671
     }
   }
 

--- a/lib/services/music_player_background_task.dart
+++ b/lib/services/music_player_background_task.dart
@@ -1129,11 +1129,15 @@ double? getGainForCurrentPlayback(MediaItem currentTrack, jellyfin_models.BaseIt
       item ?? jellyfin_models.BaseItemDto.fromJson(currentTrack.extras?["itemJson"] as Map<String, dynamic>);
 
   double? effectiveGainChange;
+  final providerContainer = GetIt.instance<ProviderContainer>();
+  providerContainer.read(
+    currentTrackMetadataProvider,
+  ); // forces it even in background https://github.com/rrousselGit/riverpod/issues/2671
+
   switch (FinampSettingsHelper.finampSettings.volumeNormalizationMode) {
     case VolumeNormalizationMode.hybrid
         when GetIt.instance<QueueService>().getQueue().isCurrentlyPlayingTracksFromSameAlbum():
     case VolumeNormalizationMode.albumBased:
-      final providerContainer = GetIt.instance<ProviderContainer>();
       // final parentNormalizationGain = providerContainer.read(currentTrackMetadataProvider).valueOrNull?.parentNormalizationGain;
       // includeLyrics is always true - fetch the metadataRequest directly.
       // Requires that provided arguments are the only fields of request,

--- a/lib/services/playback_history_service.dart
+++ b/lib/services/playback_history_service.dart
@@ -258,8 +258,7 @@ class PlaybackHistoryService {
           // played less than 30 seconds
           (element.playDuration ?? Duration.zero) >= const Duration(seconds: 30) ||
               // played less than 20% of the track duration
-              (element.playPercentage ?? 0.0) >=
-                  0.2)) {
+              (element.playPercentage ?? 0.0) >= 0.2)) {
         continue;
       }
 


### PR DESCRIPTION
## Changes

Fixes the following bug caused by Riverpod (see related issues):

<details>
<summary>The bug</summary>

To reproduce, you need 5 albums and a playlist:

- 4 unrelated tracks (from different albums)
- 2 tracks from the same album (called "reproducer album" later) with different track normalization gain (6 dB in my case) and track normalization gain of first of them should be more (i.e. track is louder) than album gain. Examples: Myth by Two Steps from Hell (~10 dB difference), ATTENTION ATTENTION by Shinedown (~6 dB difference, that's what I faced this bug on)

I recommend creating dedicated playlist instead of using a sublist of an existing playlist for tests in debug builds (they are very laggy to the point they are unusable!).

Then:

- You can start the queue from the first of the four unrelated tracks.
- Then stop the app ("Force stop" in android settings) and open it.
- Restore the queue or start again. Start playback, lay the phone down and shut the screen off (you can move it).
- Then don't do anything on phone and wait for reproducer album to play. The first track is very loud
  You can also skip instead of waiting, but skip three times (so that 4th track in a playlist is playing) and then seek it almost to the end, leaving some time to fetch the reproducer album metadata. Do not open the Finamp app!

Then either:

- Open the app and hear that volume changed to album-based ([this code](https://github.com/jmshrv/finamp/blob/1efd315d9a3d665a94db31912ad6eb5cbac3d314/lib/services/music_player_background_task.dart#L1115-L1124) triggers)
- Wait for second track and see that volume is suddenly changed ([#769](https://github.com/jmshrv/finamp/issues/769) helps to hear that)

This is caused by riverpod listeners being frozen when app is in background. This can be seen in Finamp logs - metadata is fetched only for currently playing track (which confirms `read` forces the fetching), but if you bring finamp to foreground after queue is shifted enough, other tracks are fetched simultaneously.

</details>

There are two ways to fix this (ignoring Jellyfin changes):

- Use `read` to force fetching of metadata even in background
- Split `ProviderContaier` as mentioned in https://github.com/rrousselGit/riverpod/issues/2671#issuecomment-2973693074

This PR goes the former way. This is dirtiest as it is possible as it uses (possibly) undocumented behavior however the latter way is only worse (it will double the requests). I will fully understand if you don't want a such change, then the only reasonable way is to expose album normalization gain with track metadata on Jellyfin (which I hope I'll soon dedicate time to!)

I moved `GetIt.instance<ProviderContainer>()` out of switch-case block because we need to consider `dynamic` mode in case tracks are not sequential.

Bug is reproduced on PR base. Used reproduction steps using both "album-based" and "dynamic" modes. Tested with debug apk build!

## Todo before merging

I recommend thoroughly reviewing this PR and merge only if you fully understand the parent issue, this issue and possible consequences of the change as I am not experienced with Flutter enough.

- Reproduce the bug on Android (so that I am not the only one affected)
- Reproduce the bug and test this PR on iOS too
- Consider the crash explained [here](https://github.com/rrousselGit/riverpod/issues/3354) because `dependencies.flutter_riverpod: ^2.6.1` is not 3.0.0 where it is fixed.

## Related Issues

https://github.com/rrousselGit/riverpod/issues/2671