### PR TITLE
Fix Offline Automation not resuming when PreferLocalNetwork is enabled

### DIFF
--- a/lib/components/AlbumScreen/track_list_tile.dart
+++ b/lib/components/AlbumScreen/track_list_tile.dart
@@ -642,7 +642,7 @@ class TrackListItemTile extends ConsumerWidget {
     );
     final addSpaceAfterSpecialIcons =
         (downloadedIndicator.isVisible(ref) || (baseItem.hasLyrics ?? false)) && (showDateAdded || showDateLastPlayed);
-      
+
     final showPlaybackProgress = !highlightCurrentTrack && playbackProgress != null && playbackProgress! < 0.99;
 
     return ListTileTheme(

--- a/lib/components/PlaybackHistoryScreen/playback_history_list.dart
+++ b/lib/components/PlaybackHistoryScreen/playback_history_list.dart
@@ -36,7 +36,7 @@ class PlaybackHistoryList extends StatelessWidget {
                     item: group.value[actualIndex].item.baseItem!,
                     isShownInSearchOrHistory: true,
                     highlightCurrentTrack: groupIndex == 0 && index == 0, // only highlight first track
-                    playbackProgress: group.value[actualIndex].playPercentage
+                    playbackProgress: group.value[actualIndex].playPercentage,
                   );
 
                   return index == 0

--- a/lib/services/network_manager.g.dart
+++ b/lib/services/network_manager.g.dart
@@ -11,7 +11,7 @@ part of 'network_manager.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$autoOfflineHash() => r'b164b0fa14e2124fde881f06ab6422037c52d763';
+String _$autoOfflineHash() => r'c50c147f4ee55cc5d19db6ad3ee148adbadcd852';
 
 /// See also [AutoOffline].
 @ProviderFor(AutoOffline)

--- a/lib/services/network_manager.g.dart
+++ b/lib/services/network_manager.g.dart
@@ -11,12 +11,12 @@ part of 'network_manager.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$autoOfflineHash() => r'467c3cf000350e05db33178ddeb17c10468e3b65';
+String _$autoOfflineHash() => r'b164b0fa14e2124fde881f06ab6422037c52d763';
 
 /// See also [AutoOffline].
 @ProviderFor(AutoOffline)
 final autoOfflineProvider =
-    AutoDisposeNotifierProvider<AutoOffline, bool>.internal(
+    AutoDisposeNotifierProvider<AutoOffline, int>.internal(
       AutoOffline.new,
       name: r'autoOfflineProvider',
       debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
@@ -26,6 +26,6 @@ final autoOfflineProvider =
       allTransitiveDependencies: null,
     );
 
-typedef _$AutoOffline = AutoDisposeNotifier<bool>;
+typedef _$AutoOffline = AutoDisposeNotifier<int>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/services/playback_history_service.dart
+++ b/lib/services/playback_history_service.dart
@@ -258,8 +258,7 @@ class PlaybackHistoryService {
           // played less than 30 seconds
           (element.playDuration ?? Duration.zero) >= const Duration(seconds: 30) ||
               // played less than 20% of the track duration
-              (element.playPercentage ?? 0.0) >=
-                  0.2)) {
+              (element.playPercentage ?? 0.0) >= 0.2)) {
         continue;
       }
 


### PR DESCRIPTION
## Changes
When PreferLocalNetwork is enabled, automation wouldnt resume after overwriting. This is now fixed (reason stated in code comment)

Also some formatting sneaked into the commit :)