### PR TITLE
Allow to toggle between pressing or holding a button to like a track on player screen

### DIFF
--- a/lib/components/AddToPlaylistScreen/add_to_playlist_button.dart
+++ b/lib/components/AddToPlaylistScreen/add_to_playlist_button.dart
@@ -56,15 +56,33 @@ class AddToPlaylistButton extends ConsumerWidget {
       excludeSemantics: true,
       container: true,
       child: GestureDetector(
-        onLongPress: toggleFavourite,
-        onSecondaryTap: toggleFavourite,
+        onLongPress: () async {
+          if (FinampSettingsHelper.finampSettings.favouriteButtonTogglesByShortClick) {
+            await openPlaylistActionsMenu();
+          } else {
+            toggleFavourite();
+          }
+        },
+        onSecondaryTap: () async {
+          if (FinampSettingsHelper.finampSettings.favouriteButtonTogglesByShortClick) {
+            await openPlaylistActionsMenu();
+          } else {
+            toggleFavourite();
+          }
+        },
         child: IconButton(
           icon: Icon(isFav ? Icons.favorite : Icons.favorite_outline, size: size ?? 24.0),
           color: color ?? IconTheme.of(context).color,
           disabledColor: (color ?? IconTheme.of(context).color)!.withOpacity(0.3),
           visualDensity: visualDensity ?? VisualDensity.compact,
           // tooltip: AppLocalizations.of(context)!.addToPlaylistTooltip,
-          onPressed: openPlaylistActionsMenu,
+          onPressed: () async {
+            if (FinampSettingsHelper.finampSettings.favouriteButtonTogglesByShortClick) {
+              toggleFavourite();
+            } else {
+              await openPlaylistActionsMenu();
+            }
+          },
         ),
       ),
     );

--- a/lib/components/AddToPlaylistScreen/add_to_playlist_button.dart
+++ b/lib/components/AddToPlaylistScreen/add_to_playlist_button.dart
@@ -28,6 +28,25 @@ class AddToPlaylistButton extends ConsumerWidget {
     }
 
     bool isFav = ref.watch(isFavoriteProvider(item));
+
+    void toggleFavourite() {
+      FeedbackHelper.feedback(FeedbackType.selection);
+      ref.read(isFavoriteProvider(item).notifier).updateFavorite(!isFav);
+    }
+
+    Future<void> openPlaylistActionsMenu() async {
+      if (FinampSettingsHelper.finampSettings.isOffline) {
+        return GlobalSnackbar.message((context) => AppLocalizations.of(context)!.notAvailableInOfflineMode);
+      }
+
+      bool inPlaylist = queueItemInPlaylist(queueItem);
+      await showPlaylistActionsMenu(
+        context: context,
+        items: [item!],
+        parentPlaylist: inPlaylist ? queueItem!.source.item : null,
+      );
+    }
+
     return Semantics.fromProperties(
       properties: SemanticsProperties(
         label: AppLocalizations.of(context)!.addToPlaylistTooltip,
@@ -37,32 +56,15 @@ class AddToPlaylistButton extends ConsumerWidget {
       excludeSemantics: true,
       container: true,
       child: GestureDetector(
-        onLongPress: () async {
-          FeedbackHelper.feedback(FeedbackType.selection);
-          ref.read(isFavoriteProvider(item).notifier).updateFavorite(!isFav);
-        },
-        onSecondaryTap: () async {
-          FeedbackHelper.feedback(FeedbackType.selection);
-          ref.read(isFavoriteProvider(item).notifier).updateFavorite(!isFav);
-        },
+        onLongPress: toggleFavourite,
+        onSecondaryTap: toggleFavourite,
         child: IconButton(
           icon: Icon(isFav ? Icons.favorite : Icons.favorite_outline, size: size ?? 24.0),
           color: color ?? IconTheme.of(context).color,
           disabledColor: (color ?? IconTheme.of(context).color)!.withOpacity(0.3),
           visualDensity: visualDensity ?? VisualDensity.compact,
           // tooltip: AppLocalizations.of(context)!.addToPlaylistTooltip,
-          onPressed: () async {
-            if (FinampSettingsHelper.finampSettings.isOffline) {
-              return GlobalSnackbar.message((context) => AppLocalizations.of(context)!.notAvailableInOfflineMode);
-            }
-
-            bool inPlaylist = queueItemInPlaylist(queueItem);
-            await showPlaylistActionsMenu(
-              context: context,
-              items: [item!],
-              parentPlaylist: inPlaylist ? queueItem!.source.item : null,
-            );
-          },
+          onPressed: openPlaylistActionsMenu,
         ),
       ),
     );

--- a/lib/components/AddToPlaylistScreen/add_to_playlist_button.dart
+++ b/lib/components/AddToPlaylistScreen/add_to_playlist_button.dart
@@ -57,14 +57,14 @@ class AddToPlaylistButton extends ConsumerWidget {
       container: true,
       child: GestureDetector(
         onLongPress: () async {
-          if (FinampSettingsHelper.finampSettings.favouriteButtonTogglesByShortClick) {
+          if (FinampSettingsHelper.finampSettings.preferAddingToFavoritesOverPlaylists) {
             await openPlaylistActionsMenu();
           } else {
             toggleFavourite();
           }
         },
         onSecondaryTap: () async {
-          if (FinampSettingsHelper.finampSettings.favouriteButtonTogglesByShortClick) {
+          if (FinampSettingsHelper.finampSettings.preferAddingToFavoritesOverPlaylists) {
             await openPlaylistActionsMenu();
           } else {
             toggleFavourite();
@@ -77,7 +77,7 @@ class AddToPlaylistButton extends ConsumerWidget {
           visualDensity: visualDensity ?? VisualDensity.compact,
           // tooltip: AppLocalizations.of(context)!.addToPlaylistTooltip,
           onPressed: () async {
-            if (FinampSettingsHelper.finampSettings.favouriteButtonTogglesByShortClick) {
+            if (FinampSettingsHelper.finampSettings.preferAddingToFavoritesOverPlaylists) {
               toggleFavourite();
             } else {
               await openPlaylistActionsMenu();

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2744,8 +2744,12 @@
   "@discordRPCIconWhiteTransparent": {
     "description": "A REALLY short description of the icon in use. Its format is 'ICON, BACKGROUND'. This one is the full white Finamp logo with a Transparent Background"
   },
-  "favouriteButtonTogglesByShortClickSetting": "Whether to allow favouring tracks via clicking.",
-  "@favouriteButtonTogglesByShortClickSelector": {},
-  "favouriteButtonTogglesByShortClickSettingSubtitle": "Default (disabled) opens \"Add to playlist\" menu by clicking.",
-  "@favouriteButtonTogglesByShortClickSettingSubtitle": {}
+  "preferAddingToFavoritesOverPlaylistsTitle": "Add to Favorites When Tapping Heart Icon",
+  "@preferAddingToFavoritesOverPlaylistsTitle": {
+    "description": "Title for the setting that swaps the default behavior of short- vs. long-press on the heart/favorite icon"
+  },
+  "preferAddingToFavoritesOverPlaylistsSubtitle": "When enabled, a short tap will add to favorites, and a long press will open the 'Add to Playlist' menu. Default is the inverse.",
+  "@preferAddingToFavoritesOverPlaylistsSubtitle": {
+    "description": "Subtitle for the setting that swaps the default behavior of short- vs. long-press on the heart/favorite icon"
+  }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2743,5 +2743,9 @@
   "discordRPCIconWhiteTransparent": "White Finamp - Transparent",
   "@discordRPCIconWhiteTransparent": {
     "description": "A REALLY short description of the icon in use. Its format is 'ICON, BACKGROUND'. This one is the full white Finamp logo with a Transparent Background"
-  }
+  },
+  "favouriteButtonTogglesByShortClickSetting": "Whether to allow favouring tracks via clicking.",
+  "@favouriteButtonTogglesByShortClickSelector": {},
+  "favouriteButtonTogglesByShortClickSettingSubtitle": "Default (disabled) opens \"Add to playlist\" menu by clicking.",
+  "@favouriteButtonTogglesByShortClickSettingSubtitle": {}
 }

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -229,6 +229,7 @@ class DefaultSettings {
   };
   static const rpcEnabled = false;
   static const rpcIcon = DiscordRpcIcon.transparent;
+  static const favouriteButtonTogglesByShortClick = false;
 }
 
 @HiveType(typeId: 28)
@@ -353,6 +354,7 @@ class FinampSettings {
     this.tileAdditionalInfoType = DefaultSettings.tileAdditionalInfoType,
     this.rpcEnabled = DefaultSettings.rpcEnabled,
     this.rpcIcon = DefaultSettings.rpcIcon,
+    this.favouriteButtonTogglesByShortClick = DefaultSettings.favouriteButtonTogglesByShortClick,
   });
 
   @HiveField(0, defaultValue: DefaultSettings.isOffline)
@@ -745,6 +747,9 @@ class FinampSettings {
 
   @HiveField(125, defaultValue: DefaultSettings.autoExpandPlayerScreen)
   bool autoExpandPlayerScreen = DefaultSettings.autoExpandPlayerScreen;
+
+  @HiveField(126, defaultValue: DefaultSettings.favouriteButtonTogglesByShortClick)
+  bool favouriteButtonTogglesByShortClick = DefaultSettings.favouriteButtonTogglesByShortClick;
 
   static Future<FinampSettings> create() async {
     final downloadLocation = await DownloadLocation.create(

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -229,7 +229,7 @@ class DefaultSettings {
   };
   static const rpcEnabled = false;
   static const rpcIcon = DiscordRpcIcon.transparent;
-  static const favouriteButtonTogglesByShortClick = false;
+  static const preferAddingToFavoritesOverPlaylists = false;
 }
 
 @HiveType(typeId: 28)
@@ -354,7 +354,7 @@ class FinampSettings {
     this.tileAdditionalInfoType = DefaultSettings.tileAdditionalInfoType,
     this.rpcEnabled = DefaultSettings.rpcEnabled,
     this.rpcIcon = DefaultSettings.rpcIcon,
-    this.favouriteButtonTogglesByShortClick = DefaultSettings.favouriteButtonTogglesByShortClick,
+    this.preferAddingToFavoritesOverPlaylists = DefaultSettings.preferAddingToFavoritesOverPlaylists,
   });
 
   @HiveField(0, defaultValue: DefaultSettings.isOffline)
@@ -748,8 +748,8 @@ class FinampSettings {
   @HiveField(125, defaultValue: DefaultSettings.autoExpandPlayerScreen)
   bool autoExpandPlayerScreen = DefaultSettings.autoExpandPlayerScreen;
 
-  @HiveField(126, defaultValue: DefaultSettings.favouriteButtonTogglesByShortClick)
-  bool favouriteButtonTogglesByShortClick = DefaultSettings.favouriteButtonTogglesByShortClick;
+  @HiveField(126, defaultValue: DefaultSettings.preferAddingToFavoritesOverPlaylists)
+  bool preferAddingToFavoritesOverPlaylists = DefaultSettings.preferAddingToFavoritesOverPlaylists;
 
   static Future<FinampSettings> create() async {
     final downloadLocation = await DownloadLocation.create(

--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -400,6 +400,9 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
         rpcIcon: fields[124] == null
             ? DiscordRpcIcon.transparent
             : fields[124] as DiscordRpcIcon,
+        favouriteButtonTogglesByShortClick: fields[126] == null
+            ? false
+            : fields[126] as bool,
       )
       ..disableGesture = fields[19] == null ? false : fields[19] as bool
       ..showFastScroller = fields[25] == null ? true : fields[25] as bool
@@ -414,7 +417,7 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
   @override
   void write(BinaryWriter writer, FinampSettings obj) {
     writer
-      ..writeByte(119)
+      ..writeByte(120)
       ..writeByte(0)
       ..write(obj.isOffline)
       ..writeByte(1)
@@ -652,7 +655,9 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       ..writeByte(124)
       ..write(obj.rpcIcon)
       ..writeByte(125)
-      ..write(obj.autoExpandPlayerScreen);
+      ..write(obj.autoExpandPlayerScreen)
+      ..writeByte(126)
+      ..write(obj.favouriteButtonTogglesByShortClick);
   }
 
   @override

--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -400,7 +400,7 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
         rpcIcon: fields[124] == null
             ? DiscordRpcIcon.transparent
             : fields[124] as DiscordRpcIcon,
-        favouriteButtonTogglesByShortClick: fields[126] == null
+        preferAddingToFavoritesOverPlaylists: fields[126] == null
             ? false
             : fields[126] as bool,
       )
@@ -657,7 +657,7 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       ..writeByte(125)
       ..write(obj.autoExpandPlayerScreen)
       ..writeByte(126)
-      ..write(obj.favouriteButtonTogglesByShortClick);
+      ..write(obj.preferAddingToFavoritesOverPlaylists);
   }
 
   @override

--- a/lib/screens/accessibility_settings_screen.dart
+++ b/lib/screens/accessibility_settings_screen.dart
@@ -29,7 +29,6 @@ class _AccessibilitySettingsScreenState extends State<AccessibilitySettingsScree
           UseHighContrastColorsToggle(),
           DisableGestureSelector(),
           DisableVibrationSelector(),
-          FavouriteButtonTogglesByShortClickSelector(),
         ],
       ),
     );
@@ -74,20 +73,6 @@ class DisableVibrationSelector extends ConsumerWidget {
       subtitle: Text(AppLocalizations.of(context)!.enableVibrationSubtitle),
       value: ref.watch(finampSettingsProvider.enableVibration),
       onChanged: (value) => FinampSetters.setEnableVibration(value),
-    );
-  }
-}
-
-class FavouriteButtonTogglesByShortClickSelector extends ConsumerWidget {
-  const FavouriteButtonTogglesByShortClickSelector({super.key});
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    return SwitchListTile.adaptive(
-      title: Text(AppLocalizations.of(context)!.favouriteButtonTogglesByShortClickSetting),
-      subtitle: Text(AppLocalizations.of(context)!.favouriteButtonTogglesByShortClickSettingSubtitle),
-      value: ref.watch(finampSettingsProvider.favouriteButtonTogglesByShortClick),
-      onChanged: (value) => FinampSetters.setFavouriteButtonTogglesByShortClick(value),
     );
   }
 }

--- a/lib/screens/accessibility_settings_screen.dart
+++ b/lib/screens/accessibility_settings_screen.dart
@@ -25,11 +25,7 @@ class _AccessibilitySettingsScreenState extends State<AccessibilitySettingsScree
         ],
       ),
       body: ListView(
-        children: const [
-          UseHighContrastColorsToggle(),
-          DisableGestureSelector(),
-          DisableVibrationSelector(),
-        ],
+        children: const [UseHighContrastColorsToggle(), DisableGestureSelector(), DisableVibrationSelector()],
       ),
     );
   }

--- a/lib/screens/accessibility_settings_screen.dart
+++ b/lib/screens/accessibility_settings_screen.dart
@@ -25,7 +25,12 @@ class _AccessibilitySettingsScreenState extends State<AccessibilitySettingsScree
         ],
       ),
       body: ListView(
-        children: const [UseHighContrastColorsToggle(), DisableGestureSelector(), DisableVibrationSelector()],
+        children: const [
+          UseHighContrastColorsToggle(),
+          DisableGestureSelector(),
+          DisableVibrationSelector(),
+          FavouriteButtonTogglesByShortClickSelector(),
+        ],
       ),
     );
   }
@@ -69,6 +74,20 @@ class DisableVibrationSelector extends ConsumerWidget {
       subtitle: Text(AppLocalizations.of(context)!.enableVibrationSubtitle),
       value: ref.watch(finampSettingsProvider.enableVibration),
       onChanged: (value) => FinampSetters.setEnableVibration(value),
+    );
+  }
+}
+
+class FavouriteButtonTogglesByShortClickSelector extends ConsumerWidget {
+  const FavouriteButtonTogglesByShortClickSelector({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return SwitchListTile.adaptive(
+      title: Text(AppLocalizations.of(context)!.favouriteButtonTogglesByShortClickSetting),
+      subtitle: Text(AppLocalizations.of(context)!.favouriteButtonTogglesByShortClickSettingSubtitle),
+      value: ref.watch(finampSettingsProvider.favouriteButtonTogglesByShortClick),
+      onChanged: (value) => FinampSetters.setFavouriteButtonTogglesByShortClick(value),
     );
   }
 }

--- a/lib/screens/interaction_settings_screen.dart
+++ b/lib/screens/interaction_settings_screen.dart
@@ -41,6 +41,7 @@ class _InteractionSettingsScreenState extends State<InteractionSettingsScreen> {
           ShowDeleteFromServerOptionToggle(),
           KeepScreenOnDropdownListTile(),
           KeepScreenOnWhilePluggedInSelector(),
+          PreferAddingToFavoritesOverPlaylistsToggle(),
         ],
       ),
     );
@@ -85,6 +86,20 @@ class ShowDeleteFromServerOptionToggle extends ConsumerWidget {
       subtitle: Text(AppLocalizations.of(context)!.allowDeleteFromServerSubtitle),
       value: ref.watch(finampSettingsProvider.allowDeleteFromServer),
       onChanged: FinampSetters.setAllowDeleteFromServer,
+    );
+  }
+}
+
+class PreferAddingToFavoritesOverPlaylistsToggle extends ConsumerWidget {
+  const PreferAddingToFavoritesOverPlaylistsToggle({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return SwitchListTile.adaptive(
+      title: Text(AppLocalizations.of(context)!.preferAddingToFavoritesOverPlaylistsTitle),
+      subtitle: Text(AppLocalizations.of(context)!.preferAddingToFavoritesOverPlaylistsSubtitle),
+      value: ref.watch(finampSettingsProvider.preferAddingToFavoritesOverPlaylists),
+      onChanged: (value) => FinampSetters.setPreferAddingToFavoritesOverPlaylists(value),
     );
   }
 }

--- a/lib/services/finamp_settings_helper.dart
+++ b/lib/services/finamp_settings_helper.dart
@@ -237,6 +237,7 @@ class FinampSettingsHelper {
     FinampSetters.setUseHighContrastColors(DefaultSettings.useHighContrastColors);
     FinampSetters.setDisableGesture(DefaultSettings.disableGesture);
     FinampSetters.setEnableVibration(DefaultSettings.enableVibration);
+    FinampSetters.setFavouriteButtonTogglesByShortClick(DefaultSettings.favouriteButtonTogglesByShortClick);
   }
 
   static void resetAllSettings() {

--- a/lib/services/finamp_settings_helper.dart
+++ b/lib/services/finamp_settings_helper.dart
@@ -220,6 +220,7 @@ class FinampSettingsHelper {
     FinampSetters.setShowFastScroller(DefaultSettings.showFastScroller);
     FinampSetters.setKeepScreenOnOption(DefaultSettings.keepScreenOnOption);
     FinampSetters.setKeepScreenOnWhilePluggedIn(DefaultSettings.keepScreenOnWhilePluggedIn);
+    FinampSetters.setPreferAddingToFavoritesOverPlaylists(DefaultSettings.preferAddingToFavoritesOverPlaylists);
 
     Hive.box<FinampSettings>("FinampSettings").put("FinampSettings", finampSettingsTemp);
   }
@@ -237,7 +238,6 @@ class FinampSettingsHelper {
     FinampSetters.setUseHighContrastColors(DefaultSettings.useHighContrastColors);
     FinampSetters.setDisableGesture(DefaultSettings.disableGesture);
     FinampSetters.setEnableVibration(DefaultSettings.enableVibration);
-    FinampSetters.setFavouriteButtonTogglesByShortClick(DefaultSettings.favouriteButtonTogglesByShortClick);
   }
 
   static void resetAllSettings() {

--- a/lib/services/finamp_settings_helper.g.dart
+++ b/lib/services/finamp_settings_helper.g.dart
@@ -1086,6 +1086,17 @@ extension FinampSetters on FinampSettingsHelper {
     ).put("FinampSettings", finampSettingsTemp);
   }
 
+  static void setFavouriteButtonTogglesByShortClick(
+    bool newFavouriteButtonTogglesByShortClick,
+  ) {
+    FinampSettings finampSettingsTemp = FinampSettingsHelper.finampSettings;
+    finampSettingsTemp.favouriteButtonTogglesByShortClick =
+        newFavouriteButtonTogglesByShortClick;
+    Hive.box<FinampSettings>(
+      "FinampSettings",
+    ).put("FinampSettings", finampSettingsTemp);
+  }
+
   static void setBufferDuration(Duration newBufferDuration) {
     FinampSettings finampSettingsTemp = FinampSettingsHelper.finampSettings;
     finampSettingsTemp.bufferDuration = newBufferDuration;
@@ -1468,6 +1479,10 @@ extension FinampSettingsProviderSelectors on StreamProvider<FinampSettings> {
       finampSettingsProvider.select((value) => value.requireValue.rpcIcon);
   ProviderListenable<bool> get autoExpandPlayerScreen => finampSettingsProvider
       .select((value) => value.requireValue.autoExpandPlayerScreen);
+  ProviderListenable<bool> get favouriteButtonTogglesByShortClick =>
+      finampSettingsProvider.select(
+        (value) => value.requireValue.favouriteButtonTogglesByShortClick,
+      );
   ProviderListenable<DownloadProfile> get downloadTranscodingProfile =>
       finampSettingsProvider.select(
         (value) => value.requireValue.downloadTranscodingProfile,

--- a/lib/services/finamp_settings_helper.g.dart
+++ b/lib/services/finamp_settings_helper.g.dart
@@ -1086,12 +1086,12 @@ extension FinampSetters on FinampSettingsHelper {
     ).put("FinampSettings", finampSettingsTemp);
   }
 
-  static void setFavouriteButtonTogglesByShortClick(
-    bool newFavouriteButtonTogglesByShortClick,
+  static void setPreferAddingToFavoritesOverPlaylists(
+    bool newPreferAddingToFavoritesOverPlaylists,
   ) {
     FinampSettings finampSettingsTemp = FinampSettingsHelper.finampSettings;
-    finampSettingsTemp.favouriteButtonTogglesByShortClick =
-        newFavouriteButtonTogglesByShortClick;
+    finampSettingsTemp.preferAddingToFavoritesOverPlaylists =
+        newPreferAddingToFavoritesOverPlaylists;
     Hive.box<FinampSettings>(
       "FinampSettings",
     ).put("FinampSettings", finampSettingsTemp);
@@ -1479,9 +1479,9 @@ extension FinampSettingsProviderSelectors on StreamProvider<FinampSettings> {
       finampSettingsProvider.select((value) => value.requireValue.rpcIcon);
   ProviderListenable<bool> get autoExpandPlayerScreen => finampSettingsProvider
       .select((value) => value.requireValue.autoExpandPlayerScreen);
-  ProviderListenable<bool> get favouriteButtonTogglesByShortClick =>
+  ProviderListenable<bool> get preferAddingToFavoritesOverPlaylists =>
       finampSettingsProvider.select(
-        (value) => value.requireValue.favouriteButtonTogglesByShortClick,
+        (value) => value.requireValue.preferAddingToFavoritesOverPlaylists,
       );
   ProviderListenable<DownloadProfile> get downloadTranscodingProfile =>
       finampSettingsProvider.select(


### PR DESCRIPTION
## Changes

Adds a simple setting:

<details>
<summary>Screenshot</summary>

<img width="588" height="889" alt="image" src="https://github.com/user-attachments/assets/dd61a42a-fe26-458c-b2e7-2a35ce46b44a" />

</details>

Allows to toggle between hold-to-like and press-to-like, as well as press-to-open-playlists vs hold-to-open-playlists.

Quickly tested on Linux, nothing should break though

## Todo before merging
<!-- Add custom todos if deemed necessary to give others an overview on how far this PR is progressing -->

- [x Translations
- [x] Reset Settings

## Related Issues

Couldn't find issue but I remember that this was requested