### PR TITLE
[Redesign] Track list item rebuild tweaks.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,9 @@ name: Build
 on:
   pull_request:
   push:
+    branches:
+      - main
+      - redesign
 
 # Due to a flutter bug, flutter build is not generating localizations
 # workaround by always running flutter pub get immediately before building,

--- a/devtools_options.yaml
+++ b/devtools_options.yaml
@@ -1,1 +1,2 @@
 extensions:
+  - provider: true

--- a/l10n.yaml
+++ b/l10n.yaml
@@ -1,4 +1,3 @@
-synthetic-package: false
 arb-dir: lib/l10n
 template-arb-file: app_en.arb
 output-localization-file: app_localizations.dart

--- a/lib/components/AddToPlaylistScreen/add_to_playlist_list.dart
+++ b/lib/components/AddToPlaylistScreen/add_to_playlist_list.dart
@@ -14,11 +14,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
 import 'package:get_it/get_it.dart';
 
+import '../../menus/playlist_actions_menu.dart';
 import '../../models/jellyfin_models.dart';
 import '../confirmation_prompt_dialog.dart';
 import '../global_snackbar.dart';
 import 'new_playlist_dialog.dart';
-import '../../menus/playlist_actions_menu.dart';
 
 class AddToPlaylistList extends StatefulWidget {
   const AddToPlaylistList({super.key, required this.itemsToAdd, required this.playlistsFuture});
@@ -278,9 +278,7 @@ class _AddToPlaylistTileState extends ConsumerState<AddToPlaylistTile> {
               builder: (context) => ConfirmationPromptDialog(
                 promptText: promptText,
                 confirmButtonText: AppLocalizations.of(context)!.addButtonLabel,
-                abortButtonText: MaterialLocalizations.of(context).cancelButtonLabel,
                 onConfirmed: () => confirmed = true,
-                onAborted: () {},
               ),
             );
             if (!confirmed || !context.mounted) return false;

--- a/lib/components/AlbumScreen/album_screen_content.dart
+++ b/lib/components/AlbumScreen/album_screen_content.dart
@@ -259,7 +259,7 @@ class _AlbumScreenContentState extends ConsumerState<AlbumScreenContent> {
             ),
             SliverToBoxAdapter(child: SizedBox(height: 16.0)),
           ]
-        else if (!isLoading && displayChildren.isNotEmpty)
+        else if (!isLoading)
           TracksSliverList(
             childrenForList: displayChildren,
             childrenForQueue: queueChildren,
@@ -312,13 +312,15 @@ class _TracksSliverListState extends ConsumerState<TracksSliverList> {
   @override
   Widget build(BuildContext context) {
     if (widget.childrenForList.isEmpty) {
-      return SliverToBoxAdapter(
-        child: Padding(
-          padding: const EdgeInsets.symmetric(vertical: 16.0, horizontal: 32.0),
-          child: Text(
-            AppLocalizations.of(context)!.emptyTopTracksList,
-            style: Theme.of(context).textTheme.bodyMedium,
-            textAlign: TextAlign.center,
+      return SliverFillRemaining(
+        child: Center(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(vertical: 16.0, horizontal: 32.0),
+            child: Text(
+              AppLocalizations.of(context)!.emptyAlbum,
+              style: Theme.of(context).textTheme.bodyLarge,
+              textAlign: TextAlign.center,
+            ),
           ),
         ),
       );

--- a/lib/components/AlbumScreen/album_screen_content_flexible_space_bar.dart
+++ b/lib/components/AlbumScreen/album_screen_content_flexible_space_bar.dart
@@ -121,14 +121,14 @@ class AlbumScreenContentFlexibleSpaceBar extends StatelessWidget {
                         icon: TablerIcons.player_play,
                         onPressed: () => playAlbum(),
                         // set the minimum width as 25% of the screen width,
-                        minWidth: MediaQuery.of(context).size.width * 0.25,
+                        minWidth: MediaQuery.widthOf(context) * 0.25,
                       ),
                       CTAMedium(
                         text: AppLocalizations.of(context)!.shuffleButtonLabel,
                         icon: TablerIcons.arrows_shuffle,
                         onPressed: () => shuffleAlbum(),
                         // set the minimum width as 25% of the screen width,
-                        minWidth: MediaQuery.of(context).size.width * 0.25,
+                        minWidth: MediaQuery.widthOf(context) * 0.25,
                       ),
                       OverflowMenuButton(
                         onPressed: () => isPlaylist

--- a/lib/components/AlbumScreen/download_button.dart
+++ b/lib/components/AlbumScreen/download_button.dart
@@ -80,9 +80,7 @@ class DownloadButton extends ConsumerWidget {
               builder: (context) => ConfirmationPromptDialog(
                 promptText: AppLocalizations.of(context)!.downloadLibraryPrompt(item.name),
                 confirmButtonText: AppLocalizations.of(context)!.addButtonLabel,
-                abortButtonText: MaterialLocalizations.of(context).cancelButtonLabel,
                 onConfirmed: () => DownloadDialog.show(context, item, viewId),
-                onAborted: () {},
               ),
             );
           } else {

--- a/lib/components/AlbumScreen/downloaded_indicator.dart
+++ b/lib/components/AlbumScreen/downloaded_indicator.dart
@@ -15,14 +15,19 @@ class DownloadedIndicator extends ConsumerWidget {
 
   bool isVisible(WidgetRef ref) {
     final downloadsService = GetIt.instance<DownloadsService>();
-    final status = ref.watch(downloadsService.stateProvider(item));
-    return switch (status) {
-      AsyncData(:final value) => switch (value) {
-        null || DownloadItemState.notDownloaded => false,
-        _ => true,
-      },
-      _ => false,
-    };
+    return ref.watch(
+      downloadsService
+          .stateProvider(item)
+          .select(
+            (status) => switch (status) {
+              AsyncData(:final value) => switch (value) {
+                null || DownloadItemState.notDownloaded => false,
+                _ => true,
+              },
+              _ => false,
+            },
+          ),
+    );
   }
 
   @override

--- a/lib/components/AlbumScreen/preset_chip.dart
+++ b/lib/components/AlbumScreen/preset_chip.dart
@@ -59,7 +59,7 @@ class _PresetChipsState extends State<PresetChips> {
     if (_controller == null) {
       _controller = ScrollController(initialScrollOffset: offset);
     } else {
-      if (MediaQuery.of(context).disableAnimations) {
+      if (MediaQuery.disableAnimationsOf(context)) {
         _controller!.jumpTo(offset);
       } else {
         _controller!.animateTo(offset, duration: const Duration(milliseconds: 350), curve: Curves.easeOutCubic);

--- a/lib/components/AlbumScreen/track_list_tile.dart
+++ b/lib/components/AlbumScreen/track_list_tile.dart
@@ -386,6 +386,8 @@ class QueueListTile extends StatelessWidget {
   final void Function(bool playable) onTap;
   final VoidCallback? onRemoveFromList;
 
+  static const double height = 70.0;
+
   const QueueListTile({
     super.key,
     required this.item,

--- a/lib/components/AlbumScreen/track_list_tile.dart
+++ b/lib/components/AlbumScreen/track_list_tile.dart
@@ -25,6 +25,7 @@ import '../../services/downloads_service.dart';
 import '../../services/finamp_settings_helper.dart';
 import '../../services/queue_service.dart';
 import '../../services/theme_provider.dart';
+import '../album_image.dart';
 import '../print_duration.dart';
 import 'downloaded_indicator.dart';
 
@@ -703,7 +704,7 @@ class TrackListItemTile extends ConsumerWidget {
               ),
             ),
           ),
-        //if (showCover) AlbumImage(item: baseItem, borderRadius: BorderRadius.circular(albumCoverCornerRadius)),
+        if (showCover) AlbumImage(item: baseItem, borderRadius: BorderRadius.circular(albumCoverCornerRadius)),
       ],
     );
     final tileTitle = ConstrainedBox(
@@ -885,7 +886,7 @@ class TrackListItemTile extends ConsumerWidget {
       ),
     );
     final listTile = OverflowBuilder(
-      hasOverflowed: (BoxConstraints constraints) => constraints.maxWidth > 800,
+      hasOverflowed: (BoxConstraints constraints) => constraints.maxWidth > 750,
       builder: (context, showOverflowMenu) {
         return ListTile(
           visualDensity: const VisualDensity(horizontal: 0.0, vertical: 0.5),

--- a/lib/components/AlbumScreen/track_list_tile.dart
+++ b/lib/components/AlbumScreen/track_list_tile.dart
@@ -25,7 +25,6 @@ import '../../services/downloads_service.dart';
 import '../../services/finamp_settings_helper.dart';
 import '../../services/queue_service.dart';
 import '../../services/theme_provider.dart';
-import '../album_image.dart';
 import '../print_duration.dart';
 import 'downloaded_indicator.dart';
 
@@ -680,6 +679,211 @@ class TrackListItemTile extends ConsumerWidget {
 
     final showPlaybackProgress = !highlightCurrentTrack && playbackProgress != null && playbackProgress! < 0.99;
 
+    final tileLead = Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (showIndex && actualIndex != null)
+          Padding(
+            padding: showCover
+                ? const EdgeInsets.only(left: 2.0, right: 8.0)
+                : const EdgeInsets.only(left: 6.0, right: 0.0),
+            child: Container(
+              constraints: const BoxConstraints(minWidth: 22.0),
+              child: Text(
+                actualIndex.toString(),
+                textAlign: TextAlign.center,
+                maxLines: 1,
+                softWrap: false,
+                overflow: TextOverflow.clip,
+                style: TextStyle(
+                  color: Theme.of(context).textTheme.bodyMedium?.color,
+                  fontSize: 16,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+            ),
+          ),
+        //if (showCover) AlbumImage(item: baseItem, borderRadius: BorderRadius.circular(albumCoverCornerRadius)),
+      ],
+    );
+    final tileTitle = ConstrainedBox(
+      constraints: const BoxConstraints(maxHeight: defaultTileHeight),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+        mainAxisSize: MainAxisSize.max,
+        children: [
+          Flexible(
+            fit: FlexFit.loose,
+            flex: 3,
+            child: Text(
+              baseItem.name ?? AppLocalizations.of(context)!.unknownName,
+              style: TextStyle(
+                color: Theme.of(context).textTheme.bodyLarge!.color,
+                fontSize: 15.5,
+                fontWeight: FontWeight.w500,
+                height: 1.1,
+              ),
+              overflow: TextOverflow.ellipsis,
+              maxLines: 2,
+            ),
+          ),
+          Flexible(
+            fit: FlexFit.loose,
+            flex: 2,
+            child: Text.rich(
+              overflow: TextOverflow.clip,
+              softWrap: false,
+              maxLines: 1,
+              TextSpan(
+                children: [
+                  WidgetSpan(
+                    child: Padding(
+                      padding: const EdgeInsets.only(right: 2.0),
+                      child: Transform.translate(
+                        offset: isOnDesktop ? Offset(-1.5, 1.7) : Offset(-1.5, 0.4),
+                        child: downloadedIndicator,
+                      ),
+                    ),
+                    alignment: PlaceholderAlignment.baseline,
+                    baseline: TextBaseline.alphabetic,
+                  ),
+                  if (downloadedIndicator.isVisible(ref) && (baseItem.hasLyrics == null || baseItem.hasLyrics == false))
+                    const WidgetSpan(child: SizedBox(width: 4.5)),
+                  if (baseItem.hasLyrics ?? false)
+                    WidgetSpan(
+                      child: Padding(
+                        padding: const EdgeInsets.only(right: 2.0),
+                        child: Transform.translate(
+                          offset: isOnDesktop ? Offset(-1.5, 1.7) : Offset(-1.5, 0.4),
+                          child: Icon(
+                            TablerIcons.microphone_2,
+                            size: Theme.of(context).textTheme.bodyMedium!.fontSize! + 1,
+                          ),
+                        ),
+                      ),
+                      alignment: PlaceholderAlignment.baseline,
+                      baseline: TextBaseline.alphabetic,
+                    ),
+                  if (baseItem.hasLyrics ?? false) const WidgetSpan(child: SizedBox(width: 5)),
+                  if (addSpaceAfterSpecialIcons) const WidgetSpan(child: SizedBox(width: 5)),
+                  if (showPlayCount)
+                    TextSpan(
+                      text: AppLocalizations.of(context)!.playCountValue(baseItem.userData?.playCount ?? 0),
+                      style: TextStyle(
+                        color: Theme.of(context).textTheme.bodyMedium!.color!.withOpacity(0.75),
+                        fontSize: 13,
+                        fontWeight: FontWeight.w400,
+                      ),
+                    ),
+                  if (showPlayCount) const WidgetSpan(child: SizedBox(width: 10.0)),
+                  if (showDateLastPlayed)
+                    WidgetSpan(
+                      child: Padding(
+                        padding: const EdgeInsets.only(right: 2.0),
+                        child: Transform.translate(
+                          offset: isOnDesktop ? Offset(-1.5, 1.8) : Offset(-1.5, 0.3),
+                          child: Icon(TablerIcons.clock, size: Theme.of(context).textTheme.bodyMedium!.fontSize! + 1),
+                        ),
+                      ),
+                      alignment: PlaceholderAlignment.baseline,
+                      baseline: TextBaseline.alphabetic,
+                    ),
+                  if (showDateLastPlayed)
+                    WidgetSpan(
+                      alignment: PlaceholderAlignment.baseline,
+                      baseline: TextBaseline.alphabetic,
+                      child: RelativeDateTimeTextFromString(
+                        dateString: baseItem.userData?.lastPlayedDate,
+                        fallback: AppLocalizations.of(context)!.noDateLastPlayed,
+                        style: TextStyle(
+                          color: Theme.of(context).textTheme.bodyMedium!.color!.withOpacity(0.75),
+                          fontSize: 13,
+                          fontWeight: FontWeight.w400,
+                        ),
+                        disableTextScaling: true,
+                      ),
+                    ),
+                  if (showDateLastPlayed) const WidgetSpan(child: SizedBox(width: 10.0)),
+                  if (showReleaseDate)
+                    TextSpan(
+                      text: (ReleaseDateHelper.autoFormat(baseItem) ?? AppLocalizations.of(context)!.noReleaseDate),
+                      style: TextStyle(
+                        color: Theme.of(context).textTheme.bodyMedium!.color!.withOpacity(0.75),
+                        fontSize: 13,
+                        fontWeight: FontWeight.w400,
+                      ),
+                    ),
+                  if (showReleaseDate) const WidgetSpan(child: SizedBox(width: 10.0)),
+                  if (showDateAdded)
+                    WidgetSpan(
+                      child: Padding(
+                        padding: const EdgeInsets.only(right: 3),
+                        child: Transform.translate(
+                          offset: isOnDesktop ? Offset(-1.5, 1.28) : Offset(-1.5, 0),
+                          child: Icon(
+                            TablerIcons.calendar_plus,
+                            size: Theme.of(context).textTheme.bodyMedium!.fontSize! + 1,
+                            color: Theme.of(context).textTheme.bodyMedium!.color!.withOpacity(0.75),
+                          ),
+                        ),
+                      ),
+                      alignment: PlaceholderAlignment.baseline,
+                      baseline: TextBaseline.alphabetic,
+                    ),
+                  if (showDateAdded)
+                    WidgetSpan(
+                      alignment: PlaceholderAlignment.baseline,
+                      baseline: TextBaseline.alphabetic,
+                      child: RelativeDateTimeTextFromString(
+                        dateString: baseItem.dateCreated,
+                        fallback: AppLocalizations.of(context)!.noDateAdded,
+                        style: TextStyle(
+                          color: Theme.of(context).textTheme.bodyMedium!.color!.withOpacity(0.75),
+                          fontSize: 13,
+                          fontWeight: FontWeight.w400,
+                        ),
+                        disableTextScaling: true,
+                      ),
+                    ),
+                  if (showDateAdded) const WidgetSpan(child: SizedBox(width: 10.0)),
+                  if (showArtists)
+                    TextSpan(
+                      text: artistsString,
+                      style: TextStyle(
+                        color: Theme.of(context).textTheme.bodyMedium!.color!.withOpacity(0.75),
+                        fontSize: 13,
+                        fontWeight: FontWeight.w400,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                  if (!secondRowNeeded)
+                    // show the artist anyway if nothing else is shown
+                    TextSpan(
+                      text: artistsString,
+                      style: TextStyle(
+                        color: Theme.of(context).textTheme.bodyMedium!.color!.withOpacity(0.75),
+                        fontSize: 13,
+                        fontWeight: FontWeight.w300,
+                      ),
+                    ),
+                  if (showArtists) const WidgetSpan(child: SizedBox(width: 10.0)),
+                  if (showAlbum)
+                    TextSpan(
+                      text: baseItem.album,
+                      style: TextStyle(
+                        color: Theme.of(context).textTheme.bodyMedium!.color!.withOpacity(0.6),
+                        fontSize: 13,
+                        fontWeight: FontWeight.w300,
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
     final listTile = OverflowBuilder(
       hasOverflowed: (BoxConstraints constraints) => constraints.maxWidth > 800,
       builder: (context, showOverflowMenu) {
@@ -690,216 +894,8 @@ class TrackListItemTile extends ConsumerWidget {
           contentPadding: const EdgeInsets.symmetric(vertical: 0.0, horizontal: 0.0),
           shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(albumCoverCornerRadius)),
           tileColor: highlightTrack ? Theme.of(context).colorScheme.surfaceContainer : Colors.transparent,
-          leading: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              if (showIndex && actualIndex != null)
-                Padding(
-                  padding: showCover
-                      ? const EdgeInsets.only(left: 2.0, right: 8.0)
-                      : const EdgeInsets.only(left: 6.0, right: 0.0),
-                  child: Container(
-                    constraints: const BoxConstraints(minWidth: 22.0),
-                    child: Text(
-                      actualIndex.toString(),
-                      textAlign: TextAlign.center,
-                      maxLines: 1,
-                      softWrap: false,
-                      overflow: TextOverflow.clip,
-                      style: TextStyle(
-                        color: Theme.of(context).textTheme.bodyMedium?.color,
-                        fontSize: 16,
-                        fontWeight: FontWeight.w500,
-                      ),
-                    ),
-                  ),
-                ),
-              if (showCover) AlbumImage(item: baseItem, borderRadius: BorderRadius.circular(albumCoverCornerRadius)),
-            ],
-          ),
-          title: ConstrainedBox(
-            constraints: const BoxConstraints(maxHeight: defaultTileHeight),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-              mainAxisSize: MainAxisSize.max,
-              children: [
-                Flexible(
-                  fit: FlexFit.loose,
-                  flex: 3,
-                  child: Text(
-                    baseItem.name ?? AppLocalizations.of(context)!.unknownName,
-                    style: TextStyle(
-                      color: Theme.of(context).textTheme.bodyLarge!.color,
-                      fontSize: 15.5,
-                      fontWeight: FontWeight.w500,
-                      height: 1.1,
-                    ),
-                    overflow: TextOverflow.ellipsis,
-                    maxLines: 2,
-                  ),
-                ),
-                Flexible(
-                  fit: FlexFit.loose,
-                  flex: 2,
-                  child: Text.rich(
-                    overflow: TextOverflow.clip,
-                    softWrap: false,
-                    maxLines: 1,
-                    TextSpan(
-                      children: [
-                        WidgetSpan(
-                          child: Padding(
-                            padding: const EdgeInsets.only(right: 2.0),
-                            child: Transform.translate(
-                              offset: isOnDesktop ? Offset(-1.5, 1.7) : Offset(-1.5, 0.4),
-                              child: downloadedIndicator,
-                            ),
-                          ),
-                          alignment: PlaceholderAlignment.baseline,
-                          baseline: TextBaseline.alphabetic,
-                        ),
-                        if (downloadedIndicator.isVisible(ref) &&
-                            (baseItem.hasLyrics == null || baseItem.hasLyrics == false))
-                          const WidgetSpan(child: SizedBox(width: 4.5)),
-                        if (baseItem.hasLyrics ?? false)
-                          WidgetSpan(
-                            child: Padding(
-                              padding: const EdgeInsets.only(right: 2.0),
-                              child: Transform.translate(
-                                offset: isOnDesktop ? Offset(-1.5, 1.7) : Offset(-1.5, 0.4),
-                                child: Icon(
-                                  TablerIcons.microphone_2,
-                                  size: Theme.of(context).textTheme.bodyMedium!.fontSize! + 1,
-                                ),
-                              ),
-                            ),
-                            alignment: PlaceholderAlignment.baseline,
-                            baseline: TextBaseline.alphabetic,
-                          ),
-                        if (baseItem.hasLyrics ?? false) const WidgetSpan(child: SizedBox(width: 5)),
-                        if (addSpaceAfterSpecialIcons) const WidgetSpan(child: SizedBox(width: 5)),
-                        if (showPlayCount)
-                          TextSpan(
-                            text: AppLocalizations.of(context)!.playCountValue(baseItem.userData?.playCount ?? 0),
-                            style: TextStyle(
-                              color: Theme.of(context).textTheme.bodyMedium!.color!.withOpacity(0.75),
-                              fontSize: 13,
-                              fontWeight: FontWeight.w400,
-                            ),
-                          ),
-                        if (showPlayCount) const WidgetSpan(child: SizedBox(width: 10.0)),
-                        if (showDateLastPlayed)
-                          WidgetSpan(
-                            child: Padding(
-                              padding: const EdgeInsets.only(right: 2.0),
-                              child: Transform.translate(
-                                offset: isOnDesktop ? Offset(-1.5, 1.8) : Offset(-1.5, 0.3),
-                                child: Icon(
-                                  TablerIcons.clock,
-                                  size: Theme.of(context).textTheme.bodyMedium!.fontSize! + 1,
-                                ),
-                              ),
-                            ),
-                            alignment: PlaceholderAlignment.baseline,
-                            baseline: TextBaseline.alphabetic,
-                          ),
-                        if (showDateLastPlayed)
-                          WidgetSpan(
-                            alignment: PlaceholderAlignment.baseline,
-                            baseline: TextBaseline.alphabetic,
-                            child: RelativeDateTimeTextFromString(
-                              dateString: baseItem.userData?.lastPlayedDate,
-                              fallback: AppLocalizations.of(context)!.noDateLastPlayed,
-                              style: TextStyle(
-                                color: Theme.of(context).textTheme.bodyMedium!.color!.withOpacity(0.75),
-                                fontSize: 13,
-                                fontWeight: FontWeight.w400,
-                              ),
-                              disableTextScaling: true,
-                            ),
-                          ),
-                        if (showDateLastPlayed) const WidgetSpan(child: SizedBox(width: 10.0)),
-                        if (showReleaseDate)
-                          TextSpan(
-                            text:
-                                (ReleaseDateHelper.autoFormat(baseItem) ?? AppLocalizations.of(context)!.noReleaseDate),
-                            style: TextStyle(
-                              color: Theme.of(context).textTheme.bodyMedium!.color!.withOpacity(0.75),
-                              fontSize: 13,
-                              fontWeight: FontWeight.w400,
-                            ),
-                          ),
-                        if (showReleaseDate) const WidgetSpan(child: SizedBox(width: 10.0)),
-                        if (showDateAdded)
-                          WidgetSpan(
-                            child: Padding(
-                              padding: const EdgeInsets.only(right: 3),
-                              child: Transform.translate(
-                                offset: isOnDesktop ? Offset(-1.5, 1.28) : Offset(-1.5, 0),
-                                child: Icon(
-                                  TablerIcons.calendar_plus,
-                                  size: Theme.of(context).textTheme.bodyMedium!.fontSize! + 1,
-                                  color: Theme.of(context).textTheme.bodyMedium!.color!.withOpacity(0.75),
-                                ),
-                              ),
-                            ),
-                            alignment: PlaceholderAlignment.baseline,
-                            baseline: TextBaseline.alphabetic,
-                          ),
-                        if (showDateAdded)
-                          WidgetSpan(
-                            alignment: PlaceholderAlignment.baseline,
-                            baseline: TextBaseline.alphabetic,
-                            child: RelativeDateTimeTextFromString(
-                              dateString: baseItem.dateCreated,
-                              fallback: AppLocalizations.of(context)!.noDateAdded,
-                              style: TextStyle(
-                                color: Theme.of(context).textTheme.bodyMedium!.color!.withOpacity(0.75),
-                                fontSize: 13,
-                                fontWeight: FontWeight.w400,
-                              ),
-                              disableTextScaling: true,
-                            ),
-                          ),
-                        if (showDateAdded) const WidgetSpan(child: SizedBox(width: 10.0)),
-                        if (showArtists)
-                          TextSpan(
-                            text: artistsString,
-                            style: TextStyle(
-                              color: Theme.of(context).textTheme.bodyMedium!.color!.withOpacity(0.75),
-                              fontSize: 13,
-                              fontWeight: FontWeight.w400,
-                              overflow: TextOverflow.ellipsis,
-                            ),
-                          ),
-                        if (!secondRowNeeded)
-                          // show the artist anyway if nothing else is shown
-                          TextSpan(
-                            text: artistsString,
-                            style: TextStyle(
-                              color: Theme.of(context).textTheme.bodyMedium!.color!.withOpacity(0.75),
-                              fontSize: 13,
-                              fontWeight: FontWeight.w300,
-                            ),
-                          ),
-                        if (showArtists) const WidgetSpan(child: SizedBox(width: 10.0)),
-                        if (showAlbum)
-                          TextSpan(
-                            text: baseItem.album,
-                            style: TextStyle(
-                              color: Theme.of(context).textTheme.bodyMedium!.color!.withOpacity(0.6),
-                              fontSize: 13,
-                              fontWeight: FontWeight.w300,
-                            ),
-                          ),
-                      ],
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          ),
+          leading: tileLead,
+          title: tileTitle,
           trailing: Padding(
             padding: const EdgeInsets.only(right: 4.0),
             child: Row(

--- a/lib/components/AlbumScreen/track_list_tile.dart
+++ b/lib/components/AlbumScreen/track_list_tile.dart
@@ -680,262 +680,274 @@ class TrackListItemTile extends ConsumerWidget {
 
     final showPlaybackProgress = !highlightCurrentTrack && playbackProgress != null && playbackProgress! < 0.99;
 
-    final listTile = ListTile(
-      visualDensity: const VisualDensity(horizontal: 0.0, vertical: 0.5),
-      minVerticalPadding: 0.0,
-      horizontalTitleGap: defaultTitleGap,
-      contentPadding: const EdgeInsets.symmetric(vertical: 0.0, horizontal: 0.0),
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(albumCoverCornerRadius)),
-      tileColor: highlightTrack ? Theme.of(context).colorScheme.surfaceContainer : Colors.transparent,
-      leading: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          if (showIndex && actualIndex != null)
-            Padding(
-              padding: showCover
-                  ? const EdgeInsets.only(left: 2.0, right: 8.0)
-                  : const EdgeInsets.only(left: 6.0, right: 0.0),
-              child: Container(
-                constraints: const BoxConstraints(minWidth: 22.0),
-                child: Text(
-                  actualIndex.toString(),
-                  textAlign: TextAlign.center,
-                  maxLines: 1,
-                  softWrap: false,
-                  overflow: TextOverflow.clip,
-                  style: TextStyle(
-                    color: Theme.of(context).textTheme.bodyMedium?.color,
-                    fontSize: 16,
-                    fontWeight: FontWeight.w500,
-                  ),
-                ),
-              ),
-            ),
-          if (showCover) AlbumImage(item: baseItem, borderRadius: BorderRadius.circular(albumCoverCornerRadius)),
-        ],
-      ),
-      title: ConstrainedBox(
-        constraints: const BoxConstraints(maxHeight: defaultTileHeight),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          mainAxisSize: MainAxisSize.max,
-          children: [
-            Flexible(
-              fit: FlexFit.loose,
-              flex: 3,
-              child: Text(
-                baseItem.name ?? AppLocalizations.of(context)!.unknownName,
-                style: TextStyle(
-                  color: Theme.of(context).textTheme.bodyLarge!.color,
-                  fontSize: 15.5,
-                  fontWeight: FontWeight.w500,
-                  height: 1.1,
-                ),
-                overflow: TextOverflow.ellipsis,
-                maxLines: 2,
-              ),
-            ),
-            Flexible(
-              fit: FlexFit.loose,
-              flex: 2,
-              child: Text.rich(
-                overflow: TextOverflow.clip,
-                softWrap: false,
-                maxLines: 1,
-                TextSpan(
-                  children: [
-                    WidgetSpan(
-                      child: Padding(
-                        padding: const EdgeInsets.only(right: 2.0),
-                        child: Transform.translate(
-                          offset: isOnDesktop ? Offset(-1.5, 1.7) : Offset(-1.5, 0.4),
-                          child: downloadedIndicator,
-                        ),
+    final listTile = OverflowBuilder(
+      hasOverflowed: (BoxConstraints constraints) => constraints.maxWidth > 800,
+      builder: (context, showOverflowMenu) {
+        return ListTile(
+          visualDensity: const VisualDensity(horizontal: 0.0, vertical: 0.5),
+          minVerticalPadding: 0.0,
+          horizontalTitleGap: defaultTitleGap,
+          contentPadding: const EdgeInsets.symmetric(vertical: 0.0, horizontal: 0.0),
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(albumCoverCornerRadius)),
+          tileColor: highlightTrack ? Theme.of(context).colorScheme.surfaceContainer : Colors.transparent,
+          leading: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (showIndex && actualIndex != null)
+                Padding(
+                  padding: showCover
+                      ? const EdgeInsets.only(left: 2.0, right: 8.0)
+                      : const EdgeInsets.only(left: 6.0, right: 0.0),
+                  child: Container(
+                    constraints: const BoxConstraints(minWidth: 22.0),
+                    child: Text(
+                      actualIndex.toString(),
+                      textAlign: TextAlign.center,
+                      maxLines: 1,
+                      softWrap: false,
+                      overflow: TextOverflow.clip,
+                      style: TextStyle(
+                        color: Theme.of(context).textTheme.bodyMedium?.color,
+                        fontSize: 16,
+                        fontWeight: FontWeight.w500,
                       ),
-                      alignment: PlaceholderAlignment.baseline,
-                      baseline: TextBaseline.alphabetic,
                     ),
-                    if (downloadedIndicator.isVisible(ref) &&
-                        (baseItem.hasLyrics == null || baseItem.hasLyrics == false))
-                      const WidgetSpan(child: SizedBox(width: 4.5)),
-                    if (baseItem.hasLyrics ?? false)
-                      WidgetSpan(
-                        child: Padding(
-                          padding: const EdgeInsets.only(right: 2.0),
-                          child: Transform.translate(
-                            offset: isOnDesktop ? Offset(-1.5, 1.7) : Offset(-1.5, 0.4),
-                            child: Icon(
-                              TablerIcons.microphone_2,
-                              size: Theme.of(context).textTheme.bodyMedium!.fontSize! + 1,
-                            ),
-                          ),
-                        ),
-                        alignment: PlaceholderAlignment.baseline,
-                        baseline: TextBaseline.alphabetic,
-                      ),
-                    if (baseItem.hasLyrics ?? false) const WidgetSpan(child: SizedBox(width: 5)),
-                    if (addSpaceAfterSpecialIcons) const WidgetSpan(child: SizedBox(width: 5)),
-                    if (showPlayCount)
-                      TextSpan(
-                        text: AppLocalizations.of(context)!.playCountValue(baseItem.userData?.playCount ?? 0),
-                        style: TextStyle(
-                          color: Theme.of(context).textTheme.bodyMedium!.color!.withOpacity(0.75),
-                          fontSize: 13,
-                          fontWeight: FontWeight.w400,
-                        ),
-                      ),
-                    if (showPlayCount) const WidgetSpan(child: SizedBox(width: 10.0)),
-                    if (showDateLastPlayed)
-                      WidgetSpan(
-                        child: Padding(
-                          padding: const EdgeInsets.only(right: 2.0),
-                          child: Transform.translate(
-                            offset: isOnDesktop ? Offset(-1.5, 1.8) : Offset(-1.5, 0.3),
-                            child: Icon(TablerIcons.clock, size: Theme.of(context).textTheme.bodyMedium!.fontSize! + 1),
-                          ),
-                        ),
-                        alignment: PlaceholderAlignment.baseline,
-                        baseline: TextBaseline.alphabetic,
-                      ),
-                    if (showDateLastPlayed)
-                      WidgetSpan(
-                        alignment: PlaceholderAlignment.baseline,
-                        baseline: TextBaseline.alphabetic,
-                        child: RelativeDateTimeTextFromString(
-                          dateString: baseItem.userData?.lastPlayedDate,
-                          fallback: AppLocalizations.of(context)!.noDateLastPlayed,
-                          style: TextStyle(
-                            color: Theme.of(context).textTheme.bodyMedium!.color!.withOpacity(0.75),
-                            fontSize: 13,
-                            fontWeight: FontWeight.w400,
-                          ),
-                          disableTextScaling: true,
-                        ),
-                      ),
-                    if (showDateLastPlayed) const WidgetSpan(child: SizedBox(width: 10.0)),
-                    if (showReleaseDate)
-                      TextSpan(
-                        text: (ReleaseDateHelper.autoFormat(baseItem) ?? AppLocalizations.of(context)!.noReleaseDate),
-                        style: TextStyle(
-                          color: Theme.of(context).textTheme.bodyMedium!.color!.withOpacity(0.75),
-                          fontSize: 13,
-                          fontWeight: FontWeight.w400,
-                        ),
-                      ),
-                    if (showReleaseDate) const WidgetSpan(child: SizedBox(width: 10.0)),
-                    if (showDateAdded)
-                      WidgetSpan(
-                        child: Padding(
-                          padding: const EdgeInsets.only(right: 3),
-                          child: Transform.translate(
-                            offset: isOnDesktop ? Offset(-1.5, 1.28) : Offset(-1.5, 0),
-                            child: Icon(
-                              TablerIcons.calendar_plus,
-                              size: Theme.of(context).textTheme.bodyMedium!.fontSize! + 1,
-                              color: Theme.of(context).textTheme.bodyMedium!.color!.withOpacity(0.75),
-                            ),
-                          ),
-                        ),
-                        alignment: PlaceholderAlignment.baseline,
-                        baseline: TextBaseline.alphabetic,
-                      ),
-                    if (showDateAdded)
-                      WidgetSpan(
-                        alignment: PlaceholderAlignment.baseline,
-                        baseline: TextBaseline.alphabetic,
-                        child: RelativeDateTimeTextFromString(
-                          dateString: baseItem.dateCreated,
-                          fallback: AppLocalizations.of(context)!.noDateAdded,
-                          style: TextStyle(
-                            color: Theme.of(context).textTheme.bodyMedium!.color!.withOpacity(0.75),
-                            fontSize: 13,
-                            fontWeight: FontWeight.w400,
-                          ),
-                          disableTextScaling: true,
-                        ),
-                      ),
-                    if (showDateAdded) const WidgetSpan(child: SizedBox(width: 10.0)),
-                    if (showArtists)
-                      TextSpan(
-                        text: artistsString,
-                        style: TextStyle(
-                          color: Theme.of(context).textTheme.bodyMedium!.color!.withOpacity(0.75),
-                          fontSize: 13,
-                          fontWeight: FontWeight.w400,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                      ),
-                    if (!secondRowNeeded)
-                      // show the artist anyway if nothing else is shown
-                      TextSpan(
-                        text: artistsString,
-                        style: TextStyle(
-                          color: Theme.of(context).textTheme.bodyMedium!.color!.withOpacity(0.75),
-                          fontSize: 13,
-                          fontWeight: FontWeight.w300,
-                        ),
-                      ),
-                    if (showArtists) const WidgetSpan(child: SizedBox(width: 10.0)),
-                    if (showAlbum)
-                      TextSpan(
-                        text: baseItem.album,
-                        style: TextStyle(
-                          color: Theme.of(context).textTheme.bodyMedium!.color!.withOpacity(0.6),
-                          fontSize: 13,
-                          fontWeight: FontWeight.w300,
-                        ),
-                      ),
-                  ],
-                ),
-              ),
-            ),
-          ],
-        ),
-      ),
-      trailing: Container(
-        margin: const EdgeInsets.only(right: 0.0),
-        padding: const EdgeInsets.only(right: 4.0),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          mainAxisAlignment: MainAxisAlignment.end,
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
-            Text(
-              printDuration(baseItem.runTimeTicksDuration(), leadingZeroes: false),
-              semanticsLabel: durationLabelString,
-              textAlign: TextAlign.end,
-              style: TextStyle(color: Theme.of(context).textTheme.bodySmall?.color),
-            ),
-            Semantics(
-              excludeSemantics: true,
-              child: AddToPlaylistButton(item: baseItem, size: 24, visualDensity: const VisualDensity(horizontal: -4)),
-            ),
-            if (Platform.isWindows || Platform.isLinux || Platform.isMacOS)
-              OverflowMenuButton(
-                onPressed: () => showModalTrackMenu(context: context, item: baseItem),
-                color: Theme.of(context).textTheme.bodyMedium?.color ?? Colors.white,
-                label: AppLocalizations.of(context)!.menuButtonLabel,
-              ),
-            if (allowReorder)
-              ReorderableDragStartListener(
-                index:
-                    listIndex ??
-                    0, // will briefly use 0 as index, but should resolve quickly enough for user not to notice
-                child: Padding(
-                  padding: const EdgeInsets.only(left: 6.0),
-                  child: IconButtonWithSemantics(
-                    icon: TablerIcons.menu_order,
-                    onPressed: null,
-                    label: AppLocalizations.of(context)!.dragToReorder,
-                    color: Theme.of(context).textTheme.bodyMedium?.color ?? Colors.white,
                   ),
                 ),
-              ),
-          ],
-        ),
-      ),
-      onTap: onTap,
+              if (showCover) AlbumImage(item: baseItem, borderRadius: BorderRadius.circular(albumCoverCornerRadius)),
+            ],
+          ),
+          title: ConstrainedBox(
+            constraints: const BoxConstraints(maxHeight: defaultTileHeight),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              mainAxisSize: MainAxisSize.max,
+              children: [
+                Flexible(
+                  fit: FlexFit.loose,
+                  flex: 3,
+                  child: Text(
+                    baseItem.name ?? AppLocalizations.of(context)!.unknownName,
+                    style: TextStyle(
+                      color: Theme.of(context).textTheme.bodyLarge!.color,
+                      fontSize: 15.5,
+                      fontWeight: FontWeight.w500,
+                      height: 1.1,
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                    maxLines: 2,
+                  ),
+                ),
+                Flexible(
+                  fit: FlexFit.loose,
+                  flex: 2,
+                  child: Text.rich(
+                    overflow: TextOverflow.clip,
+                    softWrap: false,
+                    maxLines: 1,
+                    TextSpan(
+                      children: [
+                        WidgetSpan(
+                          child: Padding(
+                            padding: const EdgeInsets.only(right: 2.0),
+                            child: Transform.translate(
+                              offset: isOnDesktop ? Offset(-1.5, 1.7) : Offset(-1.5, 0.4),
+                              child: downloadedIndicator,
+                            ),
+                          ),
+                          alignment: PlaceholderAlignment.baseline,
+                          baseline: TextBaseline.alphabetic,
+                        ),
+                        if (downloadedIndicator.isVisible(ref) &&
+                            (baseItem.hasLyrics == null || baseItem.hasLyrics == false))
+                          const WidgetSpan(child: SizedBox(width: 4.5)),
+                        if (baseItem.hasLyrics ?? false)
+                          WidgetSpan(
+                            child: Padding(
+                              padding: const EdgeInsets.only(right: 2.0),
+                              child: Transform.translate(
+                                offset: isOnDesktop ? Offset(-1.5, 1.7) : Offset(-1.5, 0.4),
+                                child: Icon(
+                                  TablerIcons.microphone_2,
+                                  size: Theme.of(context).textTheme.bodyMedium!.fontSize! + 1,
+                                ),
+                              ),
+                            ),
+                            alignment: PlaceholderAlignment.baseline,
+                            baseline: TextBaseline.alphabetic,
+                          ),
+                        if (baseItem.hasLyrics ?? false) const WidgetSpan(child: SizedBox(width: 5)),
+                        if (addSpaceAfterSpecialIcons) const WidgetSpan(child: SizedBox(width: 5)),
+                        if (showPlayCount)
+                          TextSpan(
+                            text: AppLocalizations.of(context)!.playCountValue(baseItem.userData?.playCount ?? 0),
+                            style: TextStyle(
+                              color: Theme.of(context).textTheme.bodyMedium!.color!.withOpacity(0.75),
+                              fontSize: 13,
+                              fontWeight: FontWeight.w400,
+                            ),
+                          ),
+                        if (showPlayCount) const WidgetSpan(child: SizedBox(width: 10.0)),
+                        if (showDateLastPlayed)
+                          WidgetSpan(
+                            child: Padding(
+                              padding: const EdgeInsets.only(right: 2.0),
+                              child: Transform.translate(
+                                offset: isOnDesktop ? Offset(-1.5, 1.8) : Offset(-1.5, 0.3),
+                                child: Icon(
+                                  TablerIcons.clock,
+                                  size: Theme.of(context).textTheme.bodyMedium!.fontSize! + 1,
+                                ),
+                              ),
+                            ),
+                            alignment: PlaceholderAlignment.baseline,
+                            baseline: TextBaseline.alphabetic,
+                          ),
+                        if (showDateLastPlayed)
+                          WidgetSpan(
+                            alignment: PlaceholderAlignment.baseline,
+                            baseline: TextBaseline.alphabetic,
+                            child: RelativeDateTimeTextFromString(
+                              dateString: baseItem.userData?.lastPlayedDate,
+                              fallback: AppLocalizations.of(context)!.noDateLastPlayed,
+                              style: TextStyle(
+                                color: Theme.of(context).textTheme.bodyMedium!.color!.withOpacity(0.75),
+                                fontSize: 13,
+                                fontWeight: FontWeight.w400,
+                              ),
+                              disableTextScaling: true,
+                            ),
+                          ),
+                        if (showDateLastPlayed) const WidgetSpan(child: SizedBox(width: 10.0)),
+                        if (showReleaseDate)
+                          TextSpan(
+                            text:
+                                (ReleaseDateHelper.autoFormat(baseItem) ?? AppLocalizations.of(context)!.noReleaseDate),
+                            style: TextStyle(
+                              color: Theme.of(context).textTheme.bodyMedium!.color!.withOpacity(0.75),
+                              fontSize: 13,
+                              fontWeight: FontWeight.w400,
+                            ),
+                          ),
+                        if (showReleaseDate) const WidgetSpan(child: SizedBox(width: 10.0)),
+                        if (showDateAdded)
+                          WidgetSpan(
+                            child: Padding(
+                              padding: const EdgeInsets.only(right: 3),
+                              child: Transform.translate(
+                                offset: isOnDesktop ? Offset(-1.5, 1.28) : Offset(-1.5, 0),
+                                child: Icon(
+                                  TablerIcons.calendar_plus,
+                                  size: Theme.of(context).textTheme.bodyMedium!.fontSize! + 1,
+                                  color: Theme.of(context).textTheme.bodyMedium!.color!.withOpacity(0.75),
+                                ),
+                              ),
+                            ),
+                            alignment: PlaceholderAlignment.baseline,
+                            baseline: TextBaseline.alphabetic,
+                          ),
+                        if (showDateAdded)
+                          WidgetSpan(
+                            alignment: PlaceholderAlignment.baseline,
+                            baseline: TextBaseline.alphabetic,
+                            child: RelativeDateTimeTextFromString(
+                              dateString: baseItem.dateCreated,
+                              fallback: AppLocalizations.of(context)!.noDateAdded,
+                              style: TextStyle(
+                                color: Theme.of(context).textTheme.bodyMedium!.color!.withOpacity(0.75),
+                                fontSize: 13,
+                                fontWeight: FontWeight.w400,
+                              ),
+                              disableTextScaling: true,
+                            ),
+                          ),
+                        if (showDateAdded) const WidgetSpan(child: SizedBox(width: 10.0)),
+                        if (showArtists)
+                          TextSpan(
+                            text: artistsString,
+                            style: TextStyle(
+                              color: Theme.of(context).textTheme.bodyMedium!.color!.withOpacity(0.75),
+                              fontSize: 13,
+                              fontWeight: FontWeight.w400,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                        if (!secondRowNeeded)
+                          // show the artist anyway if nothing else is shown
+                          TextSpan(
+                            text: artistsString,
+                            style: TextStyle(
+                              color: Theme.of(context).textTheme.bodyMedium!.color!.withOpacity(0.75),
+                              fontSize: 13,
+                              fontWeight: FontWeight.w300,
+                            ),
+                          ),
+                        if (showArtists) const WidgetSpan(child: SizedBox(width: 10.0)),
+                        if (showAlbum)
+                          TextSpan(
+                            text: baseItem.album,
+                            style: TextStyle(
+                              color: Theme.of(context).textTheme.bodyMedium!.color!.withOpacity(0.6),
+                              fontSize: 13,
+                              fontWeight: FontWeight.w300,
+                            ),
+                          ),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          trailing: Padding(
+            padding: const EdgeInsets.only(right: 4.0),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              mainAxisAlignment: MainAxisAlignment.end,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                Text(
+                  printDuration(baseItem.runTimeTicksDuration(), leadingZeroes: false),
+                  semanticsLabel: durationLabelString,
+                  textAlign: TextAlign.end,
+                  style: TextStyle(color: Theme.of(context).textTheme.bodySmall?.color),
+                ),
+                Semantics(
+                  excludeSemantics: true,
+                  child: AddToPlaylistButton(
+                    item: baseItem,
+                    size: 24,
+                    visualDensity: const VisualDensity(horizontal: -4),
+                  ),
+                ),
+                if (showOverflowMenu)
+                  OverflowMenuButton(
+                    onPressed: () => showModalTrackMenu(context: context, item: baseItem),
+                    color: Theme.of(context).textTheme.bodyMedium?.color ?? Colors.white,
+                    label: AppLocalizations.of(context)!.menuButtonLabel,
+                  ),
+                if (allowReorder)
+                  ReorderableDragStartListener(
+                    index:
+                        listIndex ??
+                        0, // will briefly use 0 as index, but should resolve quickly enough for user not to notice
+                    child: Padding(
+                      padding: const EdgeInsets.only(left: 6.0),
+                      child: IconButtonWithSemantics(
+                        icon: TablerIcons.menu_order,
+                        onPressed: null,
+                        label: AppLocalizations.of(context)!.dragToReorder,
+                        color: Theme.of(context).textTheme.bodyMedium?.color ?? Colors.white,
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          onTap: onTap,
+        );
+      },
     );
 
     return showPlaybackProgress
@@ -962,5 +974,28 @@ class TrackListItemTile extends ConsumerWidget {
             ],
           )
         : listTile;
+  }
+}
+
+class OverflowBuilder extends StatelessWidget {
+  const OverflowBuilder({super.key, required this.hasOverflowed, required this.builder});
+
+  final bool Function(BoxConstraints constraints) hasOverflowed;
+  final Widget Function(BuildContext context, bool hasOverflowed) builder;
+
+  @override
+  Widget build(BuildContext context) {
+    Widget? child;
+    bool? overflowState;
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        bool newOverflow = hasOverflowed(constraints);
+        if (overflowState != newOverflow || child == null) {
+          child = builder(context, newOverflow);
+          overflowState = newOverflow;
+        }
+        return child!;
+      },
+    );
   }
 }

--- a/lib/components/ArtistScreen/artist_screen_content_flexible_space_bar.dart
+++ b/lib/components/ArtistScreen/artist_screen_content_flexible_space_bar.dart
@@ -121,14 +121,14 @@ class ArtistScreenContentFlexibleSpaceBar extends StatelessWidget {
                         icon: TablerIcons.player_play,
                         onPressed: () => allTracks.then((items) => playAllFromArtist(items ?? [])),
                         // set the minimum width as 25% of the screen width,
-                        minWidth: MediaQuery.of(context).size.width * 0.25,
+                        minWidth: MediaQuery.widthOf(context) * 0.25,
                       ),
                       CTAMedium(
                         text: AppLocalizations.of(context)!.shuffleButtonLabel,
                         icon: TablerIcons.arrows_shuffle,
                         onPressed: () => allTracks.then((items) => shuffleAllFromArtist(items ?? [])),
                         // set the minimum width as 25% of the screen width,
-                        minWidth: MediaQuery.of(context).size.width * 0.25,
+                        minWidth: MediaQuery.widthOf(context) * 0.25,
                       ),
                       OverflowMenuButton(
                         onPressed: () => showModalArtistMenu(context: context, baseItem: parentItem),

--- a/lib/components/AudioServiceSettingsScreen/buffer_duration_list_tile.dart
+++ b/lib/components/AudioServiceSettingsScreen/buffer_duration_list_tile.dart
@@ -29,7 +29,7 @@ class _BufferDurationListTileState extends ConsumerState<BufferDurationListTile>
       title: Text(AppLocalizations.of(context)!.bufferDuration),
       subtitle: Text(AppLocalizations.of(context)!.bufferDurationSubtitle),
       trailing: SizedBox(
-        width: 50 * MediaQuery.of(context).textScaleFactor,
+        width: 50 * MediaQuery.textScaleFactorOf(context),
         child: TextField(
           controller: _controller,
           textAlign: TextAlign.center,

--- a/lib/components/AudioServiceSettingsScreen/track_shuffle_item_count_editor.dart
+++ b/lib/components/AudioServiceSettingsScreen/track_shuffle_item_count_editor.dart
@@ -29,7 +29,7 @@ class _TrackShuffleItemCountEditorState extends ConsumerState<TrackShuffleItemCo
       title: Text(AppLocalizations.of(context)!.shuffleAllTrackCount),
       subtitle: Text(AppLocalizations.of(context)!.shuffleAllTrackCountSubtitle),
       trailing: SizedBox(
-        width: 50 * MediaQuery.of(context).textScaleFactor,
+        width: 50 * MediaQuery.textScaleFactorOf(context),
         child: TextField(
           controller: _controller,
           textAlign: TextAlign.center,

--- a/lib/components/Buttons/cta_large.dart
+++ b/lib/components/Buttons/cta_large.dart
@@ -22,7 +22,7 @@ class CTALarge extends StatelessWidget {
         ),
         padding: WidgetStateProperty.all<EdgeInsetsGeometry>(const EdgeInsets.symmetric(horizontal: 24, vertical: 20)),
         backgroundColor: WidgetStateProperty.all<Color>(
-          Theme.of(context).brightness == Brightness.dark
+          Theme.brightnessOf(context) == Brightness.dark
               ? accentColor.withOpacity(0.3)
               : Color.alphaBlend(accentColor.withOpacity(0.8), Colors.white),
         ),
@@ -33,7 +33,7 @@ class CTALarge extends StatelessWidget {
           Icon(
             icon,
             size: 28,
-            color: Theme.of(context).brightness == Brightness.dark ? accentColor : Colors.white,
+            color: Theme.brightnessOf(context) == Brightness.dark ? accentColor : Colors.white,
             weight: 1.5,
           ),
           const SizedBox(width: 12),

--- a/lib/components/Buttons/cta_medium.dart
+++ b/lib/components/Buttons/cta_medium.dart
@@ -32,7 +32,7 @@ class CTAMedium extends StatelessWidget {
           EdgeInsets.only(left: 8 + paddingHorizontal, right: 8, top: paddingVertical, bottom: paddingVertical),
         ),
         backgroundColor: WidgetStateProperty.all<Color>(
-          Theme.of(context).brightness == Brightness.dark ? accentColor.withOpacity(0.3) : accentColor,
+          Theme.brightnessOf(context) == Brightness.dark ? accentColor.withOpacity(0.3) : accentColor,
         ),
       ),
       child: Container(
@@ -45,7 +45,7 @@ class CTAMedium extends StatelessWidget {
             Icon(
               icon,
               size: 24,
-              color: Theme.of(context).brightness == Brightness.dark ? accentColor : Colors.white,
+              color: Theme.brightnessOf(context) == Brightness.dark ? accentColor : Colors.white,
               weight: 1.5,
             ),
             const SizedBox(width: 8),

--- a/lib/components/Buttons/cta_medium.dart
+++ b/lib/components/Buttons/cta_medium.dart
@@ -62,7 +62,7 @@ class CTAMedium extends StatelessWidget {
   static double predictedHeight(BuildContext context) {
     final densityAdj = VisualDensity.adaptivePlatformDensity.baseSizeAdjustment.dy;
     return max(
-      MediaQuery.sizeOf(context).height * 0.03 + 24 + densityAdj + densityAdj,
+      MediaQuery.heightOf(context) * 0.03 + 24 + densityAdj + densityAdj,
       kMinInteractiveDimension + densityAdj,
     );
   }

--- a/lib/components/DownloadsScreen/downloaded_items_list.dart
+++ b/lib/components/DownloadsScreen/downloaded_items_list.dart
@@ -41,67 +41,51 @@ class _DownloadedItemTypeListState extends ConsumerState<DownloadedItemsList> {
 
   @override
   Widget build(BuildContext context) {
-    return ref
-        .watch(_downloadsService.userDownloadedItemsProvider(widget.type))
-        .when(
-          data: (items) => items.isNotEmpty
-              ? SliverList(
-                  delegate: SliverChildBuilderDelegate((context, index) {
-                    DownloadStub stub = items.elementAt(index);
-                    return ExpansionTile(
-                      key: PageStorageKey(stub.id),
-                      leading: (stub.type == DownloadItemType.finampCollection)
-                          ? AlbumImage(item: stub.finampCollection?.item)
-                          : AlbumImage(item: stub.baseItem),
-                      title: Text(stub.baseItem?.name ?? stub.name),
-                      subtitle: buildDownloadedItemSubtitle(context, stub),
-                      trailing: Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          if ((!(stub.baseItemType == BaseItemDtoType.album ||
-                                  stub.baseItemType == BaseItemDtoType.track)) &&
-                              !ref.watch(finampSettingsProvider.isOffline))
-                            IconButton(
-                              icon: const Icon(Icons.sync),
-                              onPressed: () {
-                                _downloadsService.resync(stub, null);
-                              },
-                            ),
-                          IconButton(
-                            icon: const Icon(Icons.delete),
-                            onPressed: () => askBeforeDeleteDownloadFromDevice(context, stub),
-                          ),
-                        ],
+    final items = ref.watch(_downloadsService.userDownloadedItemsProvider(widget.type));
+    return items.isNotEmpty
+        ? SliverList(
+            delegate: SliverChildBuilderDelegate((context, index) {
+              DownloadStub stub = items.elementAt(index);
+              return ExpansionTile(
+                key: PageStorageKey(stub.id),
+                leading: (stub.type == DownloadItemType.finampCollection)
+                    ? AlbumImage(item: stub.finampCollection?.item)
+                    : AlbumImage(item: stub.baseItem),
+                title: Text(stub.baseItem?.name ?? stub.name),
+                subtitle: buildDownloadedItemSubtitle(context, stub),
+                trailing: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    if ((!(stub.baseItemType == BaseItemDtoType.album || stub.baseItemType == BaseItemDtoType.track)) &&
+                        !ref.watch(finampSettingsProvider.isOffline))
+                      IconButton(
+                        icon: const Icon(Icons.sync),
+                        onPressed: () {
+                          _downloadsService.resync(stub, null);
+                        },
                       ),
-                      tilePadding: const EdgeInsets.symmetric(horizontal: 16),
-                      shape: LinearBorder(),
-                      collapsedShape: LinearBorder(),
-                      children: [
-                        if (stub.type == DownloadItemType.finampCollection || stub.baseItemType.hasChildren)
-                          DownloadedChildrenList(parent: stub),
-                      ],
-                    );
-                  }, childCount: items.length),
-                )
-              : SliverToBoxAdapter(
-                  child: Padding(
-                    padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                    child: Text(AppLocalizations.of(context)!.noItemsDownloaded),
-                  ),
+                    IconButton(
+                      icon: const Icon(Icons.delete),
+                      onPressed: () => askBeforeDeleteDownloadFromDevice(context, stub),
+                    ),
+                  ],
                 ),
-          loading: () => const SliverToBoxAdapter(
+                tilePadding: const EdgeInsets.symmetric(horizontal: 16),
+                shape: LinearBorder(),
+                collapsedShape: LinearBorder(),
+                children: [
+                  if (stub.type == DownloadItemType.finampCollection || stub.baseItemType.hasChildren)
+                    DownloadedChildrenList(parent: stub),
+                ],
+              );
+            }, childCount: items.length),
+          )
+        : SliverToBoxAdapter(
             child: Padding(
-              padding: EdgeInsets.only(top: 8, bottom: 16),
-              child: Center(child: CircularProgressIndicator()),
+              padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: Text(AppLocalizations.of(context)!.noItemsDownloaded),
             ),
-          ),
-          error: (error, stack) => SliverToBoxAdapter(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-              child: Text(error.toString()),
-            ),
-          ),
-        );
+          );
   }
 }
 

--- a/lib/components/DownloadsScreen/downloads_overview.dart
+++ b/lib/components/DownloadsScreen/downloads_overview.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
 
 import 'package:auto_size_text/auto_size_text.dart';
-import 'package:flutter/material.dart';
 import 'package:finamp/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 
 import '../../models/finamp_models.dart';
@@ -53,7 +53,7 @@ class DownloadsOverview extends StatelessWidget {
                   child: Center(
                     child: Row(
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      crossAxisAlignment: CrossAxisAlignment.end,
+                      crossAxisAlignment: CrossAxisAlignment.center,
                       children: [
                         Expanded(
                           child: Column(
@@ -73,10 +73,16 @@ class DownloadsOverview extends StatelessWidget {
                                 ),
                                 style: const TextStyle(color: Colors.grey),
                               ),
+                              if (downloadsService.serverMissingBlurhash)
+                                Text(
+                                  AppLocalizations.of(context)!.missingBlurhashWarning,
+                                  style: const TextStyle(color: Colors.red),
+                                ),
                             ],
                           ),
                         ),
-                        Expanded(
+                        Padding(
+                          padding: const EdgeInsets.only(left: 50),
                           child: Column(
                             crossAxisAlignment: CrossAxisAlignment.end,
                             children: [

--- a/lib/components/GenreScreen/genre_screen_content.dart
+++ b/lib/components/GenreScreen/genre_screen_content.dart
@@ -2,16 +2,16 @@ import 'dart:async';
 
 import 'package:finamp/components/Buttons/cta_medium.dart';
 import 'package:finamp/components/Buttons/simple_button.dart';
-import 'package:finamp/components/curated_item_filter_row.dart';
-import 'package:finamp/components/global_snackbar.dart';
-import 'package:finamp/services/audio_service_helper.dart';
-import 'package:finamp/services/genre_screen_provider.dart';
-import 'package:finamp/components/curated_item_sections.dart';
 import 'package:finamp/components/GenreScreen/genre_count_column.dart';
+import 'package:finamp/components/curated_item_filter_row.dart';
+import 'package:finamp/components/curated_item_sections.dart';
 import 'package:finamp/components/favorite_button.dart';
+import 'package:finamp/components/global_snackbar.dart';
 import 'package:finamp/l10n/app_localizations.dart';
 import 'package:finamp/screens/music_screen.dart';
+import 'package:finamp/services/audio_service_helper.dart';
 import 'package:finamp/services/finamp_user_helper.dart';
+import 'package:finamp/services/genre_screen_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
@@ -303,7 +303,7 @@ class _GenreScreenContentState extends ConsumerState<GenreScreenContent> {
                       GlobalSnackbar.error(e);
                     }
                   },
-                  minWidth: MediaQuery.of(context).size.width * 0.5,
+                  minWidth: MediaQuery.widthOf(context) * 0.5,
                 ),
               ),
             ),

--- a/lib/components/LayoutSettingsScreen/content_grid_view_cross_axis_count_list_tile.dart
+++ b/lib/components/LayoutSettingsScreen/content_grid_view_cross_axis_count_list_tile.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:finamp/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
 
 import '../../services/finamp_settings_helper.dart';
 
@@ -72,7 +72,7 @@ class _ContentGridViewCrossAxisCountListTileState extends State<ContentGridViewC
         AppLocalizations.of(context)!.gridCrossAxisCountSubtitle(widget.type.toLocalisedString(context).toLowerCase()),
       ),
       trailing: SizedBox(
-        width: 50 * MediaQuery.of(context).textScaleFactor,
+        width: 50 * MediaQuery.textScaleFactorOf(context),
         child: TextField(
           controller: _controller,
           textAlign: TextAlign.center,

--- a/lib/components/LayoutSettingsScreen/player_screen_minimum_cover_padding_editor.dart
+++ b/lib/components/LayoutSettingsScreen/player_screen_minimum_cover_padding_editor.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:finamp/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
 
 import '../../services/finamp_settings_helper.dart';
 
@@ -21,7 +21,7 @@ class _PlayerScreenMinimumCoverPaddingEditorState extends State<PlayerScreenMini
       title: Text(AppLocalizations.of(context)!.playerScreenMinimumCoverPaddingEditorTitle),
       subtitle: Text(AppLocalizations.of(context)!.playerScreenMinimumCoverPaddingEditorSubtitle),
       trailing: SizedBox(
-        width: 50 * MediaQuery.of(context).textScaleFactor,
+        width: 50 * MediaQuery.textScaleFactorOf(context),
         child: TextField(
           controller: _controller,
           textAlign: TextAlign.center,

--- a/lib/components/LoginScreen/login_flow.dart
+++ b/lib/components/LoginScreen/login_flow.dart
@@ -59,7 +59,7 @@ class _LoginFlowState extends State<LoginFlow> {
           Route createRoute(Widget page) => PageRouteBuilder(
             pageBuilder: (context, animation, secondaryAnimation) => page,
             transitionsBuilder: (context, animation, secondaryAnimation, child) {
-              if (MediaQuery.of(context).disableAnimations) {
+              if (MediaQuery.disableAnimationsOf(context)) {
                 return child;
               }
               final pushingNext = secondaryAnimation.status == AnimationStatus.forward;

--- a/lib/components/LoginScreen/login_user_selection_page.dart
+++ b/lib/components/LoginScreen/login_user_selection_page.dart
@@ -269,7 +269,7 @@ class JellyfinUserWidget extends StatelessWidget {
         } else {
           return Container(
             decoration: BoxDecoration(
-              color: Theme.of(context).brightness == Brightness.dark ? Colors.white : Colors.black,
+              color: Theme.brightnessOf(context) == Brightness.dark ? Colors.white : Colors.black,
             ),
             child: Image.asset('images/finamp.png', width: avatarSize, height: avatarSize),
           );
@@ -281,7 +281,7 @@ class JellyfinUserWidget extends StatelessWidget {
           decoration: BoxDecoration(
             border: Border.all(
               color: Theme.of(context).textTheme.bodyMedium!.color!,
-              width: Theme.of(context).brightness == Brightness.dark ? 1 : 2,
+              width: Theme.brightnessOf(context) == Brightness.dark ? 1 : 2,
             ),
             borderRadius: BorderRadius.circular(16),
           ),

--- a/lib/components/MusicScreen/alphabet_item_list.dart
+++ b/lib/components/MusicScreen/alphabet_item_list.dart
@@ -133,8 +133,8 @@ class _AlphabetListState extends ConsumerState<AlphabetList> {
                       });
                     },
                     child: Container(
-                      width: MediaQuery.sizeOf(context).width / 3,
-                      height: MediaQuery.sizeOf(context).width / 3,
+                      width: MediaQuery.widthOf(context) / 3,
+                      height: MediaQuery.widthOf(context) / 3,
                       decoration: BoxDecoration(
                         color: Theme.of(context).cardColor.withOpacity(0.85),
                         borderRadius: BorderRadius.circular(20),

--- a/lib/components/MusicScreen/artist_type_selection_row.dart
+++ b/lib/components/MusicScreen/artist_type_selection_row.dart
@@ -21,7 +21,7 @@ class ArtistTypeSelectionRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (tabType == TabContentType.artists) {
-      double screenWidth = MediaQuery.sizeOf(context).width;
+      double screenWidth = MediaQuery.widthOf(context);
       bool alignLeft = screenWidth > 600;
 
       return SafeArea(

--- a/lib/components/MusicScreen/artist_type_selection_row.dart
+++ b/lib/components/MusicScreen/artist_type_selection_row.dart
@@ -6,69 +6,78 @@ import 'package:flutter/material.dart';
 import '../../models/finamp_models.dart';
 import '../../services/finamp_settings_helper.dart';
 
-Widget buildArtistTypeSelectionRow(
-  BuildContext context,
-  TabContentType tabType,
-  ArtistType defaultArtistType,
-  Function(TabContentType) refreshTab,
-) {
-  if (tabType == TabContentType.artists) {
-    double screenWidth = MediaQuery.of(context).size.width;
-    bool alignLeft = screenWidth > 600;
+class ArtistTypeSelectionRow extends StatelessWidget {
+  final TabContentType tabType;
+  final ArtistType defaultArtistType;
+  final void Function(TabContentType) refreshTab;
 
-    return SafeArea(
-      top: false,
-      bottom: false,
-      child: Padding(
-        padding: (Platform.isWindows || Platform.isLinux || Platform.isMacOS)
-            ? const EdgeInsets.symmetric(horizontal: 4)
-            : EdgeInsets.zero,
-        child: SizedBox(
-          height: 48,
-          width: double.infinity,
-          child: Row(
-            mainAxisAlignment: alignLeft ? MainAxisAlignment.start : MainAxisAlignment.center,
-            children: [
-              FilterChip(
-                label: Text(AppLocalizations.of(context)!.albumArtists),
-                onSelected: (_) {
-                  FinampSetters.setDefaultArtistType(ArtistType.albumArtist);
-                  refreshTab(tabType);
-                },
-                selected: defaultArtistType == ArtistType.albumArtist,
-                showCheckmark: false,
-                selectedColor: Theme.of(context).colorScheme.primary,
-                backgroundColor: Theme.of(context).colorScheme.surface,
-                labelStyle: TextStyle(
-                  color: defaultArtistType == ArtistType.albumArtist
-                      ? Theme.of(context).colorScheme.onPrimary
-                      : Theme.of(context).colorScheme.onSurface,
+  const ArtistTypeSelectionRow({
+    super.key,
+    required this.tabType,
+    required this.defaultArtistType,
+    required this.refreshTab,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (tabType == TabContentType.artists) {
+      double screenWidth = MediaQuery.sizeOf(context).width;
+      bool alignLeft = screenWidth > 600;
+
+      return SafeArea(
+        top: false,
+        bottom: false,
+        child: Padding(
+          padding: (Platform.isWindows || Platform.isLinux || Platform.isMacOS)
+              ? const EdgeInsets.symmetric(horizontal: 4)
+              : EdgeInsets.zero,
+          child: SizedBox(
+            height: 48,
+            width: double.infinity,
+            child: Row(
+              mainAxisAlignment: alignLeft ? MainAxisAlignment.start : MainAxisAlignment.center,
+              children: [
+                FilterChip(
+                  label: Text(AppLocalizations.of(context)!.albumArtists),
+                  onSelected: (_) {
+                    FinampSetters.setDefaultArtistType(ArtistType.albumArtist);
+                    refreshTab(tabType);
+                  },
+                  selected: defaultArtistType == ArtistType.albumArtist,
+                  showCheckmark: false,
+                  selectedColor: Theme.of(context).colorScheme.primary,
+                  backgroundColor: Theme.of(context).colorScheme.surface,
+                  labelStyle: TextStyle(
+                    color: defaultArtistType == ArtistType.albumArtist
+                        ? Theme.of(context).colorScheme.onPrimary
+                        : Theme.of(context).colorScheme.onSurface,
+                  ),
+                  shape: StadiumBorder(),
                 ),
-                shape: StadiumBorder(),
-              ),
-              SizedBox(width: 8),
-              FilterChip(
-                label: Text(AppLocalizations.of(context)!.performingArtists),
-                onSelected: (_) {
-                  FinampSetters.setDefaultArtistType(ArtistType.artist);
-                  refreshTab(tabType);
-                },
-                selected: defaultArtistType == ArtistType.artist,
-                showCheckmark: false,
-                selectedColor: Theme.of(context).colorScheme.primary,
-                backgroundColor: Theme.of(context).colorScheme.surface,
-                labelStyle: TextStyle(
-                  color: defaultArtistType == ArtistType.artist
-                      ? Theme.of(context).colorScheme.onPrimary
-                      : Theme.of(context).colorScheme.onSurface,
+                SizedBox(width: 8),
+                FilterChip(
+                  label: Text(AppLocalizations.of(context)!.performingArtists),
+                  onSelected: (_) {
+                    FinampSetters.setDefaultArtistType(ArtistType.artist);
+                    refreshTab(tabType);
+                  },
+                  selected: defaultArtistType == ArtistType.artist,
+                  showCheckmark: false,
+                  selectedColor: Theme.of(context).colorScheme.primary,
+                  backgroundColor: Theme.of(context).colorScheme.surface,
+                  labelStyle: TextStyle(
+                    color: defaultArtistType == ArtistType.artist
+                        ? Theme.of(context).colorScheme.onPrimary
+                        : Theme.of(context).colorScheme.onSurface,
+                  ),
+                  shape: StadiumBorder(),
                 ),
-                shape: StadiumBorder(),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
-      ),
-    );
+      );
+    }
+    return SizedBox.shrink();
   }
-  return SizedBox.shrink();
 }

--- a/lib/components/MusicScreen/item_collection_card.dart
+++ b/lib/components/MusicScreen/item_collection_card.dart
@@ -25,7 +25,7 @@ class ItemCollectionCard extends ConsumerWidget {
         child: Stack(
           children: [
             AlbumImage(item: item),
-            ref.watch(finampSettingsProvider.showTextOnGridView)
+            ref.watch(finampSettingsProvider.showTextOnGridView) || item.imageId == null
                 ? _ItemCollectionCardText(item: item, parentType: parentType)
                 : const SizedBox.shrink(),
             Positioned.fill(

--- a/lib/components/MusicScreen/music_screen_tab_view.dart
+++ b/lib/components/MusicScreen/music_screen_tab_view.dart
@@ -711,7 +711,6 @@ class _CachedBuilderState<T> extends State<CachedBuilder<T>> {
 
   @override
   void didUpdateWidget(covariant CachedBuilder<T> oldWidget) {
-    // TODO: implement didUpdateWidget
     super.didUpdateWidget(oldWidget);
     if (widget.cacheKey != oldWidget.cacheKey) {
       child = null;

--- a/lib/components/MusicScreen/music_screen_tab_view.dart
+++ b/lib/components/MusicScreen/music_screen_tab_view.dart
@@ -235,7 +235,7 @@ class _MusicScreenTabViewState extends ConsumerState<MusicScreenTabView>
     });
     controller = AutoScrollController(
       suggestedRowHeight: 72,
-      viewportBoundaryGetter: () => Rect.fromLTRB(0, 0, 0, MediaQuery.of(context).padding.bottom),
+      viewportBoundaryGetter: () => Rect.fromLTRB(0, 0, 0, MediaQuery.paddingOf(context).bottom),
       axis: Axis.vertical,
     );
     _musicScreenRefreshStreamSubscription = musicScreenRefreshStream.stream.listen((_) {
@@ -320,7 +320,7 @@ class _MusicScreenTabViewState extends ConsumerState<MusicScreenTabView>
 
       _pagingController.notifyPageRequestListeners(_pagingController.nextPageKey!);
     }
-    if (MediaQuery.of(context).disableAnimations) {
+    if (MediaQuery.disableAnimationsOf(context)) {
       controller.jumpTo(controller.position.maxScrollExtent);
     } else {
       await controller.animateTo(
@@ -437,39 +437,43 @@ class _MusicScreenTabViewState extends ConsumerState<MusicScreenTabView>
                 // built-in icon padding
                 return Padding(
                   padding: EdgeInsets.only(right: max(0, MediaQuery.paddingOf(context).right - 20)),
-                  child: AutoScrollTag(
-                    key: ValueKey(index),
-                    controller: controller,
-                    index: index,
-                    child: widget.tabContentType == TabContentType.tracks
-                        ? TrackListTile(
-                            key: ValueKey(item.id),
-                            item: item,
-                            isTrack: true,
-                            index: index,
-                            isShownInSearchOrHistory: widget.searchTerm != null,
-                            // when the tabBar was filtered and we only have the tracks tab,
-                            // we can allow Dismiss gestures in the track list
-                            allowDismiss: widget.tabBarFiltered,
-                            genreFilter: widget.genreFilter,
-                            isOnGenreScreen: (widget.genreFilter != null) ? true : false,
-                            parentItem: widget.genreFilter,
-                            forceAlbumArtists: (sortBy == SortBy.albumArtist),
-                            adaptiveAdditionalInfoSortBy: sortBy,
-                            // since we can't re-create the current random sorting, we simply pass the pre-sorted tracks along
-                            // only done in offline mode since online mode doesn't support playing the tab contents in order anyway
-                            children: FinampSettingsHelper.finampSettings.isOffline && sortBy == SortBy.random
-                                ? _pagingController.itemList
-                                : null,
-                          )
-                        : ItemCollectionWrapper(
-                            key: ValueKey(item.id),
-                            item: item,
-                            isPlaylist: widget.tabContentType == TabContentType.playlists,
-                            genreFilter: widget.genreFilter,
-                            adaptiveAdditionalInfoSortBy: sortBy,
-                            showFavoriteIconOnlyWhenFilterDisabled: true,
-                          ),
+                  child: CachedBuilder(
+                    key: ValueKey(item.id),
+                    cacheKey: (item.id, index),
+                    builder: (context) {
+                      return AutoScrollTag(
+                        key: ValueKey(index),
+                        controller: controller,
+                        index: index,
+                        child: widget.tabContentType == TabContentType.tracks
+                            ? TrackListTile(
+                                item: item,
+                                isTrack: true,
+                                index: index,
+                                isShownInSearchOrHistory: widget.searchTerm != null,
+                                // when the tabBar was filtered and we only have the tracks tab,
+                                // we can allow Dismiss gestures in the track list
+                                allowDismiss: widget.tabBarFiltered,
+                                genreFilter: widget.genreFilter,
+                                isOnGenreScreen: (widget.genreFilter != null) ? true : false,
+                                parentItem: widget.genreFilter,
+                                forceAlbumArtists: (sortBy == SortBy.albumArtist),
+                                adaptiveAdditionalInfoSortBy: sortBy,
+                                // since we can't re-create the current random sorting, we simply pass the pre-sorted tracks along
+                                // only done in offline mode since online mode doesn't support playing the tab contents in order anyway
+                                children: FinampSettingsHelper.finampSettings.isOffline && sortBy == SortBy.random
+                                    ? _pagingController.itemList
+                                    : null,
+                              )
+                            : ItemCollectionWrapper(
+                                item: item,
+                                isPlaylist: widget.tabContentType == TabContentType.playlists,
+                                genreFilter: widget.genreFilter,
+                                adaptiveAdditionalInfoSortBy: sortBy,
+                                showFavoriteIconOnlyWhenFilterDisabled: true,
+                              ),
+                      );
+                    },
                   ),
                 );
               },
@@ -486,17 +490,22 @@ class _MusicScreenTabViewState extends ConsumerState<MusicScreenTabView>
             physics: _DeferredLoadingAlwaysScrollableScrollPhysics(tabState: this),
             builderDelegate: PagedChildBuilderDelegate<BaseItemDto>(
               itemBuilder: (context, item, index) {
-                return AutoScrollTag(
-                  key: ValueKey(index),
-                  controller: controller,
-                  index: index,
-                  child: ItemCollectionWrapper(
-                    key: ValueKey(item.id),
-                    item: item,
-                    isPlaylist: widget.tabContentType == TabContentType.playlists,
-                    isGrid: true,
-                    genreFilter: widget.genreFilter,
-                  ),
+                return CachedBuilder(
+                  key: ValueKey(item.id),
+                  cacheKey: (item.id, index),
+                  builder: (context) {
+                    return AutoScrollTag(
+                      key: ValueKey(index),
+                      controller: controller,
+                      index: index,
+                      child: ItemCollectionWrapper(
+                        item: item,
+                        isPlaylist: widget.tabContentType == TabContentType.playlists,
+                        isGrid: true,
+                        genreFilter: widget.genreFilter,
+                      ),
+                    );
+                  },
                 );
               },
               firstPageProgressIndicatorBuilder: (_) => const FirstPageProgressIndicator(),
@@ -508,7 +517,7 @@ class _MusicScreenTabViewState extends ConsumerState<MusicScreenTabView>
                     gridTileSize: FinampSettingsHelper.finampSettings.fixedGridTileSize.toDouble(),
                   )
                 : SliverGridDelegateWithFixedCrossAxisCount(
-                    crossAxisCount: MediaQuery.of(context).size.width > MediaQuery.of(context).size.height
+                    crossAxisCount: MediaQuery.sizeOf(context).width > MediaQuery.sizeOf(context).height
                         ? FinampSettingsHelper.finampSettings.contentGridViewCrossAxisCountLandscape
                         : FinampSettingsHelper.finampSettings.contentGridViewCrossAxisCountPortrait,
                   ),
@@ -685,4 +694,33 @@ List<BaseItemDto> filterItemsByGenreName(List<BaseItemDto> items, BaseItemDto ge
 
     return assignedGenres.any((genre) => genre.name == genreFilter.name);
   }).toList();
+}
+
+class CachedBuilder<T> extends StatefulWidget {
+  const CachedBuilder({required this.builder, required this.cacheKey, super.key});
+
+  final Widget Function(BuildContext context) builder;
+  final T cacheKey;
+
+  @override
+  State<CachedBuilder<T>> createState() => _CachedBuilderState<T>();
+}
+
+class _CachedBuilderState<T> extends State<CachedBuilder<T>> {
+  Widget? child;
+
+  @override
+  void didUpdateWidget(covariant CachedBuilder<T> oldWidget) {
+    // TODO: implement didUpdateWidget
+    super.didUpdateWidget(oldWidget);
+    if (widget.cacheKey != oldWidget.cacheKey) {
+      child = null;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    child ??= widget.builder(context);
+    return child!;
+  }
 }

--- a/lib/components/MusicScreen/music_screen_tab_view.dart
+++ b/lib/components/MusicScreen/music_screen_tab_view.dart
@@ -517,7 +517,7 @@ class _MusicScreenTabViewState extends ConsumerState<MusicScreenTabView>
                     gridTileSize: FinampSettingsHelper.finampSettings.fixedGridTileSize.toDouble(),
                   )
                 : SliverGridDelegateWithFixedCrossAxisCount(
-                    crossAxisCount: MediaQuery.sizeOf(context).width > MediaQuery.sizeOf(context).height
+                    crossAxisCount: MediaQuery.orientationOf(context) == Orientation.landscape
                         ? FinampSettingsHelper.finampSettings.contentGridViewCrossAxisCountLandscape
                         : FinampSettingsHelper.finampSettings.contentGridViewCrossAxisCountPortrait,
                   ),

--- a/lib/components/NetworkSettingsScreen/prefer_local_network_address_selector.dart
+++ b/lib/components/NetworkSettingsScreen/prefer_local_network_address_selector.dart
@@ -1,8 +1,8 @@
 import 'package:finamp/components/global_snackbar.dart';
 import 'package:finamp/l10n/app_localizations.dart';
 import 'package:finamp/models/finamp_models.dart';
-import 'package:finamp/services/network_manager.dart';
 import 'package:finamp/services/finamp_user_helper.dart';
+import 'package:finamp/services/network_manager.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:get_it/get_it.dart';
@@ -35,7 +35,7 @@ class _LocalNetworkAddressSelector extends ConsumerState<LocalNetworkAddressSele
       title: Text(AppLocalizations.of(context)!.preferLocalNetworkTargetAddressLocalSettingTitle),
       subtitle: Text(AppLocalizations.of(context)!.preferLocalNetworkTargetAddressLocalSettingDescription),
       trailing: SizedBox(
-        width: 200 * MediaQuery.of(context).textScaleFactor,
+        width: 200 * MediaQuery.textScaleFactorOf(context),
         child: TextField(
           enabled: featureEnabled,
           controller: _controller,

--- a/lib/components/NetworkSettingsScreen/public_address_selector.dart
+++ b/lib/components/NetworkSettingsScreen/public_address_selector.dart
@@ -1,7 +1,7 @@
 import 'package:finamp/components/global_snackbar.dart';
 import 'package:finamp/l10n/app_localizations.dart';
-import 'package:finamp/services/network_manager.dart';
 import 'package:finamp/services/finamp_user_helper.dart';
+import 'package:finamp/services/network_manager.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:get_it/get_it.dart';
@@ -32,7 +32,7 @@ class _PublicAddressSelector extends ConsumerState<PublicAddressSelector> {
       title: Text(AppLocalizations.of(context)!.preferLocalNetworkPublicAddressSettingTitle),
       subtitle: Text(AppLocalizations.of(context)!.preferLocalNetworkPublicAddressSettingDescription),
       trailing: SizedBox(
-        width: 200 * MediaQuery.of(context).textScaleFactor,
+        width: 200 * MediaQuery.textScaleFactorOf(context),
         child: TextField(
           controller: _controller,
           textAlign: TextAlign.center,

--- a/lib/components/PlaybackHistoryScreen/playback_history_list_tile.dart
+++ b/lib/components/PlaybackHistoryScreen/playback_history_list_tile.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
-import 'package:finamp/menus/track_menu.dart';
 import 'package:finamp/components/favorite_button.dart';
+import 'package:finamp/menus/track_menu.dart';
 import 'package:finamp/models/finamp_models.dart';
 import 'package:finamp/services/audio_service_helper.dart';
 import 'package:flutter/material.dart' hide ReorderableList;
@@ -34,7 +34,7 @@ class _PlaybackHistoryListTileState extends ConsumerState<PlaybackHistoryListTil
   @override
   Widget build(BuildContext context) {
     final baseItem = jellyfin_models.BaseItemDto.fromJson(
-      widget.item.item.item.extras?["itemJson"] as Map<String, dynamic>,
+      widget.item.item.item.extras!["itemJson"] as Map<String, dynamic>,
     );
 
     void menuCallback() async {
@@ -59,7 +59,7 @@ class _PlaybackHistoryListTileState extends ConsumerState<PlaybackHistoryListTil
           minVerticalPadding: 0.0,
           horizontalTitleGap: 10.0,
           contentPadding: const EdgeInsets.only(right: 4.0),
-          leading: AlbumImage(item: widget.item.item.item.extras?["itemJson"] == null ? null : baseItem),
+          leading: AlbumImage(item: baseItem),
           title: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [

--- a/lib/components/PlaybackReportingSettingsScreen/periodic_playback_session_update_frequency_editor.dart
+++ b/lib/components/PlaybackReportingSettingsScreen/periodic_playback_session_update_frequency_editor.dart
@@ -1,6 +1,6 @@
+import 'package:finamp/l10n/app_localizations.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:finamp/l10n/app_localizations.dart';
 
 import '../../services/finamp_settings_helper.dart';
 
@@ -58,7 +58,7 @@ class _PeriodicPlaybackSessionUpdateFrequencyEditorState extends State<PeriodicP
         ),
       ),
       trailing: SizedBox(
-        width: 50 * MediaQuery.of(context).textScaleFactor,
+        width: 50 * MediaQuery.textScaleFactorOf(context),
         child: TextField(
           controller: _controller,
           textAlign: TextAlign.center,

--- a/lib/components/PlaybackReportingSettingsScreen/play_on_reconnection_delay_editor.dart
+++ b/lib/components/PlaybackReportingSettingsScreen/play_on_reconnection_delay_editor.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:finamp/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
 
 import '../../services/finamp_settings_helper.dart';
 
@@ -30,7 +30,7 @@ class _PlayOnReconnectionDelayEditorState extends State<PlayOnReconnectionDelayE
         ),
       ),
       trailing: SizedBox(
-        width: 50 * MediaQuery.of(context).textScaleFactor,
+        width: 50 * MediaQuery.textScaleFactorOf(context),
         child: TextField(
           controller: _controller,
           textAlign: TextAlign.center,

--- a/lib/components/PlaybackReportingSettingsScreen/play_on_stale_delay_editor.dart
+++ b/lib/components/PlaybackReportingSettingsScreen/play_on_stale_delay_editor.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:finamp/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
 
 import '../../services/finamp_settings_helper.dart';
 
@@ -28,7 +28,7 @@ class _PlayOnStaleDelayEditorState extends State<PlayOnStaleDelayEditor> {
         ),
       ),
       trailing: SizedBox(
-        width: 50 * MediaQuery.of(context).textScaleFactor,
+        width: 50 * MediaQuery.textScaleFactorOf(context),
         child: TextField(
           controller: _controller,
           textAlign: TextAlign.center,

--- a/lib/components/PlayerScreen/feature_chips.dart
+++ b/lib/components/PlayerScreen/feature_chips.dart
@@ -210,9 +210,13 @@ class FeatureChips extends ConsumerWidget {
             behavior: ScrollConfiguration.of(context).copyWith(dragDevices: PointerDeviceKind.values.toSet()),
             child: SingleChildScrollView(
               scrollDirection: Axis.horizontal,
-              child: Features(
-                backgroundColor: IconTheme.of(context).color?.withOpacity(0.1) ?? _defaultBackgroundColour,
-                features: featureState,
+              child: Builder(
+                builder: (context) {
+                  return Features(
+                    backgroundColor: IconTheme.of(context).color?.withOpacity(0.1) ?? _defaultBackgroundColour,
+                    features: featureState,
+                  );
+                },
               ),
             ),
           ),

--- a/lib/components/PlayerScreen/player_screen_appbar_title.dart
+++ b/lib/components/PlayerScreen/player_screen_appbar_title.dart
@@ -45,7 +45,7 @@ class _PlayerScreenAppBarTitleState extends State<PlayerScreenAppBarTitle> {
                   style: TextStyle(
                     fontSize: 12,
                     fontWeight: FontWeight.w300,
-                    color: Theme.of(context).brightness == Brightness.dark
+                    color: Theme.brightnessOf(context) == Brightness.dark
                         ? Colors.white.withOpacity(0.7)
                         : Colors.black.withOpacity(0.8),
                   ),
@@ -57,7 +57,7 @@ class _PlayerScreenAppBarTitleState extends State<PlayerScreenAppBarTitle> {
                   queueItem.source.name.getLocalized(context),
                   style: TextStyle(
                     fontSize: 14,
-                    color: Theme.of(context).brightness == Brightness.dark
+                    color: Theme.brightnessOf(context) == Brightness.dark
                         ? Colors.white
                         : Colors.black.withOpacity(0.9),
                   ),

--- a/lib/components/PlayerScreen/player_screen_appbar_title.dart
+++ b/lib/components/PlayerScreen/player_screen_appbar_title.dart
@@ -1,7 +1,7 @@
 import 'package:balanced_text/balanced_text.dart';
+import 'package:finamp/l10n/app_localizations.dart';
 import 'package:finamp/services/queue_service.dart';
 import 'package:flutter/material.dart';
-import 'package:finamp/l10n/app_localizations.dart';
 import 'package:get_it/get_it.dart';
 
 import '../../models/finamp_models.dart';
@@ -23,7 +23,7 @@ class _PlayerScreenAppBarTitleState extends State<PlayerScreenAppBarTitle> {
   Widget build(BuildContext context) {
     final currentTrackStream = _queueService.getCurrentTrackStream();
 
-    final screenWidth = MediaQuery.of(context).size.width;
+    final screenWidth = MediaQuery.widthOf(context);
 
     return StreamBuilder<FinampQueueItem?>(
       stream: currentTrackStream,

--- a/lib/components/PlayerScreen/queue_list.dart
+++ b/lib/components/PlayerScreen/queue_list.dart
@@ -250,7 +250,7 @@ Future<dynamic> showQueueBottomSheet(BuildContext context, WidgetRef ref) {
                 children: [
                   if (ref.watch(finampSettingsProvider.useCoverAsBackground))
                     BlurredPlayerScreenBackground(
-                      opacityFactor: Theme.of(context).brightness == Brightness.dark ? 1.0 : 0.85,
+                      opacityFactor: Theme.brightnessOf(context) == Brightness.dark ? 1.0 : 0.85,
                     ),
                   Column(
                     mainAxisSize: MainAxisSize.min,
@@ -306,13 +306,21 @@ Future<dynamic> showQueueBottomSheet(BuildContext context, WidgetRef ref) {
     enableDrag: true,
     useSafeArea: true,
     routeSettings: const RouteSettings(name: QueueList.routeName),
-    constraints: BoxConstraints(maxWidth: (MediaQuery.widthOf(context) * 0.9).clamp(640, 900)),
+    constraints: BoxConstraints(maxWidth: double.infinity),
     clipBehavior: Clip.antiAlias,
     // Anchor to bottom right sub screen, required for foldables
     // On book-style foldables, this will anchor to the right half of the screen.
     // On flip-style foldables, this will anchor to the bottom half of the screen.
     anchorPoint: Offset(double.maxFinite, double.maxFinite),
-    builder: (context) => menu,
+    builder: (context) => LayoutBuilder(
+      builder: (context, constraints) {
+        final double maxWidth = (constraints.maxWidth * 0.9).clamp(640, 900);
+        return ConstrainedBox(
+          constraints: constraints.copyWith(maxWidth: maxWidth),
+          child: menu,
+        );
+      },
+    ),
   );
 }
 
@@ -684,10 +692,10 @@ class _CurrentTrackState extends ConsumerState<CurrentTrack> {
                 clipBehavior: Clip.antiAlias,
                 decoration: ShapeDecoration(
                   color: Color.alphaBlend(
-                    Theme.of(context).brightness == Brightness.dark
+                    Theme.brightnessOf(context) == Brightness.dark
                         ? IconTheme.of(context).color!.withOpacity(0.35)
                         : IconTheme.of(context).color!.withOpacity(0.65),
-                    Theme.of(context).brightness == Brightness.dark ? Colors.black : Colors.white,
+                    Theme.brightnessOf(context) == Brightness.dark ? Colors.black : Colors.white,
                   ),
                   shape: const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(12.0))),
                 ),
@@ -779,7 +787,7 @@ class _CurrentTrackState extends ConsumerState<CurrentTrack> {
                                             fontSize: 16,
                                             height: 26 / 20,
                                             color: Colors.white,
-                                            fontWeight: Theme.of(context).brightness == Brightness.light
+                                            fontWeight: Theme.brightnessOf(context) == Brightness.light
                                                 ? FontWeight.w500
                                                 : FontWeight.w600,
                                           ),
@@ -1081,7 +1089,7 @@ class NextUpSectionHeader extends StatelessWidget {
               icon: TablerIcons.x,
               iconPosition: IconPosition.end,
               iconSize: 32.0,
-              iconColor: Theme.of(context).brightness == Brightness.light ? Colors.black : Colors.white,
+              iconColor: Theme.brightnessOf(context) == Brightness.light ? Colors.black : Colors.white,
               onPressed: () {
                 queueService.clearNextUp();
                 FeedbackHelper.feedback(FeedbackType.success);
@@ -1139,13 +1147,13 @@ class PreviousTracksSectionHeader extends SliverPersistentHeaderDelegate {
                   return Icon(
                     TablerIcons.chevron_up,
                     size: 28.0,
-                    color: Theme.of(context).brightness == Brightness.light ? Colors.black : Colors.white,
+                    color: Theme.brightnessOf(context) == Brightness.light ? Colors.black : Colors.white,
                   );
                 } else {
                   return Icon(
                     TablerIcons.chevron_down,
                     size: 28.0,
-                    color: Theme.of(context).brightness == Brightness.light ? Colors.black : Colors.white,
+                    color: Theme.brightnessOf(context) == Brightness.light ? Colors.black : Colors.white,
                   );
                 }
               },

--- a/lib/components/PlayerScreen/queue_list.dart
+++ b/lib/components/PlayerScreen/queue_list.dart
@@ -103,12 +103,12 @@ class _QueueListState extends State<QueueList> {
 
     widget.scrollController.addListener(() {
       if (widget.jumpToCurrentKey.currentContext == null) return;
-      final screenSize = MediaQuery.sizeOf(widget.jumpToCurrentKey.currentContext!);
+      final screenHeight = MediaQuery.heightOf(widget.jumpToCurrentKey.currentContext!);
       double offset = widget.scrollController.offset - _currentTrackScroll;
       int jumpDirection = 0;
-      if (offset > screenSize.height * 0.5) {
+      if (offset > screenHeight * 0.5) {
         jumpDirection = -1;
-      } else if (offset < -screenSize.height) {
+      } else if (offset < -screenHeight) {
         jumpDirection = 1;
       }
       widget.jumpToCurrentKey.currentState?.showJumpToTop = jumpDirection;

--- a/lib/components/PlayerScreen/queue_list.dart
+++ b/lib/components/PlayerScreen/queue_list.dart
@@ -306,6 +306,7 @@ Future<dynamic> showQueueBottomSheet(BuildContext context, WidgetRef ref) {
     enableDrag: true,
     useSafeArea: true,
     routeSettings: const RouteSettings(name: QueueList.routeName),
+    constraints: BoxConstraints(maxWidth: (MediaQuery.widthOf(context) * 0.9).clamp(640, 900)),
     clipBehavior: Clip.antiAlias,
     // Anchor to bottom right sub screen, required for foldables
     // On book-style foldables, this will anchor to the right half of the screen.

--- a/lib/components/PlayerScreen/queue_source_helper.dart
+++ b/lib/components/PlayerScreen/queue_source_helper.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:finamp/components/global_snackbar.dart';
+import 'package:finamp/l10n/app_localizations.dart';
 import 'package:finamp/models/finamp_models.dart';
 import 'package:finamp/screens/album_screen.dart';
 import 'package:finamp/screens/artist_screen.dart';
@@ -9,7 +10,6 @@ import 'package:finamp/screens/music_screen.dart';
 import 'package:finamp/services/feedback_helper.dart';
 import 'package:finamp/services/finamp_settings_helper.dart';
 import 'package:flutter/material.dart';
-import 'package:finamp/l10n/app_localizations.dart';
 import 'package:get_it/get_it.dart';
 
 import '../../models/jellyfin_models.dart';
@@ -83,12 +83,8 @@ Future<bool> removeFromPlaylist(
           context,
         )!.removeFromPlaylistPrompt(item.name ?? "item", parent.name ?? "playlist"),
         confirmButtonText: AppLocalizations.of(context)!.removeFromPlaylistConfirm,
-        abortButtonText: AppLocalizations.of(context)!.genericCancel,
         onConfirmed: () {
           isConfirmed = true;
-        },
-        onAborted: () {
-          isConfirmed = false;
         },
       ),
     );

--- a/lib/components/PlayerScreen/track_name_content.dart
+++ b/lib/components/PlayerScreen/track_name_content.dart
@@ -33,118 +33,115 @@ class TrackNameContent extends StatelessWidget {
 
         final jellyfin_models.BaseItemDto? trackBaseItemDto = currentTrack.baseItem;
 
+        final content = Column(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Center(
+              child: Container(
+                constraints: const BoxConstraints(maxWidth: 280),
+                child: Semantics.fromProperties(
+                  properties: SemanticsProperties(
+                    label: "${currentTrack.item.title} (${AppLocalizations.of(context)!.title})",
+                  ),
+                  excludeSemantics: true,
+                  container: true,
+                  child: Consumer(
+                    builder: (context, ref, _) {
+                      final text = currentTrack.item.title;
+                      final isTwoLineMode = controller.shouldShow(PlayerHideable.twoLineTitle);
+
+                      final textStyle = TextStyle(
+                        fontSize: 20,
+                        height: 1.2,
+                        fontWeight: Theme.brightnessOf(context) == Brightness.light ? FontWeight.w500 : FontWeight.w600,
+                      );
+
+                      final textSpan = TextSpan(text: text, style: textStyle);
+                      final textPainter = TextPainter(text: textSpan, textDirection: TextDirection.ltr, maxLines: 2)
+                        ..layout(maxWidth: 280);
+
+                      final wouldOverflow = textPainter.didExceedMaxLines;
+                      textPainter.dispose();
+
+                      if (!isTwoLineMode) {
+                        return Text(
+                          text,
+                          style: textStyle,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          textAlign: TextAlign.center,
+                        );
+                      } else {
+                        if (!wouldOverflow) {
+                          return Text(
+                            text,
+                            style: textStyle,
+                            textAlign: TextAlign.center,
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                          );
+                        } else {
+                          if (ref.watch(finampSettingsProvider.oneLineMarqueeTextButton)) {
+                            return SizedBox(
+                              width: 280,
+                              height: 30,
+                              child: ScrollingTextHelper(
+                                id: ValueKey(currentTrack.item.id),
+                                text: text,
+                                style: textStyle,
+                                alignment: TextAlign.center,
+                              ),
+                            );
+                          } else {
+                            return Text(
+                              text,
+                              style: textStyle,
+                              textAlign: TextAlign.center,
+                              maxLines: 2,
+                              overflow: TextOverflow.ellipsis,
+                            );
+                          }
+                        }
+                      }
+                    },
+                  ),
+                ),
+              ),
+            ),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                PlayerButtonsMore(item: trackBaseItemDto, queueItem: currentTrack),
+                Flexible(
+                  child: ArtistChips(
+                    baseItem: trackBaseItemDto,
+                    backgroundColor: IconTheme.of(context).color!.withOpacity(0.1),
+                  ),
+                ),
+                AddToPlaylistButton(item: trackBaseItemDto, queueItem: currentTrack),
+              ],
+            ),
+            Center(
+              child: Container(
+                constraints: const BoxConstraints(maxWidth: 280),
+                child: AlbumChips(
+                  baseItem: trackBaseItemDto!,
+                  backgroundColor: IconTheme.of(context).color!.withOpacity(0.1),
+                  key: trackBaseItemDto.album == null ? null : ValueKey("${trackBaseItemDto.album}-album"),
+                ),
+              ),
+            ),
+          ],
+        );
+
         return LayoutBuilder(
           builder: (context, constraints) {
             double padding = ((constraints.maxWidth - 260) / 4).clamp(0, 20);
             return Padding(
               padding: EdgeInsets.only(left: padding, right: padding, bottom: 4.0),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.center,
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Center(
-                    child: Container(
-                      constraints: const BoxConstraints(maxWidth: 280),
-                      child: Semantics.fromProperties(
-                        properties: SemanticsProperties(
-                          label: "${currentTrack.item.title} (${AppLocalizations.of(context)!.title})",
-                        ),
-                        excludeSemantics: true,
-                        container: true,
-                        child: Consumer(
-                          builder: (context, ref, _) {
-                            final text = currentTrack.item.title;
-                            final isTwoLineMode = controller.shouldShow(PlayerHideable.twoLineTitle);
-
-                            final textStyle = TextStyle(
-                              fontSize: 20,
-                              height: 1.2,
-                              fontWeight: Theme.brightnessOf(context) == Brightness.light
-                                  ? FontWeight.w500
-                                  : FontWeight.w600,
-                            );
-
-                            final textSpan = TextSpan(text: text, style: textStyle);
-                            final textPainter = TextPainter(
-                              text: textSpan,
-                              textDirection: TextDirection.ltr,
-                              maxLines: 2,
-                            )..layout(maxWidth: 280);
-
-                            final wouldOverflow = textPainter.didExceedMaxLines;
-                            textPainter.dispose();
-
-                            if (!isTwoLineMode) {
-                              return Text(
-                                text,
-                                style: textStyle,
-                                maxLines: 1,
-                                overflow: TextOverflow.ellipsis,
-                                textAlign: TextAlign.center,
-                              );
-                            } else {
-                              if (!wouldOverflow) {
-                                return Text(
-                                  text,
-                                  style: textStyle,
-                                  textAlign: TextAlign.center,
-                                  maxLines: 2,
-                                  overflow: TextOverflow.ellipsis,
-                                );
-                              } else {
-                                if (ref.watch(finampSettingsProvider.oneLineMarqueeTextButton)) {
-                                  return SizedBox(
-                                    width: 280,
-                                    height: 30,
-                                    child: ScrollingTextHelper(
-                                      id: ValueKey(currentTrack.item.id),
-                                      text: text,
-                                      style: textStyle,
-                                      alignment: TextAlign.center,
-                                    ),
-                                  );
-                                } else {
-                                  return Text(
-                                    text,
-                                    style: textStyle,
-                                    textAlign: TextAlign.center,
-                                    maxLines: 2,
-                                    overflow: TextOverflow.ellipsis,
-                                  );
-                                }
-                              }
-                            }
-                          },
-                        ),
-                      ),
-                    ),
-                  ),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    crossAxisAlignment: CrossAxisAlignment.center,
-                    children: [
-                      PlayerButtonsMore(item: trackBaseItemDto, queueItem: currentTrack),
-                      Flexible(
-                        child: ArtistChips(
-                          baseItem: trackBaseItemDto,
-                          backgroundColor: IconTheme.of(context).color!.withOpacity(0.1),
-                        ),
-                      ),
-                      AddToPlaylistButton(item: trackBaseItemDto, queueItem: currentTrack),
-                    ],
-                  ),
-                  Center(
-                    child: Container(
-                      constraints: const BoxConstraints(maxWidth: 280),
-                      child: AlbumChips(
-                        baseItem: trackBaseItemDto!,
-                        backgroundColor: IconTheme.of(context).color!.withOpacity(0.1),
-                        key: trackBaseItemDto.album == null ? null : ValueKey("${trackBaseItemDto.album}-album"),
-                      ),
-                    ),
-                  ),
-                ],
-              ),
+              child: content,
             );
           },
         );

--- a/lib/components/PlayerScreen/track_name_content.dart
+++ b/lib/components/PlayerScreen/track_name_content.dart
@@ -59,7 +59,7 @@ class TrackNameContent extends StatelessWidget {
                             final textStyle = TextStyle(
                               fontSize: 20,
                               height: 1.2,
-                              fontWeight: Theme.of(context).brightness == Brightness.light
+                              fontWeight: Theme.brightnessOf(context) == Brightness.light
                                   ? FontWeight.w500
                                   : FontWeight.w600,
                             );

--- a/lib/components/PlayerScreen/track_name_content.dart
+++ b/lib/components/PlayerScreen/track_name_content.dart
@@ -72,6 +72,7 @@ class TrackNameContent extends StatelessWidget {
                             )..layout(maxWidth: 280);
 
                             final wouldOverflow = textPainter.didExceedMaxLines;
+                            textPainter.dispose();
 
                             if (!isTwoLineMode) {
                               return Text(

--- a/lib/components/VolumeNormalizationSettingsScreen/volume_normalization_ios_base_gain_editor.dart
+++ b/lib/components/VolumeNormalizationSettingsScreen/volume_normalization_ios_base_gain_editor.dart
@@ -29,7 +29,7 @@ class _VolumeNormalizationIOSBaseGainEditorState extends ConsumerState<VolumeNor
       title: Text(AppLocalizations.of(context)!.volumeNormalizationIOSBaseGainEditorTitle),
       subtitle: Text(AppLocalizations.of(context)!.volumeNormalizationIOSBaseGainEditorSubtitle),
       trailing: SizedBox(
-        width: 50 * MediaQuery.of(context).textScaleFactor,
+        width: 50 * MediaQuery.textScaleFactorOf(context),
         child: TextField(
           controller: _controller,
           textAlign: TextAlign.center,

--- a/lib/components/album_image.dart
+++ b/lib/components/album_image.dart
@@ -93,8 +93,8 @@ class _AlbumImageState extends ConsumerState<AlbumImage> {
             // If the current themeing context has a usable image for this item,
             // use that instead of generating a new request
             if (ref.watch(
-              localThemeInfoProvider.select(
-                (request) => (request?.largeThemeImage ?? false) && request?.item == widget.item,
+              localImageProvider.select(
+                (localImage) => localImage.largeThemeImage && localImage.request?.item == widget.item,
               ),
             )) {
               listenable = localImageProvider;
@@ -123,7 +123,7 @@ class _AlbumImageState extends ConsumerState<AlbumImage> {
 
               listenable = albumImageProvider(
                 AlbumImageRequest(item: widget.item!, maxWidth: physicalWidth, maxHeight: physicalHeight),
-              ).select((value) => ThemeImage(value, widget.item?.blurHash));
+              ).select((value) => ThemeImage(value, ThemeInfo(widget.item!)));
             }
           }
 
@@ -221,7 +221,8 @@ class BareAlbumImage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    var ThemeImage(image: image, blurHash: blurHash) = ref.watch(imageListenable);
+    final ThemeImage(image: image, request: request) = ref.watch(imageListenable);
+    final blurHash = request?.item.blurHash;
     var localPlaceholder = placeholderBuilder;
     if (blurHash != null) {
       localPlaceholder ??= (_) => Image(

--- a/lib/components/album_image.dart
+++ b/lib/components/album_image.dart
@@ -39,7 +39,7 @@ class AlbumImage extends ConsumerStatefulWidget {
   /// The item to get an image for.
   final BaseItemDto? item;
 
-  final ProviderListenable<ThemeImage>? imageListenable;
+  final ProviderListenable<FinampImage>? imageListenable;
 
   final BorderRadius? borderRadius;
 
@@ -93,9 +93,7 @@ class _AlbumImageState extends ConsumerState<AlbumImage> {
             // If the current themeing context has a usable image for this item,
             // use that instead of generating a new request
             if (ref.watch(
-              localImageProvider.select(
-                (localImage) => localImage.largeThemeImage && localImage.request?.item == widget.item,
-              ),
+              localImageProvider.select((localImage) => localImage.fullQuality && localImage.item == widget.item),
             )) {
               listenable = localImageProvider;
             } else {
@@ -123,7 +121,7 @@ class _AlbumImageState extends ConsumerState<AlbumImage> {
 
               listenable = albumImageProvider(
                 AlbumImageRequest(item: widget.item!, maxWidth: physicalWidth, maxHeight: physicalHeight),
-              ).select((value) => ThemeImage(value, ThemeInfo(widget.item!)));
+              );
             }
           }
 
@@ -205,7 +203,7 @@ class BareAlbumImage extends ConsumerWidget {
     required this.onZoomRoute,
   });
 
-  final ProviderListenable<ThemeImage> imageListenable;
+  final ProviderListenable<FinampImage> imageListenable;
   final WidgetBuilder? placeholderBuilder;
   final OctoErrorBuilder errorBuilder;
   final ImageProviderCallback? imageProviderCallback;
@@ -221,8 +219,8 @@ class BareAlbumImage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final ThemeImage(image: image, request: request) = ref.watch(imageListenable);
-    final blurHash = request?.item.blurHash;
+    final FinampImage(image: image, item: item) = ref.watch(imageListenable);
+    final blurHash = item?.blurHash;
     var localPlaceholder = placeholderBuilder;
     if (blurHash != null) {
       localPlaceholder ??= (_) => Image(

--- a/lib/components/album_image.dart
+++ b/lib/components/album_image.dart
@@ -108,9 +108,9 @@ class _AlbumImageState extends ConsumerState<AlbumImage> {
                 // Logical pixels aren't the same as the physical pixels on the device, they're quite a bit bigger.
                 // If we use logical pixels for the image request, we'll get a smaller image than we want.
                 // Because of this, we convert the logical pixels to physical pixels by multiplying by the device's DPI.
-                final MediaQueryData mediaQuery = MediaQuery.of(context);
-                physicalWidth = (constraints.maxWidth * mediaQuery.devicePixelRatio).toInt();
-                physicalHeight = (constraints.maxHeight * mediaQuery.devicePixelRatio).toInt();
+                final pixelRatio = MediaQuery.devicePixelRatioOf(context);
+                physicalWidth = (constraints.maxWidth * pixelRatio).toInt();
+                physicalHeight = (constraints.maxHeight * pixelRatio).toInt();
                 // If using grid music screen view without fixed size tiles, and if the view is resizable due
                 // to being on desktop and using split screen, then clamp album size to reduce server requests when resizing.
                 if ((!(Platform.isIOS || Platform.isAndroid) || usingPlayerSplitScreen) &&
@@ -154,7 +154,7 @@ class _AlbumImageState extends ConsumerState<AlbumImage> {
                   PageRouteBuilder<_ZoomedImage>(
                     opaque: false,
                     barrierDismissible: true,
-                    transitionDuration: MediaQuery.of(context).disableAnimations
+                    transitionDuration: MediaQuery.disableAnimationsOf(context)
                         ? Duration.zero
                         : const Duration(milliseconds: 500),
                     pageBuilder: (BuildContext context, Animation<double> animation1, Animation<double> animation2) {
@@ -242,10 +242,10 @@ class BareAlbumImage extends ConsumerWidget {
       return OctoImage(
         image: image,
         filterQuality: FilterQuality.medium,
-        fadeOutDuration: MediaQuery.of(context).disableAnimations || onZoomRoute
+        fadeOutDuration: MediaQuery.disableAnimationsOf(context) || onZoomRoute
             ? Duration.zero
             : const Duration(milliseconds: 300),
-        fadeInDuration: MediaQuery.of(context).disableAnimations || onZoomRoute
+        fadeInDuration: MediaQuery.disableAnimationsOf(context) || onZoomRoute
             ? Duration.zero
             : const Duration(milliseconds: 300),
         fit: BoxFit.contain,

--- a/lib/components/audio_fade_progress_visualizer_container.dart
+++ b/lib/components/audio_fade_progress_visualizer_container.dart
@@ -133,7 +133,7 @@ class _AudioFadeProgressVisualizerContainerState extends State<AudioFadeProgress
               borderRadius: widget.borderRadius,
               border:
                   (_controller.status == AnimationStatus.forward || _controller.status == AnimationStatus.reverse) &&
-                      !MediaQuery.of(context).disableAnimations
+                      !MediaQuery.disableAnimationsOf(context)
                   ? ProgressBorder.all(
                       color: widget.color ?? Theme.of(context).textTheme.bodyMedium!.color!.withAlpha(128),
                       width: 4,

--- a/lib/components/confirmation_prompt_dialog.dart
+++ b/lib/components/confirmation_prompt_dialog.dart
@@ -1,20 +1,20 @@
 import 'package:flutter/material.dart';
 
-class ConfirmationPromptDialog extends AlertDialog {
+import '../l10n/app_localizations.dart';
+
+class ConfirmationPromptDialog extends StatelessWidget {
   const ConfirmationPromptDialog({
     super.key,
     required this.promptText,
     required this.confirmButtonText,
-    required this.abortButtonText,
-    required this.onConfirmed,
-    required this.onAborted,
+    this.abortButtonText,
+    this.onConfirmed,
     this.centerText = false,
   });
   final String promptText;
   final String confirmButtonText;
   final String? abortButtonText;
   final void Function()? onConfirmed;
-  final void Function()? onAborted;
   final bool centerText;
 
   @override
@@ -29,23 +29,22 @@ class ConfirmationPromptDialog extends AlertDialog {
       actionsOverflowDirection: VerticalDirection.up,
       title: Text(promptText, style: const TextStyle(fontSize: 18), textAlign: centerText ? TextAlign.center : null),
       actions: [
-        if (abortButtonText != null)
-          Container(
-            constraints: const BoxConstraints(maxWidth: 150.0),
-            child: TextButton(
-              child: Text(abortButtonText!, textAlign: TextAlign.center),
-              onPressed: () {
-                Navigator.of(context).pop();
-                onAborted?.call();
-              },
-            ),
+        Container(
+          constraints: const BoxConstraints(maxWidth: 150.0),
+          child: TextButton(
+            child: Text(abortButtonText ?? AppLocalizations.of(context)!.genericCancel, textAlign: TextAlign.center),
+            onPressed: () {
+              // The widget may be dismissed via the modal instead of the cancel button, so return null to unify behaviors.
+              Navigator.of(context).pop(null);
+            },
           ),
+        ),
         Container(
           constraints: const BoxConstraints(maxWidth: 150.0),
           child: TextButton(
             child: Text(confirmButtonText, textAlign: TextAlign.center, softWrap: true),
             onPressed: () {
-              Navigator.of(context).pop(); // Close the dialog
+              Navigator.of(context).pop(true); // Close the dialog
               onConfirmed?.call();
             },
           ),

--- a/lib/components/delete_prompts.dart
+++ b/lib/components/delete_prompts.dart
@@ -18,7 +18,6 @@ Future<void> askBeforeDeleteDownloadFromDevice(BuildContext context, DownloadStu
     builder: (context) => ConfirmationPromptDialog(
       promptText: AppLocalizations.of(context)!.deleteFromTargetDialogText("", "device", type),
       confirmButtonText: AppLocalizations.of(context)!.deleteFromTargetConfirmButton("device"),
-      abortButtonText: AppLocalizations.of(context)!.genericCancel,
       onConfirmed: () async {
         try {
           await GetIt.instance<DownloadsService>().deleteDownload(stub: stub);
@@ -38,7 +37,6 @@ Future<void> askBeforeDeleteDownloadFromDevice(BuildContext context, DownloadStu
           refresh != null ? refresh() : null;
         }
       },
-      onAborted: () {},
       centerText: true,
     ),
   );
@@ -63,7 +61,6 @@ Future<void> askBeforeDeleteFromServerAndDevice(
     builder: (_) => ConfirmationPromptDialog(
       promptText: AppLocalizations.of(context)!.deleteFromTargetDialogText(deleteType.textForm, "server", type),
       confirmButtonText: AppLocalizations.of(context)!.deleteFromTargetConfirmButton("server"),
-      abortButtonText: AppLocalizations.of(context)!.genericCancel,
       onConfirmed: () async {
         try {
           await jellyfinApiHelper.deleteItem(BaseItemId(stub.id));
@@ -90,7 +87,6 @@ Future<void> askBeforeDeleteFromServerAndDevice(
           refresh != null ? refresh() : null;
         }
       },
-      onAborted: () {},
       centerText: true,
     ),
   );

--- a/lib/components/icon_and_text.dart
+++ b/lib/components/icon_and_text.dart
@@ -11,7 +11,7 @@ class IconAndText extends StatelessWidget {
   Widget build(BuildContext context) {
     final effectiveIconColor =
         iconColor ??
-        Theme.of(context).iconTheme.color?.withOpacity(Theme.of(context).brightness == Brightness.light ? 0.38 : 0.5);
+        Theme.of(context).iconTheme.color?.withOpacity(Theme.brightnessOf(context) == Brightness.light ? 0.38 : 0.5);
 
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 2),

--- a/lib/components/item_collections_sliver_list.dart
+++ b/lib/components/item_collections_sliver_list.dart
@@ -6,7 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../models/jellyfin_models.dart';
 
-class CollectionsSliverList extends ConsumerStatefulWidget {
+class CollectionsSliverList extends ConsumerWidget {
   const CollectionsSliverList({
     super.key,
     required this.childrenForList,
@@ -23,33 +23,21 @@ class CollectionsSliverList extends ConsumerStatefulWidget {
   final SortBy? adaptiveAdditionalInfoSortBy;
 
   @override
-  ConsumerState<CollectionsSliverList> createState() => _ItemsSliverListState();
-}
-
-class _ItemsSliverListState extends ConsumerState<CollectionsSliverList> {
-  final GlobalKey<SliverAnimatedListState> sliverListKey = GlobalKey<SliverAnimatedListState>();
-
-  @override
-  void initState() {
-    super.initState();
-  }
-
-  @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final filterArtistScreens = ref.watch(finampSettingsProvider.genreFilterArtistScreens);
     return SliverList(
       delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
-        final BaseItemDto item = widget.childrenForList[index];
+        final BaseItemDto item = childrenForList[index];
         final itemType = BaseItemDtoType.fromItem(item);
         return ItemCollectionWrapper(
           key: ValueKey(item.id),
           item: item,
           isPlaylist: false,
-          genreFilter: (itemType == BaseItemDtoType.artist && filterArtistScreens) ? widget.genreFilter : null,
-          albumShowsYearAndDurationInstead: widget.albumShowsYearAndDurationInstead,
-          adaptiveAdditionalInfoSortBy: widget.adaptiveAdditionalInfoSortBy,
+          genreFilter: (itemType == BaseItemDtoType.artist && filterArtistScreens) ? genreFilter : null,
+          albumShowsYearAndDurationInstead: albumShowsYearAndDurationInstead,
+          adaptiveAdditionalInfoSortBy: adaptiveAdditionalInfoSortBy,
         );
-      }, childCount: widget.childrenForList.length),
+      }, childCount: childrenForList.length),
     );
   }
 }

--- a/lib/components/now_playing_bar.dart
+++ b/lib/components/now_playing_bar.dart
@@ -41,7 +41,7 @@ class NowPlayingBar extends StatelessWidget {
       BoxShadow(
         blurRadius: 12.0,
         spreadRadius: 8.0,
-        color: Theme.of(context).brightness == Brightness.light
+        color: Theme.brightnessOf(context) == Brightness.light
             ? darkColorScheme.surface.withOpacity(0.15)
             : darkColorScheme.surface.withOpacity(0.7),
       ),
@@ -51,10 +51,10 @@ class NowPlayingBar extends StatelessWidget {
   Color getProgressBackgroundColor(WidgetRef ref) {
     return ref.watch(finampSettingsProvider.showProgressOnNowPlayingBar)
         ? Color.alphaBlend(
-            Theme.of(ref.context).brightness == Brightness.dark
+            Theme.brightnessOf(ref.context) == Brightness.dark
                 ? IconTheme.of(ref.context).color!.withOpacity(0.35)
                 : IconTheme.of(ref.context).color!.withOpacity(0.5),
-            Theme.of(ref.context).brightness == Brightness.dark ? Colors.black : Colors.white,
+            Theme.brightnessOf(ref.context) == Brightness.dark ? Colors.black : Colors.white,
           )
         : IconTheme.of(ref.context).color!.withOpacity(0.85);
   }
@@ -77,10 +77,10 @@ class NowPlayingBar extends StatelessWidget {
           child: Material(
             shadowColor: Theme.of(
               context,
-            ).colorScheme.primary.withOpacity(Theme.of(context).brightness == Brightness.light ? 0.75 : 0.3),
+            ).colorScheme.primary.withOpacity(Theme.brightnessOf(context) == Brightness.light ? 0.75 : 0.3),
             borderRadius: BorderRadius.circular(12.0),
             clipBehavior: Clip.antiAlias,
-            color: Theme.of(context).brightness == Brightness.dark
+            color: Theme.brightnessOf(context) == Brightness.dark
                 ? IconTheme.of(context).color!.withOpacity(0.1)
                 : Theme.of(context).cardColor,
             elevation: 8.0,
@@ -210,10 +210,10 @@ class NowPlayingBar extends StatelessWidget {
                   child: Material(
                     shadowColor: Theme.of(
                       context,
-                    ).colorScheme.primary.withOpacity(Theme.of(context).brightness == Brightness.light ? 0.75 : 0.3),
+                    ).colorScheme.primary.withOpacity(Theme.brightnessOf(context) == Brightness.light ? 0.75 : 0.3),
                     borderRadius: BorderRadius.circular(12.0),
                     clipBehavior: Clip.antiAlias,
-                    color: Theme.of(context).brightness == Brightness.dark
+                    color: Theme.brightnessOf(context) == Brightness.dark
                         ? IconTheme.of(context).color!.withOpacity(0.1)
                         : Theme.of(context).cardColor,
                     elevation: 8.0,
@@ -343,7 +343,7 @@ class NowPlayingBar extends StatelessWidget {
                                                           fontSize: 16,
                                                           height: 26 / 20,
                                                           color: Colors.white,
-                                                          fontWeight: Theme.of(context).brightness == Brightness.light
+                                                          fontWeight: Theme.brightnessOf(context) == Brightness.light
                                                               ? FontWeight.w500
                                                               : FontWeight.w600,
                                                         ),

--- a/lib/components/now_playing_bar.dart
+++ b/lib/components/now_playing_bar.dart
@@ -85,7 +85,7 @@ class NowPlayingBar extends StatelessWidget {
                 : Theme.of(context).cardColor,
             elevation: 8.0,
             child: Container(
-              width: MediaQuery.of(context).size.width,
+              width: MediaQuery.widthOf(context),
               height: albumImageSize,
               padding: EdgeInsets.zero,
               child: Container(
@@ -133,7 +133,7 @@ class NowPlayingBar extends StatelessWidget {
     PageRouteBuilder(
       pageBuilder: (context, animation, secondaryAnimation) => const PlayerScreen(),
       transitionsBuilder: (context, animation, secondaryAnimation, child) {
-        if (MediaQuery.of(context).disableAnimations) {
+        if (MediaQuery.disableAnimationsOf(context)) {
           return child;
         }
         const begin = Offset(0.0, 1.0);
@@ -233,7 +233,7 @@ class NowPlayingBar extends StatelessWidget {
                         if (mediaState.mediaItem != null) {
                           //TODO move into separate component and share with queue list
                           return Container(
-                            width: MediaQuery.of(context).size.width,
+                            width: MediaQuery.widthOf(context),
                             height: albumImageSize,
                             padding: EdgeInsets.zero,
                             child: Container(

--- a/lib/components/one_line_marquee_helper.dart
+++ b/lib/components/one_line_marquee_helper.dart
@@ -25,6 +25,7 @@ class OneLineMarqueeHelper extends ConsumerWidget {
         )..layout(maxWidth: constraints.maxWidth);
 
         final isOverflowing = textPainter.didExceedMaxLines;
+        textPainter.dispose();
 
         if (isOverflowing) {
           return Container(

--- a/lib/components/padded_custom_scrollview.dart
+++ b/lib/components/padded_custom_scrollview.dart
@@ -37,7 +37,7 @@ class PaddedCustomScrollview extends CustomScrollView {
   List<Widget> buildSlivers(BuildContext context) {
     final MediaQueryData? mediaQuery = MediaQuery.maybeOf(context);
     if (mediaQuery == null) {
-      return slivers;
+      return [...slivers, SliverPadding(padding: EdgeInsets.only(bottom: bottomPadding))];
     }
 
     // Strip bottom MediaQuery padding because it is being added by this widget.

--- a/lib/components/themed_bottom_sheet.dart
+++ b/lib/components/themed_bottom_sheet.dart
@@ -35,9 +35,9 @@ Future<void> showThemedBottomSheet({
   var ref = GetIt.instance<ProviderContainer>();
   final localThemeImage = ref.read(localImageProvider);
   bool useDefaultTheme = false;
-  ThemeImage? themeImage;
+  FinampImage? themeImage;
   // If we have a usable theme image for our item, propagate this information
-  if (localThemeImage.largeThemeImage && localThemeImage.request?.item == item) {
+  if (localThemeImage.fullQuality && localThemeImage.item == item) {
     themeImage = ref.read(localImageProvider);
   } else if (item == null) {
     useDefaultTheme = true;

--- a/lib/components/themed_bottom_sheet.dart
+++ b/lib/components/themed_bottom_sheet.dart
@@ -140,13 +140,14 @@ class _ThemedBottomSheetState extends ConsumerState<ThemedBottomSheet> {
   }
 
   Widget buildInternal(double stackHeight, List<Widget> slivers) {
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        stackHeight += widget.showDragHandle ? 29.5 : 0;
-        // Account for bottom padding in PaddedCustomscrollview
-        stackHeight += 32;
-        stackHeight += MediaQuery.paddingOf(context).bottom;
-        if (Platform.isIOS || Platform.isAndroid) {
+    stackHeight += widget.showDragHandle ? 29.5 : 0;
+    // Account for bottom padding in PaddedCustomscrollview
+    stackHeight += 32;
+    stackHeight += MediaQuery.paddingOf(context).bottom;
+
+    if (Platform.isIOS || Platform.isAndroid) {
+      return LayoutBuilder(
+        builder: (context, constraints) {
           var size = (stackHeight / constraints.maxHeight).clamp(widget.minDraggableHeight, 1.0);
           return DraggableScrollableSheet(
             controller: dragController,
@@ -156,17 +157,22 @@ class _ThemedBottomSheetState extends ConsumerState<ThemedBottomSheet> {
             expand: false,
             builder: (context, scrollController) => menu(scrollController, slivers),
           );
-        } else {
+        },
+      );
+    } else {
+      final child = menu(_controller, slivers);
+      return LayoutBuilder(
+        builder: (context, constraints) {
           var minSize = widget.minDraggableHeight * constraints.maxHeight;
           return SizedBox(
             // This is an overestimate of stack height on desktop, but this widget
             // needs some bottom padding on large displays anyway.
             height: max(minSize, stackHeight),
-            child: menu(_controller, slivers),
+            child: child,
           );
-        }
-      },
-    );
+        },
+      );
+    }
   }
 
   Widget menu(ScrollController scrollController, List<Widget> slivers) {

--- a/lib/components/themed_bottom_sheet.dart
+++ b/lib/components/themed_bottom_sheet.dart
@@ -33,11 +33,11 @@ Future<void> showThemedBottomSheet({
 }) async {
   FeedbackHelper.feedback(FeedbackType.heavy);
   var ref = GetIt.instance<ProviderContainer>();
-  var themeInfo = ref.read(localThemeInfoProvider);
+  final localThemeImage = ref.read(localImageProvider);
   bool useDefaultTheme = false;
   ThemeImage? themeImage;
   // If we have a usable theme image for our item, propagate this information
-  if ((themeInfo?.largeThemeImage ?? false) && themeInfo?.item == item) {
+  if (localThemeImage.largeThemeImage && localThemeImage.request?.item == item) {
     themeImage = ref.read(localImageProvider);
   } else if (item == null) {
     useDefaultTheme = true;
@@ -71,7 +71,6 @@ Future<void> showThemedBottomSheet({
         overrides: [
           if (useDefaultTheme) localThemeProvider.overrideWithValue(getDefaultTheme(Theme.brightnessOf(context))),
           if (!useDefaultTheme && themeImage != null) localImageProvider.overrideWithValue(themeImage),
-          if (!useDefaultTheme && themeImage != null) localThemeInfoProvider.overrideWithValue(themeInfo),
           if (!useDefaultTheme && themeImage == null && item != null)
             localThemeInfoProvider.overrideWithValue(ThemeInfo(item, useIsolate: false)),
         ],

--- a/lib/components/themed_bottom_sheet.dart
+++ b/lib/components/themed_bottom_sheet.dart
@@ -56,7 +56,7 @@ Future<void> showThemedBottomSheet({
     isScrollControlled: true,
     clipBehavior: Clip.hardEdge,
     constraints: BoxConstraints(
-      maxWidth: (Platform.isIOS || Platform.isAndroid) ? 500 : min(500, MediaQuery.sizeOf(context).width * 0.9),
+      maxWidth: (Platform.isIOS || Platform.isAndroid) ? 500 : min(500, MediaQuery.widthOf(context) * 0.9),
     ),
     isDismissible: true,
     enableDrag: true,

--- a/lib/components/themed_bottom_sheet.dart
+++ b/lib/components/themed_bottom_sheet.dart
@@ -42,6 +42,13 @@ Future<void> showThemedBottomSheet({
   } else if (item == null) {
     useDefaultTheme = true;
   }
+  final menu = ThemedBottomSheet(
+    key: ValueKey((item?.id?.raw ?? "") + routeName),
+    buildSlivers: buildSlivers,
+    buildWrapper: buildWrapper,
+    minDraggableHeight: minDraggableHeight,
+    showDragHandle: showDragHandle,
+  );
   await showModalBottomSheet<void>(
     context: context,
     backgroundColor: Theme.of(context).colorScheme.surfaceContainerHighest,
@@ -62,19 +69,13 @@ Future<void> showThemedBottomSheet({
     builder: (BuildContext context) {
       return ProviderScope(
         overrides: [
-          if (useDefaultTheme) localThemeProvider.overrideWithValue(getDefaultTheme(Theme.of(context).brightness)),
+          if (useDefaultTheme) localThemeProvider.overrideWithValue(getDefaultTheme(Theme.brightnessOf(context))),
           if (!useDefaultTheme && themeImage != null) localImageProvider.overrideWithValue(themeImage),
           if (!useDefaultTheme && themeImage != null) localThemeInfoProvider.overrideWithValue(themeInfo),
           if (!useDefaultTheme && themeImage == null && item != null)
             localThemeInfoProvider.overrideWithValue(ThemeInfo(item, useIsolate: false)),
         ],
-        child: ThemedBottomSheet(
-          key: ValueKey((item?.id?.raw ?? "") + routeName),
-          buildSlivers: buildSlivers,
-          buildWrapper: buildWrapper,
-          minDraggableHeight: minDraggableHeight,
-          showDragHandle: showDragHandle,
-        ),
+        child: menu,
       );
     },
   );

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2804,5 +2804,17 @@
   "syncingFailed": "Sync failed.  This download has likely been removed from the server, and should be deleted.",
   "@syncingFailed": {
     "description": "Message shown for downloads with the sync failed status, which is generally caused by the server-side item being removed."
+  },
+  "autoplayRestoredQueueTitle": "Automatically Play Restored Queues",
+  "@autoplayRestoredQueueTitle": {
+    "description": "Title for the setting that controls if restored queues automatically play."
+  },
+  "autoplayRestoredQueueSubtitle": "Queues restored automatically on startup or via the queue restore screen will begin playing automatically.  Queues which fail to restore all tracks will never autoplay, regardless of this setting.",
+  "@autoplayRestoredQueueSubtitle": {
+    "description": "Subtitle for the setting that controls if restored queues automatically play."
+  },
+  "missingBlurhashWarning": "Warning: The Jellyfin server appears to be misconfigured and is not calculating blurhashes.  This prevents Finamp from de-duplicating image downloads.  Please correct the server and run a downloads repair.",
+  "@missingBlurhashWarning": {
+    "description": "A warning message displayed on the downloads screen if the jellyfin server is missing blurhashes."
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2243,6 +2243,10 @@
   "@emptyTopTracksList": {
     "description": "Message shown as a placeholder when the top tracks list for an artist is empty"
   },
+  "emptyAlbum": "No tracks.",
+  "@emptyAlbum": {
+    "description": "Message shown as a placeholder when an album or playlist is empty."
+  },
   "emptyFilteredListTitle": "No items found",
   "@emptyFilteredListTitle": {
     "description": "Message shown when a list of items is filtered and no items match the filter"
@@ -2772,5 +2776,17 @@
   "dragToReorder": "Drag to Reorder",
   "@dragToReorder": {
     "description": "Label shown on drag handles of track list  tiles in the queue list"
+  },
+  "addDownloadLocationsErrorPrompt": "Writing to selected directory failed.  You should modify permissions or choose another location.",
+  "@addDownloadLocationsErrorPrompt": {
+    "description": "Label shown on popup dialog when adding a download location when writing songs fails"
+  },
+  "androidImageErrorPrompt": "WARNING: We are unable to write images to the android Music folder due to OS restrictions.  You should choose another location.",
+  "@androidImageErrorPrompt": {
+    "description": "Label shown on popup dialog when adding a download location when writing songs succeeds but writing images fails, which can occur on android."
+  },
+  "addDownloadLocationsErrorButton": "Add anyway",
+  "@addDownloadLocationsErrorButton": {
+    "description": "Label shown on button for adding a download location we suspect to be buggy"
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2788,5 +2788,21 @@
   "addDownloadLocationsErrorButton": "Add anyway",
   "@addDownloadLocationsErrorButton": {
     "description": "Label shown on button for adding a download location we suspect to be buggy"
+  },
+  "syncFailedWarningShort": "Warning: Failed to synchronize some downloads with server.",
+  "@syncFailedWarningShort": {
+    "description": "Simple warning message for when download sync fails due to items being deleted from the server."
+  },
+  "syncFailedWarningLong": "Some downloads failed to synchronize with the server.  The matching server item was likely deleted.  The failed download should be deleted to clean up the outdated files.",
+  "@syncFailedWarningLong": {
+    "description": "Expanded warning message for when download sync fails due to items being deleted from the server."
+  },
+  "openDownloads": "Open Downloads",
+  "@openDownloads": {
+    "description": "Label on a button to open the downloads screen after a sync fails."
+  },
+  "syncingFailed": "Sync failed.  This download has likely been removed from the server, and should be deleted.",
+  "@syncingFailed": {
+    "description": "Message shown for downloads with the sync failed status, which is generally caused by the server-side item being removed."
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -459,7 +459,12 @@ Future<void> _trustAndroidUserCerts() async {
   // Extend the default security context to trust Android user certificates.
   // This is a workaround for <https://github.com/dart-lang/sdk/issues/50435>.
   WidgetsFlutterBinding.ensureInitialized();
-  await FlutterUserCertificatesAndroid().trustAndroidUserCertificates(SecurityContext.defaultContext);
+  try {
+    await FlutterUserCertificatesAndroid().trustAndroidUserCertificates(SecurityContext.defaultContext);
+  } catch (e) {
+    Logger("AndroidCertTrust").severe("Failed to trust certificates: $e", e);
+    GlobalSnackbar.error("Failed to trust user certificates: $e");
+  }
 }
 
 Future<void> _setupFinampUserHelper() async {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -308,6 +308,8 @@ Future<void> _setupProviders() async {
   container.listen(finampSettingsProvider, (_, __) {});
   await container.read(finampSettingsProvider.future);
 
+  await initImageCache();
+
   DataSourceService.create();
   AutoOffline.startWatching();
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -281,7 +281,7 @@ Future<void> setupHive() async {
   Box<ThemeMode> themeModeBox = Hive.box("ThemeMode");
   if (themeModeBox.isEmpty) ThemeModeHelper.setThemeMode(DefaultSettings.theme);
 
-  final compactFile = File(path_helper.join(dir.path, "$isarDatabaseName.compact}"));
+  final compactFile = File(path_helper.join(dir.path, "$isarDatabaseName.isar.compact}"));
   if (compactFile.existsSync()) {
     compactFile.deleteSync();
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -281,6 +281,10 @@ Future<void> setupHive() async {
   Box<ThemeMode> themeModeBox = Hive.box("ThemeMode");
   if (themeModeBox.isEmpty) ThemeModeHelper.setThemeMode(DefaultSettings.theme);
 
+  final compactFile = File(path_helper.join(dir.path, "$isarDatabaseName.compact}"));
+  if (compactFile.existsSync()) {
+    compactFile.deleteSync();
+  }
   final isar = await Isar.open(
     [DownloadItemSchema, IsarTaskDataSchema, FinampUserSchema, DownloadedLyricsSchema],
     directory: dir.path,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -96,11 +96,13 @@ import 'services/theme_mode_helper.dart';
 import 'setup_logging.dart';
 
 final _mainLog = Logger("Main()");
+late DateTime startTime;
 
 void main() async {
   // If the app has failed, this is set to true. If true, we don't attempt to run the main app since the error app has started.
   bool hasFailed = false;
   try {
+    startTime = DateTime.now();
     await setupLogging();
     await _setupEdgeToEdgeOverlayStyle();
     _mainLog.info("Setup edge-to-edge overlay");

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -25,6 +25,7 @@ import 'package:finamp/screens/playback_history_screen.dart';
 import 'package:finamp/screens/playback_reporting_settings_screen.dart';
 import 'package:finamp/screens/player_settings_screen.dart';
 import 'package:finamp/screens/queue_restore_screen.dart';
+import 'package:finamp/services/album_image_provider.dart';
 import 'package:finamp/services/android_auto_helper.dart';
 import 'package:finamp/services/audio_service_smtc.dart';
 import 'package:finamp/services/data_source_service.dart';
@@ -379,8 +380,8 @@ Future<void> _setupPlaybackServices() async {
       androidNotificationIcon: "mipmap/white",
       androidNotificationChannelId: "com.unicornsonlsd.finamp.audio",
       // notificationColor: TODO use the theme color for older versions of Android,
-      // Preloading art does not work on android due to use of content:// scheme.
-      preloadArtwork: !Platform.isAndroid,
+      // We will handle preloading artwork ourselves
+      preloadArtwork: false,
       androidBrowsableRootExtras: <String, dynamic>{
         // support showing search button on Android Auto as well as alternative search results on the player screen after voice search
         "android.media.browse.SEARCH_SUPPORTED": true,
@@ -391,6 +392,7 @@ Future<void> _setupPlaybackServices() async {
             FinampSettingsHelper.finampSettings.contentViewType == ContentViewType.list ? 1 : 2,
       },
     ),
+    cacheManager: StubImageCache(),
   );
 
   GetIt.instance.registerSingleton<MusicPlayerBackgroundTask>(audioHandler);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -542,7 +542,7 @@ class _FinampState extends State<Finamp> with WindowListener {
           child: ValueListenableBuilder(
             valueListenable: LocaleHelper.localeListener,
             builder: (_, __, ___) {
-              final transitionBuilder = MediaQuery.of(context).disableAnimations
+              final transitionBuilder = MediaQuery.disableAnimationsOf(context)
                   ? PageTransitionsTheme(
                       // Disable page transitions on all platforms if [disableAnimations] is true, otherwise use default transitions
                       builders: TargetPlatform.values.fold(

--- a/lib/menus/components/icon_button_with_semantics.dart
+++ b/lib/menus/components/icon_button_with_semantics.dart
@@ -29,7 +29,7 @@ class IconButtonWithSemantics extends ConsumerWidget {
           visualDensity: VisualDensity.compact,
           onPressed: () {
             if (onPressed != null) {
-              onPressed();
+              onPressed!();
               FeedbackHelper.feedback(FeedbackType.selection);
             }
           },

--- a/lib/menus/components/menuEntries/delete_from_server_menu_entry.dart
+++ b/lib/menus/components/menuEntries/delete_from_server_menu_entry.dart
@@ -34,9 +34,8 @@ class DeleteFromServerMenuEntry extends ConsumerWidget implements HideableMenuEn
                 : DownloadItemType.collection,
             item: baseItem,
           );
-          await askBeforeDeleteFromServerAndDevice(context, item);
-          Navigator.pop(context); // close popup
-          musicScreenRefreshStream.add(null);
+          await askBeforeDeleteFromServerAndDevice(context, item, refresh: () => musicScreenRefreshStream.add(null));
+          if (context.mounted) Navigator.pop(context); // close popup
         },
       ),
     );

--- a/lib/menus/components/menu_item_info_header.dart
+++ b/lib/menus/components/menu_item_info_header.dart
@@ -370,7 +370,7 @@ class _ItemInfoState extends ConsumerState<ItemInfo> {
           height: widget.condensed ? infoHeaderCondensedInternalHeight : infoHeaderFullInternalHeight,
           clipBehavior: Clip.antiAlias,
           decoration: ShapeDecoration(
-            color: Theme.of(context).brightness == Brightness.dark
+            color: Theme.brightnessOf(context) == Brightness.dark
                 ? Colors.black.withOpacity(0.25)
                 : Colors.white.withOpacity(0.15),
             shape: widget.shape,

--- a/lib/menus/components/playbackActions/playback_actions.dart
+++ b/lib/menus/components/playbackActions/playback_actions.dart
@@ -75,13 +75,12 @@ class PlayPlaybackAction extends ConsumerWidget {
       icon: TablerIcons.player_play,
       label: AppLocalizations.of(context)!.playButtonLabel,
       onPressed: () async {
+        Navigator.pop(context);
         await queueService.startPlayback(
           items: await loadChildTracks(item: item),
           source: QueueItemSource.fromPlayableItem(item),
           order: FinampPlaybackOrder.linear,
         );
-
-        Navigator.pop(context);
       },
       iconColor: Theme.of(context).textTheme.bodyMedium?.color ?? Colors.white,
     );
@@ -103,6 +102,7 @@ class PlayNextPlaybackAction extends ConsumerWidget {
         icon: TablerIcons.corner_right_down,
         label: AppLocalizations.of(context)!.playNext,
         onPressed: () async {
+          Navigator.pop(context);
           await queueService.addNext(
             items: await loadChildTracks(item: item),
             source: QueueItemSource.fromPlayableItem(item, type: QueueItemSourceType.nextUpAlbum),
@@ -112,7 +112,6 @@ class PlayNextPlaybackAction extends ConsumerWidget {
             (scaffold) => AppLocalizations.of(scaffold)!.confirmPlayNext(BaseItemDtoType.fromPlayableItem(item).name),
             isConfirmation: true,
           );
-          Navigator.pop(context);
         },
         iconColor: Theme.of(context).textTheme.bodyMedium?.color ?? Colors.white,
       ),
@@ -133,6 +132,7 @@ class AddToNextUpPlaybackAction extends ConsumerWidget {
       icon: TablerIcons.corner_right_down_double,
       label: AppLocalizations.of(context)!.addToNextUp,
       onPressed: () async {
+        Navigator.pop(context);
         await queueService.addToNextUp(
           items: await loadChildTracks(item: item),
           source: QueueItemSource.fromPlayableItem(item, type: QueueItemSourceType.nextUpAlbum),
@@ -142,7 +142,6 @@ class AddToNextUpPlaybackAction extends ConsumerWidget {
           (scaffold) => AppLocalizations.of(scaffold)!.confirmAddToNextUp(BaseItemDtoType.fromPlayableItem(item).name),
           isConfirmation: true,
         );
-        Navigator.pop(context);
       },
       iconColor: Theme.of(context).textTheme.bodyMedium?.color ?? Colors.white,
     );
@@ -161,6 +160,7 @@ class AddToQueuePlaybackAction extends ConsumerWidget {
       icon: TablerIcons.playlist,
       label: AppLocalizations.of(context)!.addToQueue,
       onPressed: () async {
+        Navigator.pop(context);
         await queueService.addToQueue(
           items: await loadChildTracks(item: item),
           source: QueueItemSource.fromPlayableItem(item),
@@ -170,7 +170,6 @@ class AddToQueuePlaybackAction extends ConsumerWidget {
           (scaffold) => AppLocalizations.of(scaffold)!.confirmAddToQueue(BaseItemDtoType.fromPlayableItem(item).name),
           isConfirmation: true,
         );
-        Navigator.pop(context);
       },
       iconColor: Theme.of(context).textTheme.bodyMedium?.color ?? Colors.white,
     );
@@ -189,13 +188,12 @@ class ShufflePlaybackAction extends ConsumerWidget {
       icon: TablerIcons.arrows_shuffle,
       label: AppLocalizations.of(context)!.shuffleButtonLabel,
       onPressed: () async {
+        Navigator.pop(context);
         await queueService.startPlayback(
           items: await loadChildTracks(item: item),
           source: QueueItemSource.fromPlayableItem(item),
           order: FinampPlaybackOrder.shuffled,
         );
-
-        Navigator.pop(context);
       },
       iconColor: Theme.of(context).textTheme.bodyMedium?.color ?? Colors.white,
     );
@@ -217,6 +215,7 @@ class ShuffleNextPlaybackAction extends ConsumerWidget {
         icon: TablerIcons.corner_right_down,
         label: AppLocalizations.of(context)!.shuffleNext,
         onPressed: () async {
+          Navigator.pop(context);
           await queueService.addNext(
             items: await loadChildTracks(item: item),
             source: QueueItemSource.fromPlayableItem(item, type: QueueItemSourceType.nextUpAlbum),
@@ -224,7 +223,6 @@ class ShuffleNextPlaybackAction extends ConsumerWidget {
           );
 
           GlobalSnackbar.message((scaffold) => AppLocalizations.of(scaffold)!.confirmShuffleNext, isConfirmation: true);
-          Navigator.pop(context);
         },
         iconColor: Theme.of(context).textTheme.bodyMedium?.color ?? Colors.white,
       ),
@@ -245,6 +243,7 @@ class ShuffleToNextUpPlaybackAction extends ConsumerWidget {
       icon: TablerIcons.corner_right_down_double,
       label: AppLocalizations.of(context)!.shuffleToNextUp,
       onPressed: () async {
+        Navigator.pop(context);
         await queueService.addToNextUp(
           items: await loadChildTracks(item: item),
           source: QueueItemSource.fromPlayableItem(item, type: QueueItemSourceType.nextUpAlbum),
@@ -255,7 +254,6 @@ class ShuffleToNextUpPlaybackAction extends ConsumerWidget {
           (scaffold) => AppLocalizations.of(scaffold)!.confirmShuffleToNextUp,
           isConfirmation: true,
         );
-        Navigator.pop(context);
       },
       iconColor: Theme.of(context).textTheme.bodyMedium?.color ?? Colors.white,
     );
@@ -274,6 +272,7 @@ class ShuffleToQueuePlaybackAction extends ConsumerWidget {
       icon: TablerIcons.playlist,
       label: AppLocalizations.of(context)!.shuffleToQueue,
       onPressed: () async {
+        Navigator.pop(context);
         await queueService.addToQueue(
           items: await loadChildTracks(item: item),
           source: QueueItemSource.fromPlayableItem(item),
@@ -284,7 +283,6 @@ class ShuffleToQueuePlaybackAction extends ConsumerWidget {
           (scaffold) => AppLocalizations.of(scaffold)!.confirmShuffleToQueue,
           isConfirmation: true,
         );
-        Navigator.pop(context);
       },
       iconColor: Theme.of(context).textTheme.bodyMedium?.color ?? Colors.white,
     );
@@ -303,6 +301,7 @@ class ShuffleAlbumsAction extends ConsumerWidget {
       icon: TablerIcons.arrows_shuffle,
       label: AppLocalizations.of(context)!.shuffleAlbums,
       onPressed: () async {
+        Navigator.pop(context);
         await queueService.startPlayback(
           items: groupItems(
             items: await loadChildTracks(item: baseItem),
@@ -311,8 +310,6 @@ class ShuffleAlbumsAction extends ConsumerWidget {
           ),
           source: QueueItemSource.fromBaseItem(baseItem, type: QueueItemSourceType.nextUpAlbum),
         );
-
-        Navigator.pop(context);
       },
       iconColor: Theme.of(context).textTheme.bodyMedium?.color ?? Colors.white,
     );
@@ -334,6 +331,7 @@ class ShuffleAlbumsNextPlaybackAction extends ConsumerWidget {
         icon: TablerIcons.corner_right_down,
         label: AppLocalizations.of(context)!.shuffleAlbumsNext,
         onPressed: () async {
+          Navigator.pop(context);
           await queueService.addNext(
             items: groupItems(
               items: await loadChildTracks(item: baseItem),
@@ -344,7 +342,6 @@ class ShuffleAlbumsNextPlaybackAction extends ConsumerWidget {
           );
 
           GlobalSnackbar.message((scaffold) => AppLocalizations.of(scaffold)!.confirmShuffleNext, isConfirmation: true);
-          Navigator.pop(context);
         },
         iconColor: Theme.of(context).textTheme.bodyMedium?.color ?? Colors.white,
       ),
@@ -365,6 +362,7 @@ class ShuffleAlbumsToNextUpPlaybackAction extends ConsumerWidget {
       icon: TablerIcons.corner_right_down_double,
       label: AppLocalizations.of(context)!.shuffleAlbumsToNextUp,
       onPressed: () async {
+        Navigator.pop(context);
         await queueService.addToNextUp(
           items: groupItems(
             items: await loadChildTracks(item: baseItem),
@@ -378,7 +376,6 @@ class ShuffleAlbumsToNextUpPlaybackAction extends ConsumerWidget {
           (scaffold) => AppLocalizations.of(scaffold)!.confirmShuffleToNextUp,
           isConfirmation: true,
         );
-        Navigator.pop(context);
       },
       iconColor: Theme.of(context).textTheme.bodyMedium?.color ?? Colors.white,
     );
@@ -397,6 +394,7 @@ class ShuffleAlbumsToQueuePlaybackAction extends ConsumerWidget {
       icon: TablerIcons.playlist,
       label: AppLocalizations.of(context)!.shuffleAlbumsToQueue,
       onPressed: () async {
+        Navigator.pop(context);
         await queueService.addToQueue(
           items: groupItems(
             items: await loadChildTracks(item: baseItem),
@@ -410,7 +408,6 @@ class ShuffleAlbumsToQueuePlaybackAction extends ConsumerWidget {
           (scaffold) => AppLocalizations.of(scaffold)!.confirmShuffleToQueue,
           isConfirmation: true,
         );
-        Navigator.pop(context);
       },
       iconColor: Theme.of(context).textTheme.bodyMedium?.color ?? Colors.white,
     );

--- a/lib/menus/output_menu.dart
+++ b/lib/menus/output_menu.dart
@@ -19,13 +19,10 @@ import 'package:flutter_sticky_header/flutter_sticky_header.dart';
 import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
 import 'package:flutter_to_airplay/flutter_to_airplay.dart';
 import 'package:get_it/get_it.dart';
-import 'package:logging/logging.dart';
 
 const outputMenuRouteName = "/output-menu";
 
 Future<void> showOutputMenu({required BuildContext context, bool usePlayerTheme = true}) async {
-  final outputPanelLogger = Logger("OutputPanel");
-
   final queueService = GetIt.instance<QueueService>();
 
   FeedbackHelper.feedback(FeedbackType.selection);
@@ -48,7 +45,6 @@ Future<void> showOutputMenu({required BuildContext context, bool usePlayerTheme 
               onChange: (double currentValue) async {
                 final audioHandler = GetIt.instance<MusicPlayerBackgroundTask>();
                 audioHandler.setVolume(currentValue);
-                outputPanelLogger.fine("Volume set to $currentValue");
               },
               forceLoading: true,
             );
@@ -448,9 +444,6 @@ class RoundedRectangleTrackShape extends RoundedRectSliderTrackShape {
       thumbCenter.dx + sliderTheme.thumbShape!.getPreferredSize(isEnabled, isDiscrete).width,
       trackRect.bottom,
     );
-
-    // Inactive track
-    final inactiveRect = Rect.fromLTRB(thumbCenter.dx, trackRect.top, trackRect.right, trackRect.bottom);
 
     final Paint activePaint = Paint()..color = sliderTheme.activeTrackColor!;
     final Paint inactivePaint = Paint()..color = sliderTheme.inactiveTrackColor!;

--- a/lib/menus/output_menu.dart
+++ b/lib/menus/output_menu.dart
@@ -2,11 +2,11 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:finamp/color_schemes.g.dart';
+import 'package:finamp/components/Buttons/cta_medium.dart';
 import 'package:finamp/components/global_snackbar.dart';
 import 'package:finamp/components/themed_bottom_sheet.dart';
 import 'package:finamp/components/toggleable_list_tile.dart';
-import 'package:finamp/menus/playlist_actions_menu.dart';
-import 'package:finamp/components/Buttons/cta_medium.dart';
+import 'package:finamp/l10n/app_localizations.dart';
 import 'package:finamp/models/finamp_models.dart';
 import 'package:finamp/services/feedback_helper.dart';
 import 'package:finamp/services/finamp_settings_helper.dart';
@@ -14,7 +14,6 @@ import 'package:finamp/services/music_player_background_task.dart';
 import 'package:finamp/services/queue_service.dart';
 import 'package:finamp/services/theme_provider.dart';
 import 'package:flutter/material.dart';
-import 'package:finamp/l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_sticky_header/flutter_sticky_header.dart';
 import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
@@ -37,8 +36,6 @@ Future<void> showOutputMenu({required BuildContext context, bool usePlayerTheme 
     routeName: outputMenuRouteName,
     minDraggableHeight: 0.2,
     buildSlivers: (context) {
-      var themeColor = Theme.of(context).colorScheme.primary;
-
       final menuEntries = [
         // SongInfo.condensed(
         //   item: item,
@@ -96,7 +93,7 @@ Future<void> showOutputMenu({required BuildContext context, bool usePlayerTheme 
           ),
       ];
       // TODO better estimate, how to deal with lag getting playlists?
-      var stackHeight = MediaQuery.sizeOf(context).height * (Platform.isAndroid ? 0.65 : 0.4);
+      var stackHeight = MediaQuery.heightOf(context) * (Platform.isAndroid ? 0.65 : 0.4);
       return (stackHeight, menu);
     },
   );
@@ -133,7 +130,7 @@ class OutputMenuHeader extends ConsumerWidget {
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 8.0),
               child: AnimatedSwitcher(
-                duration: MediaQuery.of(context).disableAnimations ? Duration.zero : const Duration(milliseconds: 1000),
+                duration: MediaQuery.disableAnimationsOf(context) ? Duration.zero : const Duration(milliseconds: 1000),
                 switchOutCurve: const Threshold(0.0),
                 child: Consumer(
                   builder: (context, ref, child) {

--- a/lib/menus/playlist_actions_menu.dart
+++ b/lib/menus/playlist_actions_menu.dart
@@ -110,7 +110,7 @@ Future<void> showPlaylistActionsMenu({
         const SliverPadding(padding: EdgeInsets.only(bottom: 100.0)),
       ];
       // TODO better estimate, how to deal with lag getting playlists?
-      var stackHeight = MediaQuery.sizeOf(context).height * 0.9;
+      var stackHeight = MediaQuery.heightOf(context) * 0.9;
       return (stackHeight, menu);
     },
   );

--- a/lib/menus/quick_connect_authorization_menu.dart
+++ b/lib/menus/quick_connect_authorization_menu.dart
@@ -41,7 +41,7 @@ Future<void> showQuickConnectAuthorizationMenu({required BuildContext context}) 
         ),
         SliverPadding(padding: EdgeInsets.only(bottom: 40.0)),
       ];
-      var stackHeight = MediaQuery.sizeOf(context).height * 0.65;
+      var stackHeight = MediaQuery.heightOf(context) * 0.65;
       return (stackHeight, menu);
     },
   );

--- a/lib/menus/server_sharing_menu.dart
+++ b/lib/menus/server_sharing_menu.dart
@@ -154,9 +154,7 @@ class _ServerSharingMenuControlsState extends ConsumerState<ServerSharingMenuCon
               confirmButtonText: AppLocalizations.of(
                 context,
               )!.serverSharingMenuConfirmationDialogConfirmationButtonLabel,
-              abortButtonText: MaterialLocalizations.of(context).cancelButtonLabel,
               onConfirmed: () => setServerSharing(true),
-              onAborted: () {},
             ),
           );
         } else {

--- a/lib/menus/server_sharing_menu.dart
+++ b/lib/menus/server_sharing_menu.dart
@@ -64,7 +64,7 @@ Future<void> showServerSharingPanel({required BuildContext context}) async {
         ),
         SliverPadding(padding: EdgeInsets.only(bottom: 40.0)),
       ];
-      var stackHeight = MediaQuery.sizeOf(context).height * 0.45;
+      var stackHeight = MediaQuery.heightOf(context) * 0.45;
       return (stackHeight, menu);
     },
   );

--- a/lib/menus/track_menu.dart
+++ b/lib/menus/track_menu.dart
@@ -458,7 +458,7 @@ class _TrackMenuState extends ConsumerState<TrackMenu> with TickerProviderStateM
           child: Padding(
             padding: const EdgeInsets.only(top: 8.0, bottom: 4.0),
             child: Divider(
-              color: Theme.of(context).brightness == Brightness.light
+              color: Theme.brightnessOf(context) == Brightness.light
                   ? Color.alphaBlend(Theme.of(context).primaryColor.withOpacity(0.6), Colors.black26)
                   : Color.alphaBlend(Theme.of(context).primaryColor.withOpacity(0.8), Colors.white),
               indent: 24.0,

--- a/lib/menus/track_menu.dart
+++ b/lib/menus/track_menu.dart
@@ -192,7 +192,7 @@ class _TrackMenuState extends ConsumerState<TrackMenu> with TickerProviderStateM
   void scrollToExtent(DraggableScrollableController scrollController, double? percentage) {
     var currentSize = scrollController.size;
     if ((percentage != null && currentSize < percentage) || scrollController.size == inputStep) {
-      if (MediaQuery.of(context).disableAnimations) {
+      if (MediaQuery.disableAnimationsOf(context)) {
         scrollController.jumpTo(percentage ?? oldExtent);
       } else {
         scrollController.animateTo(
@@ -408,7 +408,7 @@ class _TrackMenuState extends ConsumerState<TrackMenu> with TickerProviderStateM
                       );
                     },
                     transitionBuilder: (child, animation) {
-                      if (MediaQuery.of(context).disableAnimations) {
+                      if (MediaQuery.disableAnimationsOf(context)) {
                         return child;
                       }
                       // Determine if this is the incoming or outgoing child

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -1334,6 +1334,7 @@ class DownloadStub {
       userTranscodingProfile: null,
       syncTranscodingProfile: transcodingProfile,
       fileTranscodingProfile: null,
+      themeColor: null,
     );
   }
 
@@ -1362,6 +1363,7 @@ class DownloadItem extends DownloadStub {
     required this.userTranscodingProfile,
     required this.syncTranscodingProfile,
     required this.fileTranscodingProfile,
+    required this.themeColor,
   }) : super._build() {
     assert(!(type == DownloadItemType.collection && baseItemType == BaseItemDtoType.playlist) || viewId == null);
   }
@@ -1404,6 +1406,10 @@ class DownloadItem extends DownloadStub {
   DownloadProfile? userTranscodingProfile;
   DownloadProfile? syncTranscodingProfile;
   DownloadProfile? fileTranscodingProfile;
+
+  /// The primary color of an image used for theming, stored as an ARGB32 int.
+  /// This should only be non-null for images with a blurhash id.
+  int? themeColor;
 
   @ignore
   DownloadLocation? get fileDownloadLocation =>
@@ -1499,6 +1505,7 @@ class DownloadItem extends DownloadStub {
       userTranscodingProfile: userTranscodingProfile,
       syncTranscodingProfile: syncTranscodingProfile,
       fileTranscodingProfile: fileTranscodingProfile,
+      themeColor: themeColor,
     );
   }
 }

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -231,6 +231,7 @@ class DefaultSettings {
   static const rpcIcon = DiscordRpcIcon.transparent;
   static const preferAddingToFavoritesOverPlaylists = false;
   static const previousTracksExpaned = false;
+  static const autoplayRestoredQueue = false;
 }
 
 @HiveType(typeId: 28)
@@ -357,6 +358,7 @@ class FinampSettings {
     this.rpcIcon = DefaultSettings.rpcIcon,
     this.preferAddingToFavoritesOverPlaylists = DefaultSettings.preferAddingToFavoritesOverPlaylists,
     this.previousTracksExpaned = DefaultSettings.previousTracksExpaned,
+    this.autoplayRestoredQueue = DefaultSettings.autoplayRestoredQueue,
   });
 
   @HiveField(0, defaultValue: DefaultSettings.isOffline)
@@ -755,6 +757,9 @@ class FinampSettings {
 
   @HiveField(127, defaultValue: DefaultSettings.previousTracksExpaned)
   bool previousTracksExpaned = DefaultSettings.previousTracksExpaned;
+
+  @HiveField(128, defaultValue: DefaultSettings.autoplayRestoredQueue)
+  bool autoplayRestoredQueue = DefaultSettings.autoplayRestoredQueue;
 
   static Future<FinampSettings> create() async {
     final downloadLocation = await DownloadLocation.create(

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -116,7 +116,7 @@ class DefaultSettings {
   static const playbackSpeedVisibility = PlaybackSpeedVisibility.automatic;
   static const contentGridViewCrossAxisCountPortrait = 2;
   static const contentGridViewCrossAxisCountLandscape = 3;
-  static const showTextOnGridView = true;
+  static const showTextOnGridView = false;
   static const sleepTimerDurationSeconds = 60 * 30;
   static const useCoverAsBackground = true;
   static const playerScreenCoverMinimumPadding = 1.5;

--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -4853,20 +4853,25 @@ const DownloadItemSchema = CollectionSchema(
 
       target: r'DownloadProfile',
     ),
-    r'type': PropertySchema(
+    r'themeColor': PropertySchema(
       id: 11,
+      name: r'themeColor',
+      type: IsarType.long,
+    ),
+    r'type': PropertySchema(
+      id: 12,
       name: r'type',
       type: IsarType.byte,
       enumMap: _DownloadItemtypeEnumValueMap,
     ),
     r'userTranscodingProfile': PropertySchema(
-      id: 12,
+      id: 13,
       name: r'userTranscodingProfile',
       type: IsarType.object,
 
       target: r'DownloadProfile',
     ),
-    r'viewId': PropertySchema(id: 13, name: r'viewId', type: IsarType.string),
+    r'viewId': PropertySchema(id: 14, name: r'viewId', type: IsarType.string),
   },
 
   estimateSize: _downloadItemEstimateSize,
@@ -5036,14 +5041,15 @@ void _downloadItemSerialize(
     DownloadProfileSchema.serialize,
     object.syncTranscodingProfile,
   );
-  writer.writeByte(offsets[11], object.type.index);
+  writer.writeLong(offsets[11], object.themeColor);
+  writer.writeByte(offsets[12], object.type.index);
   writer.writeObject<DownloadProfile>(
-    offsets[12],
+    offsets[13],
     allOffsets,
     DownloadProfileSchema.serialize,
     object.userTranscodingProfile,
   );
-  writer.writeString(offsets[13], object.isarViewId);
+  writer.writeString(offsets[14], object.isarViewId);
 }
 
 DownloadItem _downloadItemDeserialize(
@@ -5079,15 +5085,16 @@ DownloadItem _downloadItemDeserialize(
       DownloadProfileSchema.deserialize,
       allOffsets,
     ),
+    themeColor: reader.readLongOrNull(offsets[11]),
     type:
-        _DownloadItemtypeValueEnumMap[reader.readByteOrNull(offsets[11])] ??
+        _DownloadItemtypeValueEnumMap[reader.readByteOrNull(offsets[12])] ??
         DownloadItemType.collection,
     userTranscodingProfile: reader.readObjectOrNull<DownloadProfile>(
-      offsets[12],
+      offsets[13],
       DownloadProfileSchema.deserialize,
       allOffsets,
     ),
-    isarViewId: reader.readStringOrNull(offsets[13]),
+    isarViewId: reader.readStringOrNull(offsets[14]),
   );
   return object;
 }
@@ -5138,17 +5145,19 @@ P _downloadItemDeserializeProp<P>(
           ))
           as P;
     case 11:
+      return (reader.readLongOrNull(offset)) as P;
+    case 12:
       return (_DownloadItemtypeValueEnumMap[reader.readByteOrNull(offset)] ??
               DownloadItemType.collection)
           as P;
-    case 12:
+    case 13:
       return (reader.readObjectOrNull<DownloadProfile>(
             offset,
             DownloadProfileSchema.deserialize,
             allOffsets,
           ))
           as P;
-    case 13:
+    case 14:
       return (reader.readStringOrNull(offset)) as P;
     default:
       throw IsarError('Unknown property with id $propertyId');
@@ -6670,6 +6679,79 @@ extension DownloadItemQueryFilter
     });
   }
 
+  QueryBuilder<DownloadItem, DownloadItem, QAfterFilterCondition>
+  themeColorIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNull(property: r'themeColor'),
+      );
+    });
+  }
+
+  QueryBuilder<DownloadItem, DownloadItem, QAfterFilterCondition>
+  themeColorIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNotNull(property: r'themeColor'),
+      );
+    });
+  }
+
+  QueryBuilder<DownloadItem, DownloadItem, QAfterFilterCondition>
+  themeColorEqualTo(int? value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(property: r'themeColor', value: value),
+      );
+    });
+  }
+
+  QueryBuilder<DownloadItem, DownloadItem, QAfterFilterCondition>
+  themeColorGreaterThan(int? value, {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.greaterThan(
+          include: include,
+          property: r'themeColor',
+          value: value,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<DownloadItem, DownloadItem, QAfterFilterCondition>
+  themeColorLessThan(int? value, {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.lessThan(
+          include: include,
+          property: r'themeColor',
+          value: value,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<DownloadItem, DownloadItem, QAfterFilterCondition>
+  themeColorBetween(
+    int? lower,
+    int? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.between(
+          property: r'themeColor',
+          lower: lower,
+          includeLower: includeLower,
+          upper: upper,
+          includeUpper: includeUpper,
+        ),
+      );
+    });
+  }
+
   QueryBuilder<DownloadItem, DownloadItem, QAfterFilterCondition> typeEqualTo(
     DownloadItemType value,
   ) {
@@ -7279,6 +7361,19 @@ extension DownloadItemQuerySortBy
     });
   }
 
+  QueryBuilder<DownloadItem, DownloadItem, QAfterSortBy> sortByThemeColor() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'themeColor', Sort.asc);
+    });
+  }
+
+  QueryBuilder<DownloadItem, DownloadItem, QAfterSortBy>
+  sortByThemeColorDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'themeColor', Sort.desc);
+    });
+  }
+
   QueryBuilder<DownloadItem, DownloadItem, QAfterSortBy> sortByType() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'type', Sort.asc);
@@ -7420,6 +7515,19 @@ extension DownloadItemQuerySortThenBy
     });
   }
 
+  QueryBuilder<DownloadItem, DownloadItem, QAfterSortBy> thenByThemeColor() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'themeColor', Sort.asc);
+    });
+  }
+
+  QueryBuilder<DownloadItem, DownloadItem, QAfterSortBy>
+  thenByThemeColorDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'themeColor', Sort.desc);
+    });
+  }
+
   QueryBuilder<DownloadItem, DownloadItem, QAfterSortBy> thenByType() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'type', Sort.asc);
@@ -7510,6 +7618,12 @@ extension DownloadItemQueryWhereDistinct
   QueryBuilder<DownloadItem, DownloadItem, QDistinct> distinctByState() {
     return QueryBuilder.apply(this, (query) {
       return query.addDistinctBy(r'state');
+    });
+  }
+
+  QueryBuilder<DownloadItem, DownloadItem, QDistinct> distinctByThemeColor() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'themeColor');
     });
   }
 
@@ -7605,6 +7719,12 @@ extension DownloadItemQueryProperty
   syncTranscodingProfileProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'syncTranscodingProfile');
+    });
+  }
+
+  QueryBuilder<DownloadItem, int?, QQueryOperations> themeColorProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'themeColor');
     });
   }
 

--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -406,6 +406,9 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
         previousTracksExpaned: fields[127] == null
             ? false
             : fields[127] as bool,
+        autoplayRestoredQueue: fields[128] == null
+            ? false
+            : fields[128] as bool,
       )
       ..disableGesture = fields[19] == null ? false : fields[19] as bool
       ..showFastScroller = fields[25] == null ? true : fields[25] as bool
@@ -420,7 +423,7 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
   @override
   void write(BinaryWriter writer, FinampSettings obj) {
     writer
-      ..writeByte(121)
+      ..writeByte(122)
       ..writeByte(0)
       ..write(obj.isOffline)
       ..writeByte(1)
@@ -662,7 +665,9 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       ..writeByte(126)
       ..write(obj.preferAddingToFavoritesOverPlaylists)
       ..writeByte(127)
-      ..write(obj.previousTracksExpaned);
+      ..write(obj.previousTracksExpaned)
+      ..writeByte(128)
+      ..write(obj.autoplayRestoredQueue);
   }
 
   @override

--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -123,7 +123,7 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
         contentGridViewCrossAxisCountLandscape: fields[12] == null
             ? 3
             : (fields[12] as num).toInt(),
-        showTextOnGridView: fields[13] == null ? true : fields[13] as bool,
+        showTextOnGridView: fields[13] == null ? false : fields[13] as bool,
         downloadLocationsMap: fields[15] == null
             ? {}
             : (fields[15] as Map).cast<String, DownloadLocation>(),

--- a/lib/models/jellyfin_models.dart
+++ b/lib/models/jellyfin_models.dart
@@ -3774,7 +3774,7 @@ class LyricLineCue {
 
   int get startMicros => start ~/ 10;
 
-  int get endMicros => end != null ? end! ~/ 10 : 0;
+  int? get endMicros => end != null ? end! ~/ 10 : null;
 
   factory LyricLineCue.fromJson(Map<String, dynamic> json) => _$LyricLineCueFromJson(json);
 

--- a/lib/screens/active_downloads_screen.dart
+++ b/lib/screens/active_downloads_screen.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:finamp/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 import 'package:rxdart/rxdart.dart';
 
@@ -51,7 +51,7 @@ class ActiveDownloadsScreen extends StatelessWidget {
                       // https://material.io/design/iconography/system-icons.html#color
                       color: Theme.of(
                         context,
-                      ).iconTheme.color?.withOpacity(Theme.of(context).brightness == Brightness.light ? 0.38 : 0.5),
+                      ).iconTheme.color?.withOpacity(Theme.brightnessOf(context) == Brightness.light ? 0.38 : 0.5),
                     ),
                     const Padding(padding: EdgeInsets.all(8.0)),
                     Text(AppLocalizations.of(context)!.noActiveDownloads),

--- a/lib/screens/audio_service_settings_screen.dart
+++ b/lib/screens/audio_service_settings_screen.dart
@@ -41,6 +41,7 @@ class _AudioServiceSettingsScreenState extends State<AudioServiceSettingsScreen>
           const BufferDurationListTile(),
           const BufferDisableSizeConstraintsSelector(),
           const LoadQueueOnStartupSelector(),
+          const AutoplayRestoredQueueToggle(),
           const AutoReloadQueueToggle(),
           const ClearQueueOnStopToggle(),
         ],
@@ -209,6 +210,20 @@ class AutoReloadQueueToggle extends ConsumerWidget {
       subtitle: Text(AppLocalizations.of(context)!.autoReloadQueueSubtitle),
       value: ref.watch(finampSettingsProvider.autoReloadQueue),
       onChanged: FinampSetters.setAutoReloadQueue,
+    );
+  }
+}
+
+class AutoplayRestoredQueueToggle extends ConsumerWidget {
+  const AutoplayRestoredQueueToggle({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return SwitchListTile.adaptive(
+      title: Text(AppLocalizations.of(context)!.autoplayRestoredQueueTitle),
+      subtitle: Text(AppLocalizations.of(context)!.autoplayRestoredQueueSubtitle),
+      value: ref.watch(finampSettingsProvider.autoplayRestoredQueue),
+      onChanged: FinampSetters.setAutoplayRestoredQueue,
     );
   }
 }

--- a/lib/screens/audio_service_settings_screen.dart
+++ b/lib/screens/audio_service_settings_screen.dart
@@ -90,7 +90,7 @@ class _BufferSizeListTileState extends ConsumerState<BufferSizeListTile> {
       title: Text(AppLocalizations.of(context)!.bufferSizeTitle),
       subtitle: Text(AppLocalizations.of(context)!.bufferSizeSubtitle),
       trailing: SizedBox(
-        width: 50 * MediaQuery.of(context).textScaleFactor,
+        width: 50 * MediaQuery.textScaleFactorOf(context),
         child: TextField(
           controller: _controller,
           textAlign: TextAlign.center,
@@ -138,7 +138,7 @@ class _AudioFadeInDurationListTileState extends ConsumerState<AudioFadeInDuratio
       title: Text(AppLocalizations.of(context)!.audioFadeInDurationSettingTitle),
       subtitle: Text(AppLocalizations.of(context)!.audioFadeInDurationSettingSubtitle),
       trailing: SizedBox(
-        width: 50 * MediaQuery.of(context).textScaleFactor,
+        width: 50 * MediaQuery.textScaleFactorOf(context),
         child: TextField(
           controller: _controller,
           textAlign: TextAlign.center,
@@ -181,7 +181,7 @@ class _AudioFadeOutDurationListTileState extends ConsumerState<AudioFadeOutDurat
       title: Text(AppLocalizations.of(context)!.audioFadeOutDurationSettingTitle),
       subtitle: Text(AppLocalizations.of(context)!.audioFadeOutDurationSettingSubtitle),
       trailing: SizedBox(
-        width: 50 * MediaQuery.of(context).textScaleFactor,
+        width: 50 * MediaQuery.textScaleFactorOf(context),
         child: TextField(
           controller: _controller,
           textAlign: TextAlign.center,

--- a/lib/screens/blurred_player_screen_background.dart
+++ b/lib/screens/blurred_player_screen_background.dart
@@ -19,7 +19,8 @@ class BlurredPlayerScreenBackground extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    var ThemeImage(image: imageProvider, blurHash: localBlurhash) = ref.watch(localImageProvider);
+    final ThemeImage(image: imageProvider, request: request) = ref.watch(localImageProvider);
+    final localBlurhash = request?.item.blurHash;
 
     var overlayColor = Theme.brightnessOf(context) == Brightness.dark
         ? Colors.black.withOpacity(ui.clampDouble(0.675 * opacityFactor, 0.0, 1.0))

--- a/lib/screens/blurred_player_screen_background.dart
+++ b/lib/screens/blurred_player_screen_background.dart
@@ -21,7 +21,7 @@ class BlurredPlayerScreenBackground extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     var ThemeImage(image: imageProvider, blurHash: localBlurhash) = ref.watch(localImageProvider);
 
-    var overlayColor = Theme.of(context).brightness == Brightness.dark
+    var overlayColor = Theme.brightnessOf(context) == Brightness.dark
         ? Colors.black.withOpacity(ui.clampDouble(0.675 * opacityFactor, 0.0, 1.0))
         : Colors.white.withOpacity(ui.clampDouble(0.75 * opacityFactor, 0.0, 1.0));
 
@@ -45,7 +45,7 @@ class BlurredPlayerScreenBackground extends ConsumerWidget {
             : OctoImage(
                 // Don't transition between images with identical files/urls unless
                 // system theme has changed
-                key: ValueKey(imageProvider.hashCode + Theme.of(context).brightness.hashCode),
+                key: ValueKey(imageProvider.hashCode + Theme.brightnessOf(context).hashCode),
                 image: imageProvider,
                 fit: BoxFit.cover,
                 fadeInDuration: Duration.zero,
@@ -85,7 +85,7 @@ class CachePaint extends SingleChildRenderObjectWidget {
 
   @override
   RenderCachePaint createRenderObject(BuildContext context) {
-    return RenderCachePaint(imageKey, MediaQuery.sizeOf(context), Theme.of(context).brightness);
+    return RenderCachePaint(imageKey, MediaQuery.sizeOf(context), Theme.brightnessOf(context));
   }
 }
 

--- a/lib/screens/blurred_player_screen_background.dart
+++ b/lib/screens/blurred_player_screen_background.dart
@@ -19,8 +19,9 @@ class BlurredPlayerScreenBackground extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final ThemeImage(image: imageProvider, request: request) = ref.watch(localImageProvider);
-    final localBlurhash = request?.item.blurHash;
+    final finampImage = ref.watch(localImageProvider);
+    final localBlurhash = finampImage.item?.blurHash;
+    final imageProvider = finampImage.image;
 
     var overlayColor = Theme.brightnessOf(context) == Brightness.dark
         ? Colors.black.withOpacity(ui.clampDouble(0.675 * opacityFactor, 0.0, 1.0))

--- a/lib/screens/downloads_screen.dart
+++ b/lib/screens/downloads_screen.dart
@@ -7,6 +7,7 @@ import '../components/DownloadsScreen/downloaded_items_list.dart';
 import '../components/DownloadsScreen/downloads_overview.dart';
 import '../components/DownloadsScreen/repair_downloads_button.dart';
 import '../components/DownloadsScreen/sync_downloads_button.dart';
+import '../components/global_snackbar.dart';
 import '../components/padded_custom_scrollview.dart';
 
 class DownloadsScreen extends StatelessWidget {
@@ -52,4 +53,28 @@ class DownloadsScreen extends StatelessWidget {
       ),
     );
   }
+}
+
+void showSyncWarningSnackbar() {
+  GlobalSnackbar.message(
+    (scaffold) => AppLocalizations.of(scaffold)!.syncFailedWarningShort,
+    action: (context) => SnackBarAction(
+      label: MaterialLocalizations.of(context).moreButtonTooltip,
+      onPressed: () => showDialog(
+        context: context,
+        builder: (context) => AlertDialog(
+          title: Text(AppLocalizations.of(context)!.syncFailedWarningShort),
+          content: Text(AppLocalizations.of(context)!.syncFailedWarningLong),
+          actions: [
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).popAndPushNamed(DownloadsScreen.routeName);
+              },
+              child: Text(AppLocalizations.of(context)!.openDownloads),
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
 }

--- a/lib/screens/downloads_settings_screen.dart
+++ b/lib/screens/downloads_settings_screen.dart
@@ -4,7 +4,6 @@ import 'package:finamp/components/AlbumScreen/download_button.dart';
 import 'package:finamp/l10n/app_localizations.dart';
 import 'package:finamp/services/finamp_user_helper.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:get_it/get_it.dart';
 
@@ -289,7 +288,7 @@ class _BufferSizeListTileState extends State<DownloadSizeWarningCutoffTile> {
       title: Text(AppLocalizations.of(context)!.downloadSizeWarningCutoff),
       subtitle: Text(AppLocalizations.of(context)!.downloadSizeWarningCutoffSubtitle),
       trailing: SizedBox(
-        width: 50 * MediaQuery.of(context).textScaleFactor,
+        width: 50 * MediaQuery.textScaleFactorOf(context),
         child: TextField(
           controller: _controller,
           textAlign: TextAlign.center,

--- a/lib/screens/lyrics_screen.dart
+++ b/lib/screens/lyrics_screen.dart
@@ -377,7 +377,6 @@ class _LyricsViewState extends ConsumerState<LyricsView> with WidgetsBindingObse
                     ),
                   ),
                 ),
-                ),
                 if (_isSynchronizedLyrics)
                   Positioned(
                     bottom: 24,
@@ -432,18 +431,10 @@ class _LyricLine extends ConsumerWidget {
       color: Theme.of(context).textTheme.bodyLarge!.color,
       fontWeight: FontWeight.normal,
       // Keep text width consistent across the different weights
-      letterSpacing: 0.02,
-      fontSize: lyricsFontSizeToSize(ref.watch(finampSettingsProvider.lyricsFontSize)) * 0.75,
-      height: 1.25,
-    );
-    final currentLineStyle = TextStyle(
-      color: Theme.of(context).textTheme.bodyLarge!.color,
-      fontWeight: FontWeight.w500,
-      // Keep text width consistent across the different weights
       letterSpacing: -0.4,
       fontSize: lyricsFontSizeToSize(ref.watch(finampSettingsProvider.lyricsFontSize)).toDouble(),
-      height: 1.25,
     );
+    final currentLineStyle = unSyncedStyle;
     final lowlightStyle = unSyncedStyle.copyWith(color: Colors.grey);
     final cueHighlightStyle = currentLineStyle.copyWith(color: Theme.of(context).colorScheme.primary);
     final cueGreyStyle = currentLineStyle.copyWith(color: Colors.white);

--- a/lib/screens/lyrics_screen.dart
+++ b/lib/screens/lyrics_screen.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:io';
-import 'dart:math' as math;
 
 import 'package:finamp/color_schemes.g.dart';
 import 'package:finamp/components/PlayerScreen/player_screen_appbar_title.dart';
@@ -161,14 +160,14 @@ class LyricsView extends ConsumerStatefulWidget {
 class _LyricsViewState extends ConsumerState<LyricsView> with WidgetsBindingObserver {
   late AutoScrollController autoScrollController;
   StreamSubscription<ProgressState>? progressStateStreamSubscription;
-  Duration? currentPosition;
-  int? currentLineIndex;
-  int? previousLineIndex;
+  // Ranges from -1 to lyricLines.length - 1
+  final ValueNotifier<int?> currentLineNotifier = ValueNotifier(null);
 
   bool isAutoScrollEnabled = true;
 
   bool _isVisible = true;
-  bool _isSynchronizedLyrics = false;
+  bool get _isSynchronizedLyrics => lyrics?.firstOrNull?.start != null;
+  List<LyricLine>? lyrics;
 
   @override
   void initState() {
@@ -188,6 +187,59 @@ class _LyricsViewState extends ConsumerState<LyricsView> with WidgetsBindingObse
       }
     });
 
+    progressStateStreamSubscription = progressStateStream.listen((state) {
+      final currentMicros = state.position.inMicroseconds;
+
+      if (!_isSynchronizedLyrics || !_isVisible || !mounted) {
+        return;
+      }
+      final lyricLines = lyrics!;
+
+      // Find the closest line to the current position, clamping to the first and last lines
+      int closestLineIndex = -1;
+      for (int i = 0; i < lyricLines.length; i++) {
+        closestLineIndex = i;
+        final line = lyricLines[i];
+        if (line.startMicros > currentMicros) {
+          closestLineIndex = i - 1;
+          break;
+        }
+      }
+      closestLineIndex = closestLineIndex.clamp(-1, lyricLines.length - 1);
+
+      if (currentLineNotifier.value != closestLineIndex && mounted) {
+        currentLineNotifier.value = closestLineIndex; // Rebuild to update the current line
+        if (autoScrollController.hasClients && isAutoScrollEnabled) {
+          MediaQuery.disableAnimationsOf(context);
+          if (closestLineIndex < 0) {
+            unawaited(
+              autoScrollController.scrollToIndex(
+                -1,
+                preferPosition: AutoScrollPosition.middle,
+                duration: MediaQuery.disableAnimationsOf(context)
+                    ? const Duration(
+                        milliseconds: 1,
+                      ) // there's an assertion in the library forbidding a duration of 0, so we use 1ms instead to get instant scrolling
+                    : const Duration(milliseconds: 300),
+              ),
+            );
+          } else {
+            unawaited(
+              autoScrollController.scrollToIndex(
+                closestLineIndex,
+                preferPosition: AutoScrollPosition.middle,
+                duration: MediaQuery.disableAnimationsOf(context)
+                    ? const Duration(
+                        milliseconds: 1,
+                      ) // there's an assertion in the library forbidding a duration of 0, so we use 1ms instead to get instant scrolling
+                    : const Duration(milliseconds: 300),
+              ),
+            );
+          }
+        }
+      }
+    });
+
     super.initState();
   }
 
@@ -201,110 +253,56 @@ class _LyricsViewState extends ConsumerState<LyricsView> with WidgetsBindingObse
   void dispose() {
     progressStateStreamSubscription?.cancel();
     WidgetsBinding.instance.removeObserver(this);
+    autoScrollController.dispose();
+    currentLineNotifier.dispose();
     super.dispose();
+  }
+
+  // Only call while within build()
+  Widget _getEmptyState({required String message, required IconData icon}) {
+    return Center(
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          return Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              ConstrainedBox(
+                constraints: BoxConstraints(maxHeight: constraints.maxHeight - 180),
+                child: ref.watch(finampSettingsProvider.showLyricsScreenAlbumPrelude)
+                    ? const PlayerScreenAlbumImage()
+                    : SizedBox(),
+              ),
+              const SizedBox(height: 24),
+              Icon(icon, size: 32, color: Theme.of(context).textTheme.headlineMedium!.color),
+              const SizedBox(height: 12),
+              Text(message, style: TextStyle(color: Theme.of(context).textTheme.headlineMedium!.color, fontSize: 16)),
+            ],
+          );
+        },
+      ),
+    );
   }
 
   @override
   Widget build(BuildContext context) {
-    final audioHandler = GetIt.instance<MusicPlayerBackgroundTask>();
-
-    final metadata = ref.watch(currentTrackMetadataProvider).unwrapPrevious();
-    final finampSettings = ref.watch(finampSettingsProvider).value;
-
     //!!! use unwrapPrevious() to prevent getting previous values. If we don't have the lyrics for the current track yet, we want to show the loading state, and not the lyrics for the previous track
-    _isSynchronizedLyrics = metadata.valueOrNull?.lyrics?.lyrics?.first.start != null;
-
-    Widget getEmptyState({required String message, required IconData icon}) {
-      return Center(
-        child: LayoutBuilder(
-          builder: (context, constraints) {
-            return Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                ConstrainedBox(
-                  constraints: BoxConstraints(maxHeight: constraints.maxHeight - 180),
-                  child: (finampSettings?.showLyricsScreenAlbumPrelude ?? true)
-                      ? const PlayerScreenAlbumImage()
-                      : SizedBox(),
-                ),
-                const SizedBox(height: 24),
-                Icon(icon, size: 32, color: Theme.of(context).textTheme.headlineMedium!.color),
-                const SizedBox(height: 12),
-                Text(message, style: TextStyle(color: Theme.of(context).textTheme.headlineMedium!.color, fontSize: 16)),
-              ],
-            );
-          },
-        ),
-      );
+    final metadata = ref.watch(currentTrackMetadataProvider).unwrapPrevious();
+    lyrics = metadata.valueOrNull?.lyrics?.lyrics;
+    if (!_isSynchronizedLyrics) {
+      currentLineNotifier.value = null;
     }
 
     if ((metadata.isLoading && !metadata.hasValue) || metadata.isRefreshing) {
-      return getEmptyState(message: "Loading lyrics...", icon: TablerIcons.microphone_2);
+      return _getEmptyState(message: "Loading lyrics...", icon: TablerIcons.microphone_2);
     } else if (!metadata.hasValue ||
         metadata.value == null ||
         metadata.value!.hasLyrics && metadata.value!.lyrics == null && !metadata.isLoading) {
-      return getEmptyState(message: "Couldn't load lyrics!", icon: TablerIcons.microphone_2_off);
+      return _getEmptyState(message: "Couldn't load lyrics!", icon: TablerIcons.microphone_2_off);
     } else if (!metadata.value!.hasLyrics) {
-      return getEmptyState(message: "No lyrics available.", icon: TablerIcons.microphone_2_off);
+      return _getEmptyState(message: "No lyrics available.", icon: TablerIcons.microphone_2_off);
     } else {
       // We have lyrics that we can display
-      final lyricLines = metadata.value!.lyrics!.lyrics ?? [];
-
-      progressStateStreamSubscription?.cancel();
-      progressStateStreamSubscription = progressStateStream.listen((state) async {
-        currentPosition = state.position;
-        final currentMicros = state.position.inMicroseconds;
-
-        if (!_isSynchronizedLyrics || !_isVisible) {
-          return;
-        }
-
-        // Find the closest line to the current position, clamping to the first and last lines
-        int closestLineIndex = -1;
-        for (int i = 0; i < lyricLines.length; i++) {
-          closestLineIndex = i;
-          final line = lyricLines[i];
-          if (line.startMicros > currentMicros) {
-            closestLineIndex = i - 1;
-            break;
-          }
-        }
-
-        currentLineIndex = closestLineIndex;
-        if (currentLineIndex! != previousLineIndex && context.mounted) {
-          setState(() {}); // Rebuild to update the current line
-          if (autoScrollController.hasClients && isAutoScrollEnabled) {
-            int clampedIndex = currentLineIndex ?? 0;
-            if (clampedIndex >= lyricLines.length) {
-              clampedIndex = lyricLines.length - 1;
-            }
-            if (clampedIndex < 0) {
-              await autoScrollController.scrollToIndex(
-                -1,
-                preferPosition: AutoScrollPosition.middle,
-                duration: MediaQuery.disableAnimationsOf(context)
-                    ? const Duration(
-                        milliseconds: 1,
-                      ) // there's an assertion in the library forbidding a duration of 0, so we use 1ms instead to get instant scrolling
-                    : const Duration(milliseconds: 300),
-              );
-            } else {
-              unawaited(
-                autoScrollController.scrollToIndex(
-                  clampedIndex.clamp(0, lyricLines.length - 1),
-                  preferPosition: AutoScrollPosition.middle,
-                  duration: MediaQuery.disableAnimationsOf(context)
-                      ? const Duration(
-                          milliseconds: 1,
-                        ) // there's an assertion in the library forbidding a duration of 0, so we use 1ms instead to get instant scrolling
-                      : const Duration(milliseconds: 300),
-                ),
-              );
-            }
-          }
-          previousLineIndex = currentLineIndex;
-        }
-      });
+      final lyricLines = lyrics ?? [];
 
       return LayoutBuilder(
         builder: (context, constraints) {
@@ -313,52 +311,52 @@ class _LyricsViewState extends ConsumerState<LyricsView> with WidgetsBindingObse
             child: Stack(
               children: [
                 LyricsListMask(
-                  child: ListView.builder(
-                    controller: autoScrollController,
-                    itemCount: lyricLines.length,
-                    itemBuilder: (context, index) {
-                      final currentMicros = currentPosition?.inMicroseconds ?? 0;
-                      final line = lyricLines[index];
-                      final nextLine = index < lyricLines.length - 1 ? lyricLines[index + 1] : null;
-
-                      final isCurrentLine =
-                          currentMicros >= line.startMicros &&
-                          (nextLine == null || currentMicros < nextLine.startMicros);
-
-                      return Column(
-                        key: ValueKey(line.startMicros),
-                        crossAxisAlignment: CrossAxisAlignment.stretch,
-                        children: [
-                          if (index == 0)
-                            AutoScrollTag(
-                              key: const ValueKey(-1),
-                              controller: autoScrollController,
-                              index: -1,
-                              child: (finampSettings?.showLyricsScreenAlbumPrelude ?? true)
-                                  ? SizedBox(
-                                      height: constraints.maxHeight * 0.65,
-                                      child: Center(
-                                        child: SizedBox(
-                                          height: constraints.maxHeight * 0.55,
-                                          child: const PlayerScreenAlbumImage(),
-                                        ),
+                  child: ScrollConfiguration(
+                    behavior: const LyricsScrollBehavior(),
+                    child: ListView.builder(
+                      controller: autoScrollController,
+                      itemCount: lyricLines.length + 2,
+                      itemBuilder: (context, rawIndex) {
+                        if (rawIndex == 0) {
+                          // build header
+                          return AutoScrollTag(
+                            key: const ValueKey(-1),
+                            controller: autoScrollController,
+                            index: -1,
+                            child: ref.watch(finampSettingsProvider.showLyricsScreenAlbumPrelude)
+                                ? SizedBox(
+                                    height: constraints.maxHeight * 0.65,
+                                    child: Center(
+                                      child: SizedBox(
+                                        height: constraints.maxHeight * 0.55,
+                                        child: const PlayerScreenAlbumImage(),
                                       ),
-                                    )
-                                  : SizedBox(height: constraints.maxHeight * 0.2),
-                            ),
-                          AutoScrollTag(
+                                    ),
+                                  )
+                                : SizedBox(height: constraints.maxHeight * 0.2),
+                          );
+                        } else if (rawIndex == lyricLines.length + 1) {
+                          // build footer
+                          return SizedBox(height: constraints.maxHeight * 0.2);
+                        } else {
+                          final index = rawIndex - 1;
+                          final line = lyricLines[index];
+                          return AutoScrollTag(
                             key: ValueKey(index),
                             controller: autoScrollController,
                             index: index,
                             child: _LyricLine(
+                              lineNumber: index,
                               line: line,
-                              isCurrentLine: isCurrentLine,
                               onTap: () async {
-                                // Seek to the start of the line
-                                await audioHandler.seek(Duration(microseconds: line.startMicros));
+                                // Seek to the start of the line + 1 millisecond to account for player inaccuracy
+                                await GetIt.instance<MusicPlayerBackgroundTask>().seek(
+                                  Duration(microseconds: line.startMicros + 1000),
+                                );
                                 setState(() {
                                   isAutoScrollEnabled = true;
                                 });
+                                if (!context.mounted) return;
                                 unawaited(
                                   autoScrollController.scrollToIndex(
                                     index,
@@ -371,12 +369,12 @@ class _LyricsViewState extends ConsumerState<LyricsView> with WidgetsBindingObse
                                   ),
                                 );
                               },
+                              currentLineNumberNotifier: currentLineNotifier,
                             ),
-                          ),
-                          if (index == lyricLines.length - 1) SizedBox(height: constraints.maxHeight * 0.2),
-                        ],
-                      );
-                    },
+                          );
+                        }
+                      },
+                    ),
                   ),
                 ),
                 if (_isSynchronizedLyrics)
@@ -389,10 +387,10 @@ class _LyricsViewState extends ConsumerState<LyricsView> with WidgetsBindingObse
                         setState(() {
                           isAutoScrollEnabled = true;
                         });
-                        if (previousLineIndex != null) {
+                        if (currentLineNotifier.value != null) {
                           unawaited(
                             autoScrollController.scrollToIndex(
-                              previousLineIndex!,
+                              currentLineNotifier.value!,
                               preferPosition: AutoScrollPosition.middle,
                               duration: MediaQuery.disableAnimationsOf(context)
                                   ? const Duration(
@@ -417,332 +415,276 @@ class _LyricsViewState extends ConsumerState<LyricsView> with WidgetsBindingObse
 
 class _LyricLine extends ConsumerWidget {
   final LyricLine line;
-  final bool isCurrentLine;
   final VoidCallback? onTap;
+  final int lineNumber;
+  final ValueNotifier<int?> currentLineNumberNotifier;
 
-  const _LyricLine({required this.line, required this.isCurrentLine, this.onTap});
+  const _LyricLine({required this.line, required this.lineNumber, required this.currentLineNumberNotifier, this.onTap});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final finampSettings = ref.watch(finampSettingsProvider).value;
-
     final isSynchronized = line.start != null;
-    final showTimestamp = isSynchronized && !line.text.isNullOrBlank && (finampSettings?.showLyricsTimestamps ?? true);
-    final lowlightLine = isSynchronized && !isCurrentLine;
+    final showTimestamp =
+        isSynchronized && !line.text.isNullOrBlank && ref.watch(finampSettingsProvider.showLyricsTimestamps);
 
-    final textSpan = TextSpan(
-      text: line.text ?? "<missing lyric line>",
-      style: TextStyle(
-        color: lowlightLine ? Colors.grey : Theme.of(context).textTheme.bodyLarge!.color,
-        fontWeight: lowlightLine || !isSynchronized ? FontWeight.normal : FontWeight.w500,
-        // Keep text width consistent across the different weights
-        letterSpacing: lowlightLine || !isSynchronized ? 0.02 : -0.4,
-        fontSize:
-            lyricsFontSizeToSize(finampSettings?.lyricsFontSize ?? LyricsFontSize.medium) *
-            (isSynchronized ? 1.0 : 0.75),
-        height: 1.25,
-      ),
+    final unSyncedStyle = TextStyle(
+      color: Theme.of(context).textTheme.bodyLarge!.color,
+      fontWeight: FontWeight.normal,
+      // Keep text width consistent across the different weights
+      letterSpacing: 0.02,
+      fontSize: lyricsFontSizeToSize(ref.watch(finampSettingsProvider.lyricsFontSize)) * 0.75,
+      height: 1.25,
+    );
+    final currentLineStyle = TextStyle(
+      color: Theme.of(context).textTheme.bodyLarge!.color,
+      fontWeight: FontWeight.w500,
+      // Keep text width consistent across the different weights
+      letterSpacing: -0.4,
+      fontSize: lyricsFontSizeToSize(ref.watch(finampSettingsProvider.lyricsFontSize)).toDouble(),
+      height: 1.25,
+    );
+    final lowlightStyle = unSyncedStyle.copyWith(color: Colors.grey);
+    final cueHighlightStyle = currentLineStyle.copyWith(color: Theme.of(context).colorScheme.primary);
+    final cueGreyStyle = currentLineStyle.copyWith(color: Colors.white);
+    final cueFadeStyle = currentLineStyle.copyWith(
+      color: Color.alphaBlend(Theme.of(context).colorScheme.primary.withOpacity(0.6), Colors.white),
     );
 
     return GestureDetector(
       onTap: isSynchronized ? onTap : null,
       child: Padding(
         padding: EdgeInsets.symmetric(vertical: isSynchronized ? 10.0 : 6.0),
-        child: LayoutBuilder(
-          builder: (context, constraints) {
-            // Calculate available width for lyrics (accounting for timestamp if shown)
-            final availableWidth = constraints.maxWidth - (showTimestamp ? 60 : 0);
-
-            final linePainter = TextPainter(
-              text: textSpan,
-              textAlign: lyricsAlignmentToTextAlign(finampSettings?.lyricsAlignment ?? LyricsAlignment.start),
-              textDirection: TextDirection.ltr,
-            )..setPlaceholderDimensions([]);
-            linePainter.layout(minWidth: 0, maxWidth: availableWidth);
-
-            return StreamBuilder<ProgressState>(
-              stream: progressStateStream,
-              builder: (context, snapshot) {
-                final currentMicros = snapshot.data?.position.inMicroseconds ?? 0;
-
-                return Row(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    if (showTimestamp)
-                      Padding(
-                        padding: const EdgeInsets.only(right: 8.0),
-                        child: Text(
-                          "${Duration(microseconds: line.startMicros).inMinutes}:${(Duration(microseconds: line.startMicros).inSeconds % 60).toString().padLeft(2, '0')}",
-                          style: TextStyle(
-                            color: lowlightLine ? Colors.grey : Theme.of(context).textTheme.bodyLarge!.color,
-                            fontSize: 16,
-                            height:
-                                1.75 *
-                                (lyricsFontSizeToSize(finampSettings?.lyricsFontSize ?? LyricsFontSize.medium) / 26),
-                          ),
-                        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.baseline,
+          textBaseline: TextBaseline.alphabetic,
+          children: [
+            if (showTimestamp)
+              Padding(
+                padding: const EdgeInsets.only(right: 8.0),
+                child: ValueListenableBuilder(
+                  valueListenable: currentLineNumberNotifier,
+                  builder: (context, value, _) {
+                    return Text(
+                      "${Duration(microseconds: line.startMicros).inMinutes}:${(Duration(microseconds: line.startMicros).inSeconds % 60).toString().padLeft(2, '0')}",
+                      style: TextStyle(
+                        color: isSynchronized && value != lineNumber
+                            ? Colors.grey
+                            : Theme.of(context).textTheme.bodyLarge!.color,
+                        fontSize: 16,
                       ),
-                    Expanded(
-                      child: CustomPaint(
-                        size: Size(availableWidth, linePainter.height),
-                        painter: LyricsLinePainter(
-                          textPainter: linePainter,
-                          line: line,
-                          currentMicros: currentMicros,
-                          isCurrentLine: isCurrentLine,
-                          primaryColor: Theme.of(context).textTheme.bodyLarge?.color,
-                          highlightColor: Theme.of(context).colorScheme.primary,
-                          grayedColor: Colors.white,
-                          lowlightLine: lowlightLine,
-                          maxWidth: availableWidth,
-                          textAlign: lyricsAlignmentToTextAlign(
-                            finampSettings?.lyricsAlignment ?? LyricsAlignment.start,
-                          ),
-                          baseStyle: TextStyle(
-                            color: lowlightLine ? Colors.grey : Theme.of(context).textTheme.bodyLarge!.color,
-                            fontWeight: lowlightLine || !isSynchronized ? FontWeight.normal : FontWeight.w500,
-                            // Keep text width consistent across the different weights
-                            letterSpacing: lowlightLine || !isSynchronized ? 0.02 : -0.4,
-                            fontSize:
-                                lyricsFontSizeToSize(finampSettings?.lyricsFontSize ?? LyricsFontSize.medium) *
-                                (isSynchronized ? 1.0 : 0.75),
-                            height: 1.25,
-                          ),
-                        ),
-                      ),
-                    ),
-                  ],
-                );
-              },
-            );
-          },
+                    );
+                  },
+                ),
+              ),
+            Expanded(
+              child: _LyricLineText(
+                line: line,
+                lineNumber: lineNumber,
+                currentLineNumberNotifier: currentLineNumberNotifier,
+                lowlightStyle: lowlightStyle,
+                cueGreyStyle: cueGreyStyle,
+                cueHighlightStyle: cueHighlightStyle,
+                unSyncedStyle: unSyncedStyle,
+                currentLineStyle: currentLineStyle,
+                cueFadeStyle: cueFadeStyle,
+              ),
+            ),
+          ],
         ),
       ),
     );
   }
 }
 
-class LyricsLinePainter extends ChangeNotifier implements CustomPainter {
-  final TextPainter textPainter;
+class _LyricLineText extends ConsumerStatefulWidget {
   final LyricLine line;
-  final int currentMicros;
-  final bool isCurrentLine;
-  final Color? primaryColor;
-  final Color highlightColor;
-  final Color grayedColor;
-  final bool lowlightLine;
-  final TextStyle baseStyle;
-  final double maxWidth;
-  final TextAlign textAlign;
+  final int lineNumber;
+  final ValueNotifier<int?> currentLineNumberNotifier;
+  final TextStyle lowlightStyle;
+  final TextStyle unSyncedStyle;
+  final TextStyle currentLineStyle;
+  final TextStyle cueGreyStyle;
+  final TextStyle cueFadeStyle;
+  final TextStyle cueHighlightStyle;
 
-  LyricsLinePainter({
-    required this.textPainter,
+  bool get _useCues => line.cues != null && line.cues!.isNotEmpty;
+  bool get _isSynced => line.start != null;
+
+  const _LyricLineText({
     required this.line,
-    required this.currentMicros,
-    required this.isCurrentLine,
-    required this.primaryColor,
-    required this.highlightColor,
-    required this.grayedColor,
-    required this.lowlightLine,
-    required this.baseStyle,
-    required this.maxWidth,
-    required this.textAlign,
+    required this.lineNumber,
+    required this.currentLineNumberNotifier,
+    required this.lowlightStyle,
+    required this.cueGreyStyle,
+    required this.cueHighlightStyle,
+    required this.unSyncedStyle,
+    required this.currentLineStyle,
+    required this.cueFadeStyle,
   });
 
   @override
-  void paint(Canvas canvas, Size size) {
-    // If we have word-level cues and this is the current line, paint word-by-word
-    if (line.cues != null && line.cues!.isNotEmpty && isCurrentLine && !lowlightLine) {
-      _paintWithWordHighlighting(canvas, size);
-    } else {
-      // Default painting for non-current lines or lines without cues
-      final offsetX = _calculateTextAlignmentOffset(size.width, textPainter.width);
-      textPainter.paint(canvas, Offset(offsetX, 0.0));
+  ConsumerState<ConsumerStatefulWidget> createState() => _LyricLineTextState();
+}
+
+class _LyricLineTextState extends ConsumerState<_LyricLineText> {
+  InlineSpan? textSpan;
+  bool isCurrentLine = false;
+  StreamSubscription<ProgressState>? cueStream;
+
+  @override
+  void initState() {
+    widget.currentLineNumberNotifier.addListener(_updateCurrentTrack);
+    _updateCurrentTrack();
+    super.initState();
+  }
+
+  void _updateCurrentTrack({bool force = false}) {
+    bool isCurrent = widget.currentLineNumberNotifier.value == widget.lineNumber;
+    bool requireUpdate = force || textSpan == null;
+    if (isCurrent && (!isCurrentLine || requireUpdate)) {
+      isCurrentLine = isCurrent;
+      cueStream?.cancel();
+      if (widget._useCues) {
+        _updateTextFromCues(GetIt.instance<MusicPlayerBackgroundTask>().playbackState.value.position.inMicroseconds);
+        cueStream = progressStateStream.listen((state) => _updateTextFromCues(state.position.inMicroseconds));
+      } else {
+        _updateTextWithoutCues();
+      }
+    } else if (!isCurrent && (isCurrentLine || requireUpdate)) {
+      isCurrentLine = isCurrent;
+      cueStream?.cancel();
+      _updateTextWithoutCues();
     }
   }
 
-  /// Calculates the horizontal offset for text alignment
-  double _calculateTextAlignmentOffset(double containerWidth, double textWidth) {
-    switch (textAlign) {
-      case TextAlign.start:
-      case TextAlign.left:
-        return 0.0;
-      case TextAlign.center:
-        return (containerWidth - textWidth) / 2.0;
-      case TextAlign.end:
-      case TextAlign.right:
-        return containerWidth - textWidth;
-      case TextAlign.justify:
-        return 0.0; // Justify behaves like start for single lines
-    }
-  }
+  void _updateTextFromCues(int currentMicros) {
+    assert(isCurrentLine && widget._useCues);
+    final text = widget.line.text;
 
-  void _paintWithWordHighlighting(Canvas canvas, Size size) {
-    final text = line.text ?? "";
-    final cues = line.cues ?? [];
-
-    if (text.isEmpty || cues.isEmpty) {
-      textPainter.paint(canvas, Offset.zero);
+    if (text == null || text.isEmpty) {
+      setState(() {
+        textSpan = TextSpan(text: text ?? "<missing lyric line>", style: widget.currentLineStyle);
+      });
       return;
     }
 
-    // Build a single TextSpan with different colored segments
-    final segments = <TextSpan>[];
-
-    int lastPosition = 0;
-
-    // Start by assuming all text should be grayed out, then highlight as needed
-    for (int i = 0; i < cues.length; i++) {
-      final cue = cues[i];
-      final nextCue = i < cues.length - 1 ? cues[i + 1] : null;
-
-      // Add any text before this cue that wasn't covered
-      if (cue.position > lastPosition) {
-        final beforeText = text.substring(lastPosition, cue.position);
-        if (beforeText.isNotEmpty) {
-          segments.add(
-            TextSpan(
-              text: beforeText,
-              style: baseStyle.copyWith(color: grayedColor),
-            ),
-          );
-        }
-      }
-
-      // Determine the end position for this cue using endPosition if available, otherwise fallback to next cue's position
+    // Calculate per-letter styling by starting with cueGrey and applying highlighting
+    // and fades for appropriate cues.
+    List<TextStyle> letterStyles = List.filled(text.length, widget.cueGreyStyle);
+    final cueList = widget.line.cues!;
+    for (int i = 0; i < cueList.length; i++) {
+      final cue = cueList[i];
+      final nextCue = i + 1 < cueList.length ? cueList[i + 1] : null;
       final endPosition = cue.endPosition ?? nextCue?.position ?? text.length;
-      final cueText = text.substring(cue.position, math.min(endPosition, text.length));
+      final endTime = cue.endMicros ?? nextCue?.startMicros;
+      if (endPosition - cue.position <= 0) continue;
 
-      if (cueText.isNotEmpty) {
-        // Determine color based on timing with fade-in effect
-        Color segmentColor;
+      // Check if this word is currently being sung
+      final hasReachedThisCue = currentMicros >= cue.startMicros;
+      final hasPassedCue = endTime != null && currentMicros >= endTime;
 
-        // Check if this word is currently being sung
-        final hasReachedThisCue = currentMicros >= cue.startMicros;
-        final hasReachedNextCue = nextCue != null && currentMicros >= nextCue.startMicros;
+      // Calculate fade-in timing (0.5 seconds = 500,000 microseconds before the cue)
+      const fadeInDurationMicros = 500000; // 0.5 seconds
+      final fadeInStartTime = cue.startMicros - fadeInDurationMicros;
+      final isInFadeInPeriod = currentMicros >= fadeInStartTime && !hasReachedThisCue;
 
-        // Calculate fade-in timing (0.5 seconds = 500,000 microseconds before the cue)
-        const fadeInDurationMicros = 500000; // 0.5 seconds
-        final fadeInStartTime = cue.startMicros - fadeInDurationMicros;
-        final isInFadeInPeriod = currentMicros >= fadeInStartTime && currentMicros < cue.startMicros;
-
-        if (hasReachedThisCue && !hasReachedNextCue) {
-          // This word/segment is currently active - highlight it
-          segmentColor = highlightColor;
-        } else if (isInFadeInPeriod) {
-          // This word is about to become active - fade it in letter by letter with color change
-          final fadeProgress = (currentMicros - fadeInStartTime) / fadeInDurationMicros;
-          final clampedProgress = fadeProgress.clamp(0.0, 1.0);
-
-          // Calculate how many letters should be highlighted based on progress
-          final totalLetters = cueText.length;
-          final highlightedLetters = (totalLetters * clampedProgress).round();
-
-          // Split the text into highlighted and non-highlighted parts
-          if (highlightedLetters > 0) {
-            final highlightedText = cueText.substring(0, highlightedLetters);
-            segments.add(
-              TextSpan(
-                text: highlightedText,
-                style: baseStyle.copyWith(color: Color.alphaBlend(highlightColor.withOpacity(0.6), grayedColor)),
-              ),
-            );
-          }
-
-          if (highlightedLetters < totalLetters) {
-            final remainingText = cueText.substring(highlightedLetters);
-            segments.add(
-              TextSpan(
-                text: remainingText,
-                style: baseStyle.copyWith(color: grayedColor),
-              ),
-            );
-          }
-
-          lastPosition = math.max(lastPosition, math.min(endPosition, text.length));
-          continue;
-        } else {
-          // All other words (past and future) - use normal grayed color
-          segmentColor = grayedColor;
+      if (hasReachedThisCue && !hasPassedCue) {
+        // This word/segment is currently active - highlight it
+        for (int i = cue.position; i < endPosition; i++) {
+          letterStyles[i] = widget.cueHighlightStyle;
         }
+      } else if (isInFadeInPeriod) {
+        // This word is about to become active - fade it in letter by letter with color change
+        final fadeProgress = (currentMicros - fadeInStartTime) / fadeInDurationMicros;
+        final totalLetters = endPosition - cue.position;
+        final highlightedLetters = (totalLetters * fadeProgress).round();
+        final int fadeEndPosition = (cue.position + highlightedLetters).clamp(cue.position, endPosition);
 
-        // Add the segment for non-fade-in cases
-        if (!isInFadeInPeriod) {
-          segments.add(
-            TextSpan(
-              text: cueText,
-              style: baseStyle.copyWith(color: segmentColor),
-            ),
-          );
+        for (int i = cue.position; i < fadeEndPosition; i++) {
+          letterStyles[i] = widget.cueFadeStyle;
         }
       }
-      lastPosition = math.max(lastPosition, math.min(endPosition, text.length));
     }
 
-    // Add any remaining text after the last cue
-    if (lastPosition < text.length) {
-      final remainingText = text.substring(lastPosition);
-      if (remainingText.isNotEmpty) {
-        segments.add(
-          TextSpan(
-            text: remainingText,
-            style: baseStyle.copyWith(color: grayedColor),
-          ),
-        );
+    // Gather letter-by-letter styling into text spans
+    TextStyle previousStyle = letterStyles[0];
+    int lastAdded = 0;
+    List<TextSpan> segments = [];
+    for (int i = 1; i < letterStyles.length; i++) {
+      final newStyle = letterStyles[i];
+      if (identical(previousStyle, newStyle)) continue;
+      segments.add(TextSpan(text: text.substring(lastAdded, i), style: previousStyle));
+      lastAdded = i;
+      previousStyle = newStyle;
+    }
+    segments.add(TextSpan(text: text.substring(lastAdded, letterStyles.length), style: previousStyle));
+
+    setState(() {
+      textSpan = TextSpan(children: segments);
+    });
+  }
+
+  void _updateTextWithoutCues() {
+    setState(() {
+      if (!widget._isSynced) {
+        textSpan = TextSpan(text: widget.line.text ?? "<missing lyric line>", style: widget.unSyncedStyle);
+      } else if (!isCurrentLine) {
+        textSpan = TextSpan(text: widget.line.text ?? "<missing lyric line>", style: widget.lowlightStyle);
+      } else {
+        assert(!widget._useCues);
+        textSpan = TextSpan(text: widget.line.text ?? "<missing lyric line>", style: widget.currentLineStyle);
+      }
+    });
+  }
+
+  @override
+  void didUpdateWidget(covariant _LyricLineText oldWidget) {
+    if (widget.currentLineNumberNotifier != oldWidget.currentLineNumberNotifier) {
+      oldWidget.currentLineNumberNotifier.removeListener(_updateCurrentTrack);
+      widget.currentLineNumberNotifier.addListener(_updateCurrentTrack);
+    }
+    if (widget.line != oldWidget.line || widget.lineNumber != oldWidget.lineNumber) {
+      _updateCurrentTrack(force: true);
+    } else if (isCurrentLine) {
+      if (widget._useCues) {
+        if (widget.cueHighlightStyle != oldWidget.cueHighlightStyle ||
+            widget.cueGreyStyle != oldWidget.cueGreyStyle ||
+            widget.cueFadeStyle != oldWidget.cueFadeStyle) {
+          _updateCurrentTrack(force: true);
+        }
+      } else {
+        if (widget.currentLineStyle != oldWidget.currentLineStyle) {
+          _updateCurrentTrack(force: true);
+        }
+      }
+    } else {
+      if (widget._isSynced) {
+        if (widget.lowlightStyle != oldWidget.lowlightStyle) {
+          _updateCurrentTrack(force: true);
+        }
+      } else {
+        if (widget.unSyncedStyle != oldWidget.unSyncedStyle) {
+          _updateCurrentTrack(force: true);
+        }
       }
     }
+    super.didUpdateWidget(oldWidget);
+  }
 
-    // Fallback: if we have no segments, just render the original text in grayed color
-    if (segments.isEmpty) {
-      segments.add(
-        TextSpan(
-          text: text,
-          style: baseStyle.copyWith(color: grayedColor),
-        ),
-      );
-    }
+  @override
+  void dispose() {
+    widget.currentLineNumberNotifier.removeListener(_updateCurrentTrack);
+    cueStream?.cancel();
+    super.dispose();
+  }
 
-    // Create a new TextPainter with the colored segments, using the same layout parameters
-    final coloredTextSpan = TextSpan(children: segments);
-    final coloredTextPainter = TextPainter(
-      text: coloredTextSpan,
-      textAlign: textAlign, // Use the passed text alignment
-      textDirection: textPainter.textDirection,
-      textScaler: textPainter.textScaler, // Preserve text scaling
-      maxLines: textPainter.maxLines,
+  @override
+  Widget build(BuildContext context) {
+    return RichText(
+      text: textSpan!,
+      textAlign: lyricsAlignmentToTextAlign(ref.watch(finampSettingsProvider.lyricsAlignment)),
     );
-
-    // Use the exact same layout constraints as the original to ensure identical line breaking
-    // Use the maxWidth that was passed to ensure consistency with the original layout
-    coloredTextPainter.layout(minWidth: 0, maxWidth: maxWidth);
-
-    // Calculate the offset based on text alignment
-    final offsetX = _calculateTextAlignmentOffset(size.width, coloredTextPainter.width);
-
-    // Paint the colored text with the calculated offset
-    coloredTextPainter.paint(canvas, Offset(offsetX, 0.0));
   }
-
-  @override
-  bool shouldRepaint(LyricsLinePainter oldDelegate) {
-    return textPainter.text != oldDelegate.textPainter.text ||
-        textAlign != oldDelegate.textAlign ||
-        currentMicros != oldDelegate.currentMicros ||
-        isCurrentLine != oldDelegate.isCurrentLine ||
-        lowlightLine != oldDelegate.lowlightLine ||
-        maxWidth != oldDelegate.maxWidth;
-  }
-
-  @override
-  SemanticsBuilderCallback? get semanticsBuilder => null;
-
-  @override
-  bool shouldRebuildSemantics(covariant LyricsLinePainter oldDelegate) {
-    return shouldRepaint(oldDelegate);
-  }
-
-  @override
-  bool? hitTest(Offset position) => null;
 }
 
 class LyricsListMask extends StatelessWidget {
@@ -818,5 +760,34 @@ int lyricsFontSizeToSize(LyricsFontSize fontSize) {
       return 26;
     case LyricsFontSize.large:
       return 32;
+  }
+}
+
+class LyricsScrollBehavior extends MaterialScrollBehavior {
+  const LyricsScrollBehavior();
+
+  @override
+  Widget buildScrollbar(BuildContext context, Widget child, ScrollableDetails details) {
+    final controller = details.controller;
+    switch (axisDirectionToAxis(details.direction)) {
+      case Axis.horizontal:
+        return child;
+      case Axis.vertical:
+        assert(controller != null);
+        return Scrollbar(
+          controller: controller,
+          notificationPredicate: (notification) {
+            if (notification.depth != 0) return false;
+            if (controller is AutoScrollController && controller.isAutoScrolling) {
+              if (notification is ScrollUpdateNotification && notification.scrollDelta == null) {
+                return true;
+              }
+              return false;
+            }
+            return true;
+          },
+          child: child,
+        );
+    }
   }
 }

--- a/lib/screens/lyrics_screen.dart
+++ b/lib/screens/lyrics_screen.dart
@@ -329,6 +329,7 @@ class _LyricsViewState extends ConsumerState<LyricsView> with WidgetsBindingObse
                     behavior: const FinampScrollBehavior(scrollbars: false),
                     child: LyricsListMask(
                       child: ListView.builder(
+                        key: PageStorageKey(metadata.valueOrNull?.item),
                         controller: autoScrollController,
                         itemCount: lyricLines.length + 2,
                         itemBuilder: (context, rawIndex) {

--- a/lib/screens/lyrics_screen.dart
+++ b/lib/screens/lyrics_screen.dart
@@ -459,9 +459,7 @@ class _LyricLine extends ConsumerWidget {
                     return Text(
                       "${Duration(microseconds: line.startMicros).inMinutes}:${(Duration(microseconds: line.startMicros).inSeconds % 60).toString().padLeft(2, '0')}",
                       style: TextStyle(
-                        color: isSynchronized && value != lineNumber
-                            ? Colors.grey
-                            : Theme.of(context).textTheme.bodyLarge!.color,
+                        color: isSynchronized && value != lineNumber ? lowlightStyle.color : unSyncedStyle.color,
                         fontSize: 16,
                       ),
                     );

--- a/lib/screens/lyrics_screen.dart
+++ b/lib/screens/lyrics_screen.dart
@@ -175,7 +175,7 @@ class _LyricsViewState extends ConsumerState<LyricsView> with WidgetsBindingObse
     WidgetsBinding.instance.addObserver(this);
     autoScrollController = AutoScrollController(
       suggestedRowHeight: 72,
-      viewportBoundaryGetter: () => Rect.fromLTRB(0, 0, 0, MediaQuery.of(context).padding.bottom),
+      viewportBoundaryGetter: () => Rect.fromLTRB(0, 0, 0, MediaQuery.paddingOf(context).bottom),
       axis: Axis.vertical,
     );
 
@@ -271,7 +271,7 @@ class _LyricsViewState extends ConsumerState<LyricsView> with WidgetsBindingObse
         }
 
         currentLineIndex = closestLineIndex;
-        if (currentLineIndex! != previousLineIndex) {
+        if (currentLineIndex! != previousLineIndex && context.mounted) {
           setState(() {}); // Rebuild to update the current line
           if (autoScrollController.hasClients && isAutoScrollEnabled) {
             int clampedIndex = currentLineIndex ?? 0;
@@ -282,7 +282,7 @@ class _LyricsViewState extends ConsumerState<LyricsView> with WidgetsBindingObse
               await autoScrollController.scrollToIndex(
                 -1,
                 preferPosition: AutoScrollPosition.middle,
-                duration: MediaQuery.of(context).disableAnimations
+                duration: MediaQuery.disableAnimationsOf(context)
                     ? const Duration(
                         milliseconds: 1,
                       ) // there's an assertion in the library forbidding a duration of 0, so we use 1ms instead to get instant scrolling
@@ -293,7 +293,7 @@ class _LyricsViewState extends ConsumerState<LyricsView> with WidgetsBindingObse
                 autoScrollController.scrollToIndex(
                   clampedIndex.clamp(0, lyricLines.length - 1),
                   preferPosition: AutoScrollPosition.middle,
-                  duration: MediaQuery.of(context).disableAnimations
+                  duration: MediaQuery.disableAnimationsOf(context)
                       ? const Duration(
                           milliseconds: 1,
                         ) // there's an assertion in the library forbidding a duration of 0, so we use 1ms instead to get instant scrolling
@@ -363,7 +363,7 @@ class _LyricsViewState extends ConsumerState<LyricsView> with WidgetsBindingObse
                                   autoScrollController.scrollToIndex(
                                     index,
                                     preferPosition: AutoScrollPosition.middle,
-                                    duration: MediaQuery.of(context).disableAnimations
+                                    duration: MediaQuery.disableAnimationsOf(context)
                                         ? const Duration(
                                             milliseconds: 1,
                                           ) // there's an assertion in the library forbidding a duration of 0, so we use 1ms instead to get instant scrolling
@@ -394,7 +394,7 @@ class _LyricsViewState extends ConsumerState<LyricsView> with WidgetsBindingObse
                             autoScrollController.scrollToIndex(
                               previousLineIndex!,
                               preferPosition: AutoScrollPosition.middle,
-                              duration: MediaQuery.of(context).disableAnimations
+                              duration: MediaQuery.disableAnimationsOf(context)
                                   ? const Duration(
                                       milliseconds: 1,
                                     ) // there's an assertion in the library forbidding a duration of 0, so we use 1ms instead to get instant scrolling

--- a/lib/screens/music_screen.dart
+++ b/lib/screens/music_screen.dart
@@ -491,8 +491,10 @@ class _TransparentRightSwipeDetectorState extends State<TransparentRightSwipeDet
     final finalOffset = details.globalPosition;
     final initialOffset = _initialSwipeOffset;
     if (initialOffset != null) {
-      final offsetDifference = initialOffset.dx - finalOffset.dx;
-      if (offsetDifference < -100.0) {
+      final horizontalOffset = initialOffset.dx - finalOffset.dx;
+      final verticalOffset = initialOffset.dy - finalOffset.dy;
+      // Only trigger if swipe angle primarily horizontal
+      if (horizontalOffset < -100.0 && horizontalOffset.abs() > verticalOffset.abs() * 1.5) {
         _initialSwipeOffset = null;
         widget.action();
       }

--- a/lib/screens/music_screen.dart
+++ b/lib/screens/music_screen.dart
@@ -370,7 +370,7 @@ class _MusicScreenState extends ConsumerState<MusicScreen> with TickerProviderSt
           builder: (context) {
             final child = TabBarView(
               controller: _tabController,
-              physics: ref.watch(finampSettingsProvider.disableGesture) || MediaQuery.of(context).disableAnimations
+              physics: ref.watch(finampSettingsProvider.disableGesture) || MediaQuery.disableAnimationsOf(context)
                   ? const NeverScrollableScrollPhysics()
                   : widget.tabTypeFilter != null
                   ? NeverScrollableScrollPhysics()
@@ -379,11 +379,10 @@ class _MusicScreenState extends ConsumerState<MusicScreen> with TickerProviderSt
               children: sortedTabs.map((tabType) {
                 return Column(
                   children: [
-                    buildArtistTypeSelectionRow(
-                      context,
-                      tabType,
-                      ref.watch(finampSettingsProvider.defaultArtistType),
-                      refreshTab,
+                    ArtistTypeSelectionRow(
+                      tabType: tabType,
+                      defaultArtistType: ref.watch(finampSettingsProvider.defaultArtistType),
+                      refreshTab: refreshTab,
                     ),
                     Expanded(
                       child: MusicScreenTabView(

--- a/lib/screens/player_screen.dart
+++ b/lib/screens/player_screen.dart
@@ -35,13 +35,13 @@ import 'blurred_player_screen_background.dart';
 const double _defaultToolbarHeight = 53.0;
 const int _defaultMaxToolbarLines = 2;
 
-class PlayerScreen extends ConsumerWidget {
+class PlayerScreen extends StatelessWidget {
   const PlayerScreen({super.key});
 
   static const routeName = "/nowplaying";
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     final queueService = GetIt.instance<QueueService>();
 
     // close the player screen if the queue is empty

--- a/lib/screens/player_screen.dart
+++ b/lib/screens/player_screen.dart
@@ -90,10 +90,10 @@ class PlayerScreen extends ConsumerWidget {
       onTap: retryCallback,
       child: Scaffold(
         backgroundColor: Color.alphaBlend(
-          Theme.of(context).brightness == Brightness.dark
+          Theme.brightnessOf(context) == Brightness.dark
               ? IconTheme.of(context).color!.withOpacity(0.35)
               : IconTheme.of(context).color!.withOpacity(0.5),
-          Theme.of(context).brightness == Brightness.dark ? Colors.black : Colors.white,
+          Theme.brightnessOf(context) == Brightness.dark ? Colors.black : Colors.white,
         ),
         // Required for sleep timer input
         resizeToAvoidBottomInset: false,
@@ -191,7 +191,7 @@ class _PlayerScreenContent extends ConsumerWidget {
               // this is needed to ensure the player screen stays in full screen mode WITHOUT having contrast issues in the status bar
               systemNavigationBarColor: Colors.transparent,
               systemStatusBarContrastEnforced: false,
-              statusBarIconBrightness: Theme.of(context).brightness == Brightness.dark
+              statusBarIconBrightness: Theme.brightnessOf(context) == Brightness.dark
                   ? Brightness.light
                   : Brightness.dark,
             ),

--- a/lib/screens/player_screen.dart
+++ b/lib/screens/player_screen.dart
@@ -83,8 +83,8 @@ class PlayerScreen extends ConsumerWidget {
     );
   }
 
-  Widget buildLoadingScreen(BuildContext context, Function()? retryCallback) {
-    double imageSize = min(MediaQuery.sizeOf(context).width, MediaQuery.sizeOf(context).height) / 2;
+  Widget buildLoadingScreen(BuildContext context, void Function()? retryCallback) {
+    double imageSize = min(MediaQuery.widthOf(context), MediaQuery.heightOf(context)) / 2;
 
     return SimpleGestureDetector(
       onTap: retryCallback,

--- a/lib/screens/player_screen.dart
+++ b/lib/screens/player_screen.dart
@@ -3,12 +3,11 @@ import 'dart:io';
 import 'dart:math';
 
 import 'package:balanced_text/balanced_text.dart';
-import 'package:finamp/color_schemes.g.dart';
-import 'package:finamp/menus/track_menu.dart';
 import 'package:finamp/components/Buttons/simple_button.dart';
-import 'package:finamp/menus/output_menu.dart';
 import 'package:finamp/components/PlayerScreen/player_screen_appbar_title.dart';
 import 'package:finamp/l10n/app_localizations.dart';
+import 'package:finamp/menus/output_menu.dart';
+import 'package:finamp/menus/track_menu.dart';
 import 'package:finamp/models/finamp_models.dart';
 import 'package:finamp/screens/lyrics_screen.dart';
 import 'package:finamp/services/current_track_metadata_provider.dart';
@@ -23,7 +22,6 @@ import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
 import 'package:get_it/get_it.dart';
 import 'package:simple_gesture_detector/simple_gesture_detector.dart';
 
-import '../menus/playlist_actions_menu.dart';
 import '../components/PlayerScreen/control_area.dart';
 import '../components/PlayerScreen/player_screen_album_image.dart';
 import '../components/PlayerScreen/player_split_screen_scaffold.dart';
@@ -31,6 +29,7 @@ import '../components/PlayerScreen/queue_button.dart';
 import '../components/PlayerScreen/queue_list.dart';
 import '../components/PlayerScreen/track_name_content.dart';
 import '../components/finamp_app_bar_button.dart';
+import '../menus/playlist_actions_menu.dart';
 import 'blurred_player_screen_background.dart';
 
 const double _defaultToolbarHeight = 53.0;
@@ -85,7 +84,7 @@ class PlayerScreen extends ConsumerWidget {
   }
 
   Widget buildLoadingScreen(BuildContext context, Function()? retryCallback) {
-    double imageSize = min(MediaQuery.of(context).size.width, MediaQuery.of(context).size.height) / 2;
+    double imageSize = min(MediaQuery.sizeOf(context).width, MediaQuery.sizeOf(context).height) / 2;
 
     return SimpleGestureDetector(
       onTap: retryCallback,
@@ -310,7 +309,7 @@ class _PlayerScreenContent extends ConsumerWidget {
       settings: routeSettings,
       pageBuilder: (context, animation, secondaryAnimation) => targetWidget,
       transitionsBuilder: (context, animation, secondaryAnimation, child) {
-        if (MediaQuery.of(context).disableAnimations) {
+        if (MediaQuery.disableAnimationsOf(context)) {
           return child;
         }
         const curve = Curves.ease;

--- a/lib/services/audio_service_smtc.dart
+++ b/lib/services/audio_service_smtc.dart
@@ -84,8 +84,6 @@ class AudioServiceSMTC extends AudioServicePlatform {
 
   @override
   Future<void> setMediaItem(SetMediaItemRequest request) async {
-    // Note - smtc_windows does not accept file:// URIs.  Only network images
-    // are currently supported.
     var artURI = request.mediaItem.artUri;
     await smtc.updateMetadata(
       MusicMetadata(

--- a/lib/services/current_album_image_provider.dart
+++ b/lib/services/current_album_image_provider.dart
@@ -12,7 +12,11 @@ import 'album_image_provider.dart';
 /// Used on the player screen to sync up loading the blurred background.
 /// Use ListenableImage as output to allow directly overriding localImageProvider
 final currentAlbumImageProvider = Provider<ThemeImage>((ref) {
-  final List<FinampQueueItem> precacheItems = GetIt.instance<QueueService>().peekQueue(next: 3, previous: 1);
+  final List<FinampQueueItem> precacheItems = GetIt.instance<QueueService>().peekQueue(
+    next: 3,
+    previous: 1,
+    current: true,
+  );
   for (final itemToPrecache in precacheItems) {
     BaseItemDto? base = itemToPrecache.baseItem;
     if (base != null) {

--- a/lib/services/current_album_image_provider.dart
+++ b/lib/services/current_album_image_provider.dart
@@ -37,7 +37,12 @@ final currentAlbumImageProvider = Provider<ThemeImage>((ref) {
   final currentTrack = ref.watch(currentTrackProvider).value?.baseItem;
   if (currentTrack != null) {
     final request = AlbumImageRequest(item: currentTrack);
-    return ThemeImage(ref.watch(albumImageProvider(request)), currentTrack.blurHash);
+    // Setting useIsolate to false provides negligible speedup for player images and induces lag, so use true.
+    return ThemeImage(
+      ref.watch(albumImageProvider(request)),
+      ThemeInfo(currentTrack, useIsolate: true),
+      largeThemeImage: true,
+    );
   }
   return ThemeImage.empty();
 });

--- a/lib/services/current_album_image_provider.dart
+++ b/lib/services/current_album_image_provider.dart
@@ -2,7 +2,6 @@ import 'package:finamp/models/finamp_models.dart';
 import 'package:finamp/models/jellyfin_models.dart';
 import 'package:finamp/services/queue_service.dart';
 import 'package:finamp/services/theme_provider.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:get_it/get_it.dart';
 
@@ -11,7 +10,7 @@ import 'album_image_provider.dart';
 /// Provider to handle syncing up the current playing item's image provider.
 /// Used on the player screen to sync up loading the blurred background.
 /// Use ListenableImage as output to allow directly overriding localImageProvider
-final currentAlbumImageProvider = Provider<ThemeImage>((ref) {
+final currentAlbumImageProvider = Provider<FinampImage>((ref) {
   final List<FinampQueueItem> precacheItems = GetIt.instance<QueueService>().peekQueue(
     next: 3,
     previous: 1,
@@ -21,16 +20,9 @@ final currentAlbumImageProvider = Provider<ThemeImage>((ref) {
     BaseItemDto? base = itemToPrecache.baseItem;
     if (base != null) {
       final request = AlbumImageRequest(item: base);
-      var image = ref.watch(albumImageProvider(request));
-      if (image != null) {
-        // Cache the returned image
-        var stream = image.resolve(const ImageConfiguration(devicePixelRatio: 1.0));
-        var listener = ImageStreamListener((image, synchronousCall) {});
-        ref.onDispose(() {
-          stream.removeListener(listener);
-        });
-        stream.addListener(listener);
-      }
+      // full quality player images are cached immediately upon albumImageProvider creation, so we don't need to
+      // resolve the provider like we would to initiate caching with a NetworkImage
+      ref.listen(albumImageProvider(request), (_, _) {});
     }
   }
 
@@ -38,13 +30,11 @@ final currentAlbumImageProvider = Provider<ThemeImage>((ref) {
   if (currentTrack != null) {
     final request = AlbumImageRequest(item: currentTrack);
     // Setting useIsolate to false provides negligible speedup for player images and induces lag, so use true.
-    return ThemeImage(
-      ref.watch(albumImageProvider(request)),
-      ThemeInfo(currentTrack, useIsolate: true),
-      largeThemeImage: true,
-    );
+    final albumImage = ref.watch(albumImageProvider(request));
+    assert(albumImage.fullQuality);
+    return FinampThemeImage(albumImage.image, ThemeInfo(currentTrack, useIsolate: true), fullQuality: true);
   }
-  return ThemeImage.empty();
+  return FinampImage.empty();
 });
 
 final currentTrackProvider = StreamProvider((_) => GetIt.instance<QueueService>().getCurrentTrackStream());

--- a/lib/services/current_album_image_provider.dart
+++ b/lib/services/current_album_image_provider.dart
@@ -22,7 +22,18 @@ final currentAlbumImageProvider = Provider<FinampImage>((ref) {
       final request = AlbumImageRequest(item: base);
       // full quality player images are cached immediately upon albumImageProvider creation, so we don't need to
       // resolve the provider like we would to initiate caching with a NetworkImage
-      ref.listen(albumImageProvider(request), (_, _) {});
+      ref.listen(albumImageProvider(request), (_, latest) {});
+      // TODO maybe we still want to resolve the images to make sure the decoded image is already in memory?
+      /*var image = ref.watch(albumImageProvider(request)).image;
+      if (image != null) {
+        // Cache the returned image
+        var stream = image.resolve(const ImageConfiguration(devicePixelRatio: 1.0));
+        var listener = ImageStreamListener((image, synchronousCall) {});
+        ref.onDispose(() {
+          stream.removeListener(listener);
+        });
+        stream.addListener(listener);
+      }*/
     }
   }
 
@@ -32,7 +43,7 @@ final currentAlbumImageProvider = Provider<FinampImage>((ref) {
     // Setting useIsolate to false provides negligible speedup for player images and induces lag, so use true.
     final albumImage = ref.watch(albumImageProvider(request));
     assert(albumImage.fullQuality);
-    return FinampThemeImage(albumImage.image, ThemeInfo(currentTrack, useIsolate: true), fullQuality: true);
+    return albumImage.asTheme(ThemeInfo(currentTrack, useIsolate: true));
   }
   return FinampImage.empty();
 });

--- a/lib/services/current_track_metadata_provider.dart
+++ b/lib/services/current_track_metadata_provider.dart
@@ -8,7 +8,11 @@ import 'metadata_provider.dart';
 
 /// Provider to handle pre-fetching metadata for upcoming tracks
 final currentTrackMetadataProvider = AutoDisposeProvider<AsyncValue<MetadataProvider?>>((ref) {
-  final List<FinampQueueItem> precacheItems = GetIt.instance<QueueService>().peekQueue(next: 3, previous: 1);
+  final List<FinampQueueItem> precacheItems = GetIt.instance<QueueService>().peekQueue(
+    next: 3,
+    previous: 1,
+    current: true,
+  );
   for (final itemToPrecache in precacheItems) {
     BaseItemDto? base = itemToPrecache.baseItem;
     if (base != null) {

--- a/lib/services/downloads_service.dart
+++ b/lib/services/downloads_service.dart
@@ -79,6 +79,9 @@ class DownloadsService {
   /// Causes the downloads queue to stop processing new items
   bool get allowDownloads => allowSyncs && !syncBuffer.isRunning;
 
+  /// Marks whether we have encountered an image with a missing blurhash
+  bool serverMissingBlurhash = false;
+
   //
   // Providers
   //
@@ -1573,6 +1576,9 @@ class DownloadsService {
     String? imageId = blurHash ?? item!.blurHash ?? item!.imageId;
     if (imageId == null) {
       return null;
+    }
+    if (item != null && item.blurHash == null) {
+      serverMissingBlurhash = true;
     }
     return _getDownloadByID(imageId, DownloadItemType.image);
   }

--- a/lib/services/downloads_service.dart
+++ b/lib/services/downloads_service.dart
@@ -120,39 +120,41 @@ class DownloadsService {
 
   /// Provider for user-downloaded items of a specific category.
   /// Used to show and group downloaded items on the downloads screen.
-  late final userDownloadedItemsProvider = FutureProvider.family
-      .autoDispose<List<DownloadStub>, DownloadsScreenCategory>((ref, category) async {
-        // Refresh lists when addDownload or removeDownload is called.
-        ref.watch(_anchorProvider);
-        final allItems = await _isar.downloadItems
-            .filter()
-            .requiredBy((q) => q.isarIdEqualTo(_anchor.isarId))
-            .sortByName()
-            .findAll();
+  late final userDownloadedItemsProvider = Provider.family.autoDispose<List<DownloadStub>, DownloadsScreenCategory>((
+    ref,
+    category,
+  ) {
+    // Refresh lists when addDownload or removeDownload is called.
+    ref.watch(_anchorProvider);
+    final allItems = _isar.downloadItems
+        .filter()
+        .requiredBy((q) => q.isarIdEqualTo(_anchor.isarId))
+        .sortByName()
+        .findAllSync();
 
-        return allItems
-            .where(
-              (item) => switch (category) {
-                DownloadsScreenCategory.special =>
-                  item.type == category.type &&
-                      item.finampCollection?.type != FinampCollectionType.collectionWithLibraryFilter,
+    return allItems
+        .where(
+          (item) => switch (category) {
+            DownloadsScreenCategory.special =>
+              item.type == category.type &&
+                  item.finampCollection?.type != FinampCollectionType.collectionWithLibraryFilter,
 
-                DownloadsScreenCategory.artists =>
-                  (item.type == category.type && item.baseItemType == category.baseItemType) ||
-                      (item.finampCollection?.type == FinampCollectionType.collectionWithLibraryFilter &&
-                          BaseItemDtoType.fromItem(item.finampCollection!.item!) == BaseItemDtoType.artist),
+            DownloadsScreenCategory.artists =>
+              (item.type == category.type && item.baseItemType == category.baseItemType) ||
+                  (item.finampCollection?.type == FinampCollectionType.collectionWithLibraryFilter &&
+                      BaseItemDtoType.fromItem(item.finampCollection!.item!) == BaseItemDtoType.artist),
 
-                DownloadsScreenCategory.genres =>
-                  (item.type == category.type && item.baseItemType == category.baseItemType) ||
-                      (item.finampCollection?.type == FinampCollectionType.collectionWithLibraryFilter &&
-                          BaseItemDtoType.fromItem(item.finampCollection!.item!) == BaseItemDtoType.genre),
-                _ =>
-                  item.type == category.type &&
-                      (category.baseItemType == null || item.baseItemType == category.baseItemType),
-              },
-            )
-            .toList();
-      });
+            DownloadsScreenCategory.genres =>
+              (item.type == category.type && item.baseItemType == category.baseItemType) ||
+                  (item.finampCollection?.type == FinampCollectionType.collectionWithLibraryFilter &&
+                      BaseItemDtoType.fromItem(item.finampCollection!.item!) == BaseItemDtoType.genre),
+            _ =>
+              item.type == category.type &&
+                  (category.baseItemType == null || item.baseItemType == category.baseItemType),
+          },
+        )
+        .toList();
+  });
 
   /// Constructs the service.  startQueues should also be called to complete initialization.
   DownloadsService() {

--- a/lib/services/downloads_service.dart
+++ b/lib/services/downloads_service.dart
@@ -1575,6 +1575,33 @@ class DownloadsService {
     return _getDownloadByID(imageId, DownloadItemType.image);
   }
 
+  /// Retrieve the primary theme color of an image.  Only images stored by blurhash are supported to avoid the theoretical
+  /// possibility of the color and image file becoming desynced.  The returned value is (image is downloaded,theme color).
+  (bool, Color?) getImageTheme(String? blurHash) {
+    if (blurHash == null) {
+      return (false, null);
+    }
+    var item = _isar.downloadItems.getSync(DownloadStub.getHash(blurHash, DownloadItemType.image));
+    assert(item == null || item.baseItem!.blurHash == blurHash);
+    return (item != null, item?.themeColor != null ? Color(item!.themeColor!) : null);
+  }
+
+  /// Set the primary theme color of an image.  Only images stored by blurhash are supported to avoid the theoretical
+  /// possibility of the color and image file becoming desynced.
+  void setImageTheme(String? blurHash, Color themeColor) {
+    if (blurHash == null) {
+      return;
+    }
+    _isar.writeTxnSync(() {
+      final item = _isar.downloadItems.getSync(DownloadStub.getHash(blurHash, DownloadItemType.image));
+      if (item != null) {
+        assert(item.baseItem!.blurHash == blurHash);
+        item.themeColor = themeColor.toARGB32();
+        _isar.downloadItems.putSync(item, saveLinks: false);
+      }
+    });
+  }
+
   /// Get DownloadedLyrics by the corresponding track's BaseItemDto.
   Future<DownloadedLyrics?> getLyricsDownload({required BaseItemDto baseItem}) async {
     var item = _isar.downloadedLyrics.getSync(DownloadStub.getHash(baseItem.id.raw, DownloadItemType.track));

--- a/lib/services/environment_metadata.dart
+++ b/lib/services/environment_metadata.dart
@@ -237,7 +237,6 @@ class EnvironmentMetadata {
   }
 
   String get pretty =>
-      "=== METADATA ===\n"
       "${deviceInfo.pretty}\n"
       "${appInfo.pretty}\n"
       "${serverInfo?.pretty ?? "Server Info: Not available"}";

--- a/lib/services/finamp_logs_helper.dart
+++ b/lib/services/finamp_logs_helper.dart
@@ -92,7 +92,7 @@ class FinampLogsHelper {
   /// Write logs to a file and share the file
   Future<void> shareLogs() async {
     final tempDir = await getTemporaryDirectory();
-    final tempFile = File(path_helper.join(tempDir.path, "finamp-logs-${DateTime.now().millisecondsSinceEpoch}.txt"));
+    final tempFile = File(path_helper.join(tempDir.path, _logExportName));
     tempFile.createSync();
 
     tempFile.writeAsStringSync(await getFullLogs());
@@ -106,10 +106,13 @@ class FinampLogsHelper {
   /// Write logs to a file and save to user-picked directory
   Future<void> exportLogs() async {
     await FilePicker.platform.saveFile(
-      fileName: "finamp-logs-${DateTime.now().millisecondsSinceEpoch}.txt",
+      fileName: _logExportName,
       // initialDirectory is ignored on mobile
       initialDirectory: (await getApplicationDocumentsDirectory()).path,
       bytes: utf8.encode(await getFullLogs()),
     );
   }
+
+  String? get _logExportName =>
+      "finamp-logs-${DateTime.now().toIso8601String().replaceAll(RegExp(r'[/?<>:*|.\\"]'), "-")}.txt";
 }

--- a/lib/services/finamp_logs_helper.dart
+++ b/lib/services/finamp_logs_helper.dart
@@ -65,6 +65,7 @@ class FinampLogsHelper {
     final logMeta = await EnvironmentMetadata.create();
 
     // Prepend this metadata to the logs
+    fullLogsBuffer.writeln("=== METADATA ===");
     fullLogsBuffer.writeln(logMeta.pretty);
     fullLogsBuffer.writeln("=== LOGS ===");
 
@@ -91,7 +92,7 @@ class FinampLogsHelper {
   /// Write logs to a file and share the file
   Future<void> shareLogs() async {
     final tempDir = await getTemporaryDirectory();
-    final tempFile = File(path_helper.join(tempDir.path, "finamp-logs.txt"));
+    final tempFile = File(path_helper.join(tempDir.path, "finamp-logs-${DateTime.now().millisecondsSinceEpoch}.txt"));
     tempFile.createSync();
 
     tempFile.writeAsStringSync(await getFullLogs());
@@ -105,7 +106,7 @@ class FinampLogsHelper {
   /// Write logs to a file and save to user-picked directory
   Future<void> exportLogs() async {
     await FilePicker.platform.saveFile(
-      fileName: "finamp-logs.txt",
+      fileName: "finamp-logs-${DateTime.now().millisecondsSinceEpoch}.txt",
       // initialDirectory is ignored on mobile
       initialDirectory: (await getApplicationDocumentsDirectory()).path,
       bytes: utf8.encode(await getFullLogs()),

--- a/lib/services/finamp_settings_helper.dart
+++ b/lib/services/finamp_settings_helper.dart
@@ -262,7 +262,7 @@ class FinampSettingsHelper {
 
   static IconButton makeSettingsResetButtonWithDialog(
     BuildContext context,
-    Function() resetFunction, {
+    void Function() resetFunction, {
     bool isGlobal = false,
   }) {
     // TODO: Replace the following Strings with localization
@@ -277,9 +277,7 @@ class FinampSettingsHelper {
             confirmButtonText: isGlobal
                 ? AppLocalizations.of(context)!.resetSettingsPromptGlobalConfirm
                 : AppLocalizations.of(context)!.reset,
-            abortButtonText: AppLocalizations.of(context)!.genericCancel,
             onConfirmed: resetFunction,
-            onAborted: () {},
           ),
         );
       },

--- a/lib/services/finamp_settings_helper.dart
+++ b/lib/services/finamp_settings_helper.dart
@@ -181,6 +181,7 @@ class FinampSettingsHelper {
     FinampSetters.setAutoloadLastQueueOnStartup(DefaultSettings.autoLoadLastQueueOnStartup);
     FinampSetters.setAutoReloadQueue(DefaultSettings.autoReloadQueue);
     FinampSetters.setClearQueueOnStopEvent(DefaultSettings.clearQueueOnStopEvent);
+    FinampSetters.setAutoplayRestoredQueue(DefaultSettings.autoplayRestoredQueue);
   }
 
   static void resetPlaybackReportingSettings() {

--- a/lib/services/finamp_settings_helper.g.dart
+++ b/lib/services/finamp_settings_helper.g.dart
@@ -1105,6 +1105,14 @@ extension FinampSetters on FinampSettingsHelper {
     ).put("FinampSettings", finampSettingsTemp);
   }
 
+  static void setAutoplayRestoredQueue(bool newAutoplayRestoredQueue) {
+    FinampSettings finampSettingsTemp = FinampSettingsHelper.finampSettings;
+    finampSettingsTemp.autoplayRestoredQueue = newAutoplayRestoredQueue;
+    Hive.box<FinampSettings>(
+      "FinampSettings",
+    ).put("FinampSettings", finampSettingsTemp);
+  }
+
   static void setBufferDuration(Duration newBufferDuration) {
     FinampSettings finampSettingsTemp = FinampSettingsHelper.finampSettings;
     finampSettingsTemp.bufferDuration = newBufferDuration;
@@ -1493,6 +1501,8 @@ extension FinampSettingsProviderSelectors on StreamProvider<FinampSettings> {
       );
   ProviderListenable<bool> get previousTracksExpaned => finampSettingsProvider
       .select((value) => value.requireValue.previousTracksExpaned);
+  ProviderListenable<bool> get autoplayRestoredQueue => finampSettingsProvider
+      .select((value) => value.requireValue.autoplayRestoredQueue);
   ProviderListenable<DownloadProfile> get downloadTranscodingProfile =>
       finampSettingsProvider.select(
         (value) => value.requireValue.downloadTranscodingProfile,

--- a/lib/services/jellyfin_api_helper.dart
+++ b/lib/services/jellyfin_api_helper.dart
@@ -107,7 +107,7 @@ class JellyfinApiHelper {
     if (output is T) {
       return output;
     }
-    _jellyfinApiHelperLogger.severe("Error in background isolate:", output);
+    _jellyfinApiHelperLogger.severe("Error in background isolate: $output", output);
     throw output as Object;
   }
 

--- a/lib/services/metadata_provider.dart
+++ b/lib/services/metadata_provider.dart
@@ -1,8 +1,4 @@
-import 'dart:io';
-
 import 'package:finamp/models/finamp_models.dart';
-import 'package:finamp/services/finamp_user_helper.dart';
-import 'package:finamp/services/queue_service.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:get_it/get_it.dart';
 import 'package:logging/logging.dart';
@@ -23,12 +19,14 @@ class MetadataProvider {
   static const speedControlLongAlbumDuration = Duration(hours: 3);
 
   final PlaybackInfoResponse playbackInfo;
+  final BaseItemDto item;
   LyricDto? lyrics;
   bool isDownloaded;
   bool qualifiesForPlaybackSpeedControl;
   double? parentNormalizationGain;
 
   MetadataProvider({
+    required this.item,
     required this.playbackInfo,
     this.lyrics,
     this.isDownloaded = false,
@@ -152,6 +150,7 @@ final AutoDisposeFutureProviderFamily<MetadataProvider?, BaseItemDto> metadataPr
       }
 
       final metadata = MetadataProvider(
+        item: item,
         playbackInfo: playbackInfo,
         isDownloaded: localPlaybackInfo != null,
         parentNormalizationGain: parent?.normalizationGain,

--- a/lib/services/music_player_background_task.dart
+++ b/lib/services/music_player_background_task.dart
@@ -8,10 +8,10 @@ import 'package:finamp/components/global_snackbar.dart';
 import 'package:finamp/l10n/app_localizations.dart';
 import 'package:finamp/models/finamp_models.dart';
 import 'package:finamp/models/jellyfin_models.dart' as jellyfin_models;
+import 'package:finamp/services/current_track_metadata_provider.dart';
 import 'package:finamp/services/favorite_provider.dart';
 import 'package:finamp/services/jellyfin_api_helper.dart';
 import 'package:finamp/services/queue_service.dart';
-import 'package:finamp/services/current_track_metadata_provider.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -64,6 +64,8 @@ class FadeState {
 }
 
 class PlayerVolumeController {
+  static final _volumeLogger = Logger("Volume");
+
   PlayerVolumeController(this._player) {
     _updateVolume();
   }
@@ -98,6 +100,9 @@ class PlayerVolumeController {
     var vol2 = _replayGainVolume.clamp(0.0, 1.0);
     var vol3 = _fadeVolume.clamp(0.0, 1.0);
     var totalVol = vol1 * vol2 * vol3;
+    _volumeLogger.info(
+      "Setting volume to $totalVol - user: $_internalVolume gain: $_replayGainVolume fade: $_fadeVolume",
+    );
     return _player.setVolume(totalVol.clamp(0.0, 1.0));
   }
 }

--- a/lib/services/queue_service.dart
+++ b/lib/services/queue_service.dart
@@ -11,8 +11,6 @@ import 'package:finamp/models/finamp_models.dart';
 import 'package:finamp/models/jellyfin_models.dart' as jellyfin_models;
 import 'package:finamp/services/album_image_provider.dart';
 import 'package:finamp/services/current_album_image_provider.dart';
-import 'package:finamp/services/current_track_metadata_provider.dart';
-import 'package:finamp/services/metadata_provider.dart';
 import 'package:finamp/services/playback_history_service.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:get_it/get_it.dart';

--- a/lib/services/queue_service.dart
+++ b/lib/services/queue_service.dart
@@ -448,7 +448,7 @@ class QueueService {
           // Always restore queues as linear to prevent them being reshuffled while restoring
           order: FinampPlaybackOrder.linear,
           beginPlaying:
-              (isReload && (_audioHandler.playbackState.valueOrNull?.playing ?? false)) ||
+              isReload ? (_audioHandler.playbackState.valueOrNull?.playing ?? false) :
               (FinampSettingsHelper.finampSettings.autoplayRestoredQueue && droppedTracks == 0),
           source: info.source ?? savedQueueSource,
         );

--- a/lib/services/queue_service.dart
+++ b/lib/services/queue_service.dart
@@ -886,13 +886,15 @@ class QueueService {
   /// If [next] is provided (and greater than 0), at most [next] QueueItems from Next Up and the regular queue will be returned
   /// If [previous] is provided (and greater than 0), at most [previous] QueueItems from previous tracks will be additionally returned.
   /// The length of the returned list may be less than the sum of [next] and [previous] if there are not enough items in the queue
-  /// The current track is *not* included
-  List<FinampQueueItem> peekQueue({int? next, int previous = 0}) {
+  List<FinampQueueItem> peekQueue({int? next, int previous = 0, bool current = false}) {
     List<FinampQueueItem> nextTracks = [];
     if (_queuePreviousTracks.isNotEmpty && previous > 0) {
       nextTracks.addAll(
         _queuePreviousTracks.sublist(max(0, _queuePreviousTracks.length - previous), _queuePreviousTracks.length),
       );
+    }
+    if (_currentTrack != null && current) {
+      nextTracks.add(_currentTrack!);
     }
     if (_queueNextUp.isNotEmpty) {
       if (next == null) {

--- a/lib/services/queue_service.dart
+++ b/lib/services/queue_service.dart
@@ -12,7 +12,6 @@ import 'package:finamp/models/jellyfin_models.dart' as jellyfin_models;
 import 'package:finamp/services/album_image_provider.dart';
 import 'package:finamp/services/current_album_image_provider.dart';
 import 'package:finamp/services/playback_history_service.dart';
-import 'package:finamp/services/theme_provider.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:get_it/get_it.dart';
 import 'package:hive_ce_flutter/hive_flutter.dart';
@@ -156,7 +155,7 @@ class QueueService {
     // );
   }
 
-  ProviderSubscription<FinampAlbumImage>? _latestAlbumImage;
+  ProviderSubscription<AlbumImageInfo>? _latestAlbumImage;
 
   void _queueFromConcatenatingAudioSource({bool logUpdate = true}) {
     final playbackHistoryService = GetIt.instance<PlaybackHistoryService>();
@@ -256,7 +255,7 @@ class QueueService {
       final item = jellyfin_models.BaseItemDto.fromJson(currentMediaItem.extras!["itemJson"] as Map<String, dynamic>);
       final artRequest = AlbumImageRequest(item: item);
 
-      void updateMediaItem(FinampAlbumImage latest, bool force) async {
+      void updateMediaItem(AlbumImageInfo latest, bool force) async {
         var artUri = latest.uri;
         if (artUri == null) {
           // replace with placeholder art

--- a/lib/services/queue_service.dart
+++ b/lib/services/queue_service.dart
@@ -448,7 +448,9 @@ class QueueService {
           initialIndex: items["current"]!.isNotEmpty || items["queue"]!.isNotEmpty ? items["previous"]!.length : 0,
           // Always restore queues as linear to prevent them being reshuffled while restoring
           order: FinampPlaybackOrder.linear,
-          beginPlaying: isReload && (_audioHandler.playbackState.valueOrNull?.playing ?? false),
+          beginPlaying:
+              (isReload && (_audioHandler.playbackState.valueOrNull?.playing ?? false)) ||
+              (FinampSettingsHelper.finampSettings.autoplayRestoredQueue && droppedTracks == 0),
           source: info.source ?? savedQueueSource,
         );
 

--- a/lib/services/queue_service.dart
+++ b/lib/services/queue_service.dart
@@ -238,7 +238,7 @@ class QueueService {
       _currentTrack = null;
       _audioHandler.playbackState.add(
         PlaybackState(
-          processingState: AudioProcessingState.completed,
+          processingState: AudioProcessingState.idle,
           playing: false,
           queueIndex: 0,
           updatePosition: Duration.zero,
@@ -279,7 +279,7 @@ class QueueService {
         (_, latest) => updateMediaItem(latest, false),
       );
       updateMediaItem(_providers.read(albumImageProvider(artRequest)), true);
-    }
+    } else {}
     _audioHandler.queue.add(
       _queuePreviousTracks
           .followedBy(_currentTrack != null ? [_currentTrack!] : [])

--- a/lib/services/theme_provider.dart
+++ b/lib/services/theme_provider.dart
@@ -209,6 +209,7 @@ class FinampThemeFromImage extends _$FinampThemeFromImage {
         // Keep cached player themes until app closure, as they can take several seconds to calculate
         ref.keepAlive();
       }
+      themeProviderLogger.finer("Calculated theme color $color for image $image");
       return _getColorScheme(color, brightness);
     }).then((value) => state = value);
     return getGrayTheme(brightness);

--- a/lib/services/theme_provider.dart
+++ b/lib/services/theme_provider.dart
@@ -39,7 +39,7 @@ class PlayerScreenTheme extends StatelessWidget {
           if (item == null) {
             return null;
           }
-          // Setting useIsolate to true provides negligible speedup for player images and induces lag.
+          // Setting useIsolate to false provides negligible speedup for player images and induces lag.
           return ThemeInfo(item, largeThemeImage: true, useIsolate: true);
         }),
       ],

--- a/lib/services/theme_provider.dart
+++ b/lib/services/theme_provider.dart
@@ -376,7 +376,7 @@ class _ThemeTransitionCalculator {
   bool _skipAllTransitions = false;
 
   Duration getThemeTransitionDuration(BuildContext context, Duration? duration) {
-    if (_skipAllTransitions || MediaQuery.of(context).disableAnimations) {
+    if (_skipAllTransitions || MediaQuery.disableAnimationsOf(context)) {
       return Duration.zero;
     }
     return (context.mounted && (ModalRoute.isCurrentOf(context) ?? true))

--- a/lib/services/theme_provider.g.dart
+++ b/lib/services/theme_provider.g.dart
@@ -149,7 +149,7 @@ class _FinampThemeProviderElement
   ThemeInfo get request => (origin as FinampThemeProvider).request;
 }
 
-String _$themeImageHash() => r'a272002f5ed1a8b542f8c25651c6cf33101616df';
+String _$themeImageHash() => r'd32e3fd9fa76884a37629b2d067b97d332dfd917';
 
 /// See also [themeImage].
 @ProviderFor(themeImage)
@@ -266,7 +266,7 @@ class _ThemeImageProviderElement extends AutoDisposeProviderElement<ThemeImage>
 }
 
 String _$finampThemeFromImageHash() =>
-    r'2ed79ead4ee052c8961940b332757b997bdeba99';
+    r'9675ea9074b1e36131d82d2723706ed26419a213';
 
 abstract class _$FinampThemeFromImage
     extends BuildlessAutoDisposeNotifier<ColorScheme> {

--- a/lib/services/theme_provider.g.dart
+++ b/lib/services/theme_provider.g.dart
@@ -149,14 +149,14 @@ class _FinampThemeProviderElement
   ThemeInfo get request => (origin as FinampThemeProvider).request;
 }
 
-String _$themeImageHash() => r'98d3edc872a1d07a044948a17e2ebabffc97c0e6';
+String _$themeImageHash() => r'278c78e938802c8d0e09bc392f2166eddeadcb25';
 
 /// See also [themeImage].
 @ProviderFor(themeImage)
 const themeImageProvider = ThemeImageFamily();
 
 /// See also [themeImage].
-class ThemeImageFamily extends Family<ThemeImage> {
+class ThemeImageFamily extends Family<FinampThemeImage> {
   /// See also [themeImage].
   const ThemeImageFamily();
 
@@ -188,7 +188,7 @@ class ThemeImageFamily extends Family<ThemeImage> {
 }
 
 /// See also [themeImage].
-class ThemeImageProvider extends AutoDisposeProvider<ThemeImage> {
+class ThemeImageProvider extends AutoDisposeProvider<FinampThemeImage> {
   /// See also [themeImage].
   ThemeImageProvider(ThemeInfo request)
     : this._internal(
@@ -216,7 +216,9 @@ class ThemeImageProvider extends AutoDisposeProvider<ThemeImage> {
   final ThemeInfo request;
 
   @override
-  Override overrideWith(ThemeImage Function(ThemeImageRef provider) create) {
+  Override overrideWith(
+    FinampThemeImage Function(ThemeImageRef provider) create,
+  ) {
     return ProviderOverride(
       origin: this,
       override: ThemeImageProvider._internal(
@@ -232,7 +234,7 @@ class ThemeImageProvider extends AutoDisposeProvider<ThemeImage> {
   }
 
   @override
-  AutoDisposeProviderElement<ThemeImage> createElement() {
+  AutoDisposeProviderElement<FinampThemeImage> createElement() {
     return _ThemeImageProviderElement(this);
   }
 
@@ -252,12 +254,13 @@ class ThemeImageProvider extends AutoDisposeProvider<ThemeImage> {
 
 @Deprecated('Will be removed in 3.0. Use Ref instead')
 // ignore: unused_element
-mixin ThemeImageRef on AutoDisposeProviderRef<ThemeImage> {
+mixin ThemeImageRef on AutoDisposeProviderRef<FinampThemeImage> {
   /// The parameter `request` of this provider.
   ThemeInfo get request;
 }
 
-class _ThemeImageProviderElement extends AutoDisposeProviderElement<ThemeImage>
+class _ThemeImageProviderElement
+    extends AutoDisposeProviderElement<FinampThemeImage>
     with ThemeImageRef {
   _ThemeImageProviderElement(super.provider);
 
@@ -266,13 +269,13 @@ class _ThemeImageProviderElement extends AutoDisposeProviderElement<ThemeImage>
 }
 
 String _$finampThemeFromImageHash() =>
-    r'ed36da8eca59020c61184f7cf671dec5494c4c85';
+    r'e40168a56b4d61dc3d5f285159b48f4799055d3d';
 
 abstract class _$FinampThemeFromImage
     extends BuildlessAutoDisposeNotifier<ColorScheme> {
-  late final ThemeImage theme;
+  late final ThemeColorRequest theme;
 
-  ColorScheme build(ThemeImage theme);
+  ColorScheme build(ThemeColorRequest theme);
 }
 
 /// See also [FinampThemeFromImage].
@@ -285,7 +288,7 @@ class FinampThemeFromImageFamily extends Family<ColorScheme> {
   const FinampThemeFromImageFamily();
 
   /// See also [FinampThemeFromImage].
-  FinampThemeFromImageProvider call(ThemeImage theme) {
+  FinampThemeFromImageProvider call(ThemeColorRequest theme) {
     return FinampThemeFromImageProvider(theme);
   }
 
@@ -315,7 +318,7 @@ class FinampThemeFromImageFamily extends Family<ColorScheme> {
 class FinampThemeFromImageProvider
     extends AutoDisposeNotifierProviderImpl<FinampThemeFromImage, ColorScheme> {
   /// See also [FinampThemeFromImage].
-  FinampThemeFromImageProvider(ThemeImage theme)
+  FinampThemeFromImageProvider(ThemeColorRequest theme)
     : this._internal(
         () => FinampThemeFromImage()..theme = theme,
         from: finampThemeFromImageProvider,
@@ -339,7 +342,7 @@ class FinampThemeFromImageProvider
     required this.theme,
   }) : super.internal();
 
-  final ThemeImage theme;
+  final ThemeColorRequest theme;
 
   @override
   ColorScheme runNotifierBuild(covariant FinampThemeFromImage notifier) {
@@ -386,7 +389,7 @@ class FinampThemeFromImageProvider
 // ignore: unused_element
 mixin FinampThemeFromImageRef on AutoDisposeNotifierProviderRef<ColorScheme> {
   /// The parameter `theme` of this provider.
-  ThemeImage get theme;
+  ThemeColorRequest get theme;
 }
 
 class _FinampThemeFromImageProviderElement
@@ -396,7 +399,7 @@ class _FinampThemeFromImageProviderElement
   _FinampThemeFromImageProviderElement(super.provider);
 
   @override
-  ThemeImage get theme => (origin as FinampThemeFromImageProvider).theme;
+  ThemeColorRequest get theme => (origin as FinampThemeFromImageProvider).theme;
 }
 
 // ignore_for_file: type=lint

--- a/lib/services/theme_provider.g.dart
+++ b/lib/services/theme_provider.g.dart
@@ -11,7 +11,7 @@ part of 'theme_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$finampThemeHash() => r'abb984453c1aedf6014b3ce6308d4dd09e33cbba';
+String _$finampThemeHash() => r'1065d27efdcdb93cc700ae0c8ecf3245fabd3371';
 
 /// Copied from Dart SDK
 class _SystemHash {
@@ -149,7 +149,7 @@ class _FinampThemeProviderElement
   ThemeInfo get request => (origin as FinampThemeProvider).request;
 }
 
-String _$themeImageHash() => r'278c78e938802c8d0e09bc392f2166eddeadcb25';
+String _$themeImageHash() => r'4c14e6d1ad29267d4a93be3de5caf69e158bda5e';
 
 /// See also [themeImage].
 @ProviderFor(themeImage)
@@ -269,7 +269,7 @@ class _ThemeImageProviderElement
 }
 
 String _$finampThemeFromImageHash() =>
-    r'e40168a56b4d61dc3d5f285159b48f4799055d3d';
+    r'b201ab94d21c87f90f599d77608c9565dda86047';
 
 abstract class _$FinampThemeFromImage
     extends BuildlessAutoDisposeNotifier<ColorScheme> {

--- a/lib/services/theme_provider.g.dart
+++ b/lib/services/theme_provider.g.dart
@@ -11,7 +11,7 @@ part of 'theme_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$finampThemeHash() => r'7233b420a9c2a738d975c076d4870b16c1476018';
+String _$finampThemeHash() => r'abb984453c1aedf6014b3ce6308d4dd09e33cbba';
 
 /// Copied from Dart SDK
 class _SystemHash {
@@ -149,7 +149,7 @@ class _FinampThemeProviderElement
   ThemeInfo get request => (origin as FinampThemeProvider).request;
 }
 
-String _$themeImageHash() => r'd32e3fd9fa76884a37629b2d067b97d332dfd917';
+String _$themeImageHash() => r'98d3edc872a1d07a044948a17e2ebabffc97c0e6';
 
 /// See also [themeImage].
 @ProviderFor(themeImage)
@@ -266,13 +266,13 @@ class _ThemeImageProviderElement extends AutoDisposeProviderElement<ThemeImage>
 }
 
 String _$finampThemeFromImageHash() =>
-    r'9675ea9074b1e36131d82d2723706ed26419a213';
+    r'ed36da8eca59020c61184f7cf671dec5494c4c85';
 
 abstract class _$FinampThemeFromImage
     extends BuildlessAutoDisposeNotifier<ColorScheme> {
-  late final ThemeRequestFromImage request;
+  late final ThemeImage theme;
 
-  ColorScheme build(ThemeRequestFromImage request);
+  ColorScheme build(ThemeImage theme);
 }
 
 /// See also [FinampThemeFromImage].
@@ -285,15 +285,15 @@ class FinampThemeFromImageFamily extends Family<ColorScheme> {
   const FinampThemeFromImageFamily();
 
   /// See also [FinampThemeFromImage].
-  FinampThemeFromImageProvider call(ThemeRequestFromImage request) {
-    return FinampThemeFromImageProvider(request);
+  FinampThemeFromImageProvider call(ThemeImage theme) {
+    return FinampThemeFromImageProvider(theme);
   }
 
   @override
   FinampThemeFromImageProvider getProviderOverride(
     covariant FinampThemeFromImageProvider provider,
   ) {
-    return call(provider.request);
+    return call(provider.theme);
   }
 
   static const Iterable<ProviderOrFamily>? _dependencies = null;
@@ -315,9 +315,9 @@ class FinampThemeFromImageFamily extends Family<ColorScheme> {
 class FinampThemeFromImageProvider
     extends AutoDisposeNotifierProviderImpl<FinampThemeFromImage, ColorScheme> {
   /// See also [FinampThemeFromImage].
-  FinampThemeFromImageProvider(ThemeRequestFromImage request)
+  FinampThemeFromImageProvider(ThemeImage theme)
     : this._internal(
-        () => FinampThemeFromImage()..request = request,
+        () => FinampThemeFromImage()..theme = theme,
         from: finampThemeFromImageProvider,
         name: r'finampThemeFromImageProvider',
         debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
@@ -326,7 +326,7 @@ class FinampThemeFromImageProvider
         dependencies: FinampThemeFromImageFamily._dependencies,
         allTransitiveDependencies:
             FinampThemeFromImageFamily._allTransitiveDependencies,
-        request: request,
+        theme: theme,
       );
 
   FinampThemeFromImageProvider._internal(
@@ -336,14 +336,14 @@ class FinampThemeFromImageProvider
     required super.allTransitiveDependencies,
     required super.debugGetCreateSourceHash,
     required super.from,
-    required this.request,
+    required this.theme,
   }) : super.internal();
 
-  final ThemeRequestFromImage request;
+  final ThemeImage theme;
 
   @override
   ColorScheme runNotifierBuild(covariant FinampThemeFromImage notifier) {
-    return notifier.build(request);
+    return notifier.build(theme);
   }
 
   @override
@@ -351,13 +351,13 @@ class FinampThemeFromImageProvider
     return ProviderOverride(
       origin: this,
       override: FinampThemeFromImageProvider._internal(
-        () => create()..request = request,
+        () => create()..theme = theme,
         from: from,
         name: null,
         dependencies: null,
         allTransitiveDependencies: null,
         debugGetCreateSourceHash: null,
-        request: request,
+        theme: theme,
       ),
     );
   }
@@ -370,13 +370,13 @@ class FinampThemeFromImageProvider
 
   @override
   bool operator ==(Object other) {
-    return other is FinampThemeFromImageProvider && other.request == request;
+    return other is FinampThemeFromImageProvider && other.theme == theme;
   }
 
   @override
   int get hashCode {
     var hash = _SystemHash.combine(0, runtimeType.hashCode);
-    hash = _SystemHash.combine(hash, request.hashCode);
+    hash = _SystemHash.combine(hash, theme.hashCode);
 
     return _SystemHash.finish(hash);
   }
@@ -385,8 +385,8 @@ class FinampThemeFromImageProvider
 @Deprecated('Will be removed in 3.0. Use Ref instead')
 // ignore: unused_element
 mixin FinampThemeFromImageRef on AutoDisposeNotifierProviderRef<ColorScheme> {
-  /// The parameter `request` of this provider.
-  ThemeRequestFromImage get request;
+  /// The parameter `theme` of this provider.
+  ThemeImage get theme;
 }
 
 class _FinampThemeFromImageProviderElement
@@ -396,8 +396,7 @@ class _FinampThemeFromImageProviderElement
   _FinampThemeFromImageProviderElement(super.provider);
 
   @override
-  ThemeRequestFromImage get request =>
-      (origin as FinampThemeFromImageProvider).request;
+  ThemeImage get theme => (origin as FinampThemeFromImageProvider).theme;
 }
 
 // ignore_for_file: type=lint

--- a/lib/setup_logging.dart
+++ b/lib/setup_logging.dart
@@ -1,14 +1,11 @@
-import 'dart:convert';
-
 import 'package:finamp/components/global_snackbar.dart';
 import 'package:finamp/services/censored_log.dart';
 import 'package:flutter/foundation.dart';
 import 'package:get_it/get_it.dart';
 import 'package:logging/logging.dart';
 
-import 'services/finamp_logs_helper.dart';
 import 'services/environment_metadata.dart';
-import 'services/censored_log.dart';
+import 'services/finamp_logs_helper.dart';
 
 Future<void> setupLogging() async {
   GetIt.instance.registerSingleton(FinampLogsHelper());
@@ -38,6 +35,5 @@ Future<void> setupLogging() async {
     fetchServerInfo:
         false, // we can't fetch server info yet, because the user helper isn't set up yet. it's also faster to skip this here
   );
-  startupLogger.info(metadata.pretty);
-  startupLogger.info("=== LOGS ===");
+  startupLogger.info("\n${metadata.pretty}");
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -491,7 +491,7 @@ packages:
     source: hosted
     version: "2.1.4"
   file:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: file
       sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -141,10 +141,10 @@ packages:
     dependency: "direct main"
     description:
       name: background_downloader
-      sha256: c59bff0b66a6704bed8bfb09c67571df88167906e0f5543a722373b3d180a743
+      sha256: a22acfa37aa06ba5cfe6eb7b1aa700c78af64770ff450c73dd3d279d7c37d4ac
       url: "https://pub.dev"
     source: hosted
-    version: "9.2.3"
+    version: "9.2.6"
   balanced_text:
     dependency: "direct main"
     description:
@@ -158,10 +158,10 @@ packages:
     dependency: "direct main"
     description:
       name: battery_plus
-      sha256: "03d5a6bb36db9d2b977c548f6b0262d5a84c4d5a4cfee2edac4a91d57011b365"
+      sha256: ad16fcb55b7384be6b4bbc763d5e2031ac7ea62b2d9b6b661490c7b9741155bf
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.3"
+    version: "7.0.0"
   battery_plus_platform_interface:
     dependency: transitive
     description:
@@ -190,10 +190,10 @@ packages:
     dependency: transitive
     description:
       name: build_cli_annotations
-      sha256: b59d2769769efd6c9ff6d4c4cede0be115a566afc591705c2040b707534b1172
+      sha256: e563c2e01de8974566a1998410d3f6f03521788160a02503b0b1f1a46c7b3d95
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   build_config:
     dependency: transitive
     description:
@@ -246,10 +246,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: ba95c961bafcd8686d1cf63be864eb59447e795e124d98d6a27d91fcd13602fb
+      sha256: a30f0a0e38671e89a492c44d005b5545b830a961575bbd8336d42869ff71066d
       url: "https://pub.dev"
     source: hosted
-    version: "8.11.1"
+    version: "8.12.0"
   characters:
     dependency: transitive
     description:
@@ -270,10 +270,10 @@ packages:
     dependency: "direct main"
     description:
       name: chopper
-      sha256: "35cde96292178809ca4290f42dbb83d832551333c2b18a2226a2538103ab40d3"
+      sha256: fb6106cd29553e34c811874efd8e8ee051ad7b9546e0d8c79394d2b6c9621b45
       url: "https://pub.dev"
     source: hosted
-    version: "8.3.0"
+    version: "8.4.0"
   chopper_generator:
     dependency: "direct dev"
     description:
@@ -302,10 +302,10 @@ packages:
     dependency: "direct main"
     description:
       name: clipboard
-      sha256: "2ec38f0e59878008ceca0ab122e4bfde98847f88ef0f83331362ba4521f565a9"
+      sha256: "1920c0337f8808be4166c5f1b236301ff381ef69633b0757c502d97f1f740102"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.3"
+    version: "2.0.2"
   clock:
     dependency: transitive
     description:
@@ -318,10 +318,10 @@ packages:
     dependency: transitive
     description:
       name: code_builder
-      sha256: "0ec10bf4a89e4c613960bf1e8b42c64127021740fb21640c29c909826a5eea3e"
+      sha256: "11654819532ba94c34de52ff5feb52bd81cba1de00ef2ed622fd50295f9d4243"
       url: "https://pub.dev"
     source: hosted
-    version: "4.10.1"
+    version: "4.11.0"
   collection:
     dependency: "direct main"
     description:
@@ -342,10 +342,10 @@ packages:
     dependency: "direct main"
     description:
       name: connectivity_plus
-      sha256: b5e72753cf63becce2c61fd04dfe0f1c430cc5278b53a1342dc5ad839eab29ec
+      sha256: "33bae12a398f841c6cda09d1064212957265869104c478e5ad51e2fb26c3973c"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.5"
+    version: "7.0.0"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
@@ -446,10 +446,10 @@ packages:
     dependency: "direct main"
     description:
       name: device_info_plus
-      sha256: "98f28b42168cc509abc92f88518882fd58061ea372d7999aecc424345c7bff6a"
+      sha256: "49413c8ca514dea7633e8def233b25efdf83ec8522955cc2c0e3ad802927e7c6"
       url: "https://pub.dev"
     source: hosted
-    version: "11.5.0"
+    version: "12.1.0"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -502,10 +502,10 @@ packages:
     dependency: "direct main"
     description:
       name: file_picker
-      sha256: ef7d2a085c1b1d69d17b6842d0734aad90156de08df6bd3c12496d0bd6ddf8e2
+      sha256: f2d9f173c2c14635cc0e9b14c143c49ef30b4934e8d1d274d6206fcb0086a06f
       url: "https://pub.dev"
     source: hosted
-    version: "10.3.1"
+    version: "10.3.3"
   file_sizes:
     dependency: "direct main"
     description:
@@ -555,18 +555,18 @@ packages:
     dependency: transitive
     description:
       name: flutter_gen_core
-      sha256: eda54fdc5de08e7eeea663eb8442aafc8660b5a13fda4e0c9e572c64e50195fb
+      sha256: b6bafbbd981da2f964eb45bcb8b8a7676a281084f8922c0c75de4cfbaa849311
       url: "https://pub.dev"
     source: hosted
-    version: "5.11.0"
+    version: "5.12.0"
   flutter_gen_runner:
     dependency: "direct dev"
     description:
       name: flutter_gen_runner
-      sha256: "669bf8b7a9b4acbdcb7fcc5e12bf638aca19acedf43341714cbca3bf3a219521"
+      sha256: c99b10af9d404e3f46fd1927e7d90099779e935e86022674c4c2a9e6c2a93b29
       url: "https://pub.dev"
     source: hosted
-    version: "5.11.0"
+    version: "5.12.0"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:
@@ -579,10 +579,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: "5398f14efa795ffb7a33e9b6a08798b26a180edac4ad7db3f231e40f82ce11e1"
+      sha256: "3105dc8492f6183fb076ccf1f351ac3d60564bff92e20bfc4af9cc1651f4e7e1"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.0"
+    version: "6.0.0"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -592,10 +592,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_plugin_android_lifecycle
-      sha256: "6382ce712ff69b0f719640ce957559dde459e55ecd433c767e06d139ddf16cab"
+      sha256: b0694b7fb1689b0e6cc193b3f1fcac6423c4f93c74fb20b806c6b6f196db0c31
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.29"
+    version: "2.0.30"
   flutter_riverpod:
     dependency: "direct main"
     description:
@@ -632,10 +632,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_svg
-      sha256: cd57f7969b4679317c17af6fd16ee233c1e60a82ed209d8a475c54fd6fd6f845
+      sha256: b9c2ad5872518a27507ab432d1fb97e8813b05f0fc693f9d40fad06d073e0678
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.2.1"
   flutter_tabler_icons:
     dependency: "direct main"
     description:
@@ -653,10 +653,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_to_airplay
-      sha256: "702408986b652dfaef5ad68c6f3c3008941ae8d8ef5db526792239c8d490a16d"
+      sha256: e71e7cbdf363c3f9686625f68b14e57497b507ef72d54016c14ccdffd3e4305d
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.5"
+    version: "2.1.0"
   flutter_user_certificates_android:
     dependency: "direct main"
     description:
@@ -707,10 +707,10 @@ packages:
     dependency: "direct main"
     description:
       name: get_it
-      sha256: d85128a5dae4ea777324730dc65edd9c9f43155c109d5cc0a69cab74139fbac1
+      sha256: a4292e7cf67193f8e7c1258203104eb2a51ec8b3a04baa14695f4064c144297b
       url: "https://pub.dev"
     source: hosted
-    version: "7.7.0"
+    version: "8.2.0"
   glob:
     dependency: transitive
     description:
@@ -747,18 +747,18 @@ packages:
     dependency: "direct main"
     description:
       name: hive_ce
-      sha256: "708bb39050998707c5d422752159f91944d3c81ab42d80e1bd0ee37d8e130658"
+      sha256: "89746b555109029a30780e0a601978460b8065643592667f6e43a238faccb8a4"
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.3"
+    version: "2.13.2"
   hive_ce_flutter:
     dependency: "direct main"
     description:
       name: hive_ce_flutter
-      sha256: a0989670652eab097b47544f1e5a4456e861b1b01b050098ea0b80a5fabe9909
+      sha256: f5bd57fda84402bca7557fedb8c629c96c8ea10fab4a542968d7b60864ca02cc
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.3.2"
   hive_ce_generator:
     dependency: "direct dev"
     description:
@@ -933,10 +933,10 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "8dcda04c3fc16c14f48a7bb586d4be1f0d1572731b6d81d51772ef47c02081e0"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "11.0.1"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -957,10 +957,10 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: c35bb79562d980e9a453fc715854e1ed39e24e7d0297a880ef54e17f9874a9d7
+      sha256: a5e2b223cb7c9c8efdc663ef484fdd95bb243bff242ef5b13e26883547fce9a0
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.1"
+    version: "6.0.0"
   locale_names:
     dependency: "direct main"
     description:
@@ -1046,10 +1046,10 @@ packages:
     dependency: "direct dev"
     description:
       name: msix
-      sha256: edde648a8133bf301883c869d19d127049683037c65ff64173ba526ac7a8af2f
+      sha256: f88033fcb9e0dd8de5b18897cbebbd28ea30596810f4a7c86b12b0c03ace87e5
       url: "https://pub.dev"
     source: hosted
-    version: "3.16.9"
+    version: "3.16.12"
   nested:
     dependency: transitive
     description:
@@ -1086,10 +1086,10 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: "16eee997588c60225bda0488b6dcfac69280a6b7a3cf02c741895dd370a02968"
+      sha256: f69da0d3189a4b4ceaeb1a3defb0f329b3b352517f52bed4290f83d4f06bc08d
       url: "https://pub.dev"
     source: hosted
-    version: "8.3.1"
+    version: "9.0.0"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -1135,10 +1135,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: d0d310befe2c8ab9e7f393288ccbb11b60c019c6b5afc21973eeee4dda2b35e9
+      sha256: "993381400e94d18469750e5b9dcb8206f15bc09f9da86b9e44a9b0092a0066db"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.17"
+    version: "2.2.18"
   path_provider_foundation:
     dependency: transitive
     description:
@@ -1223,10 +1223,10 @@ packages:
     dependency: transitive
     description:
       name: petitparser
-      sha256: "07c8f0b1913bcde1ff0d26e57ace2f3012ccbf2b204e070290dad3bb22797646"
+      sha256: "1a97266a94f7350d30ae522c0af07890c70b8e62c71e8e3920d1db4d23c057d1"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.0"
+    version: "7.0.1"
   platform:
     dependency: transitive
     description:
@@ -1247,10 +1247,10 @@ packages:
     dependency: transitive
     description:
       name: pool
-      sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
+      sha256: "978783255c543aa3586a1b3c21f6e9d720eb315376a915872c61ef8b5c20177d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.1"
+    version: "1.5.2"
   posix:
     dependency: transitive
     description:
@@ -1295,10 +1295,10 @@ packages:
     dependency: transitive
     description:
       name: qs_dart
-      sha256: "4e293534a5ff88fded92a229c8f5371ec8a6cb3ba81b7be1969692c5ff4afa46"
+      sha256: "23e435223d985630e3880fd667128f520237059ca3af0cc2dc029d5365ce9ec1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "1.5.6"
   riverpod:
     dependency: transitive
     description:
@@ -1407,18 +1407,18 @@ packages:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: fce43200aa03ea87b91ce4c3ac79f0cecd52e2a7a56c7a4185023c271fbfa6da
+      sha256: "3424e9d5c22fd7f7590254ba09465febd6f8827c8b19a44350de4ac31d92d3a6"
       url: "https://pub.dev"
     source: hosted
-    version: "10.1.4"
+    version: "12.0.0"
   share_plus_platform_interface:
     dependency: transitive
     description:
       name: share_plus_platform_interface
-      sha256: cc012a23fc2d479854e6c80150696c4a5f5bb62cb89af4de1c505cf78d0a5d0b
+      sha256: "88023e53a13429bd65d8e85e11a9b484f49d4c190abbd96c7932b74d6927cc9a"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.2"
+    version: "6.1.0"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -1431,10 +1431,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: "5bcf0772a761b04f8c6bf814721713de6f3e5d9d89caf8d3fe031b02a342379e"
+      sha256: bd14436108211b0d4ee5038689a56d4ae3620fd72fd6036e113bf1345bc74d9e
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.11"
+    version: "2.4.13"
   shared_preferences_foundation:
     dependency: transitive
     description:
@@ -1734,10 +1734,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "0aedad096a85b49df2e4725fa32118f9fa580f3b14af7a2d2221896a02cd5656"
+      sha256: "199bc33e746088546a39cc5f36bac5a278c5e53b40cb3196f99e7345fdcfae6b"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.17"
+    version: "6.3.22"
   url_launcher_ios:
     dependency: transitive
     description:
@@ -1822,10 +1822,10 @@ packages:
     dependency: transitive
     description:
       name: vector_graphics_compiler
-      sha256: ca81fdfaf62a5ab45d7296614aea108d2c7d0efca8393e96174bf4d51e6725b0
+      sha256: d354a7ec6931e6047785f4db12a1f61ec3d43b207fc0790f863818543f8ff0dc
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.18"
+    version: "1.1.19"
   vector_math:
     dependency: transitive
     description:
@@ -1854,26 +1854,26 @@ packages:
     dependency: "direct main"
     description:
       name: wakelock_plus
-      sha256: a474e314c3e8fb5adef1f9ae2d247e57467ad557fa7483a2b895bc1b421c5678
+      sha256: "9296d40c9adbedaba95d1e704f4e0b434be446e2792948d0e4aa977048104228"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.4.0"
   wakelock_plus_platform_interface:
     dependency: transitive
     description:
       name: wakelock_plus_platform_interface
-      sha256: e10444072e50dbc4999d7316fd303f7ea53d31c824aa5eb05d7ccbdd98985207
+      sha256: "036deb14cd62f558ca3b73006d52ce049fabcdcb2eddfe0bf0fe4e8a943b5cf2"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.3"
+    version: "1.3.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      sha256: "0b7fd4a0bbc4b92641dbf20adfd7e3fd1398fe17102d94b674234563e110088a"
+      sha256: "5bf046f41320ac97a469d506261797f35254fa61c641741ef32dacda98b7d39c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.3"
   weak_map:
     dependency: transitive
     description:
@@ -1926,10 +1926,10 @@ packages:
     dependency: "direct main"
     description:
       name: window_manager
-      sha256: "732896e1416297c63c9e3fb95aea72d0355f61390263982a47fd519169dc5059"
+      sha256: "7eb6d6c4164ec08e1bf978d6e733f3cebe792e2a23fb07cbca25c2872bfdbdcd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.3"
+    version: "0.5.1"
   xdg_directories:
     dependency: transitive
     description:
@@ -1942,10 +1942,10 @@ packages:
     dependency: transitive
     description:
       name: xml
-      sha256: b015a8ad1c488f66851d762d3090a21c600e479dc75e68328c52774040cf9226
+      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
       url: "https://pub.dev"
     source: hosted
-    version: "6.5.0"
+    version: "6.6.1"
   xxh3:
     dependency: transitive
     description:
@@ -1972,4 +1972,4 @@ packages:
     version: "2.1.0"
 sdks:
   dart: ">=3.9.0 <4.0.0"
-  flutter: ">=3.32.0"
+  flutter: ">=3.35.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1021,8 +1021,8 @@ packages:
     dependency: "direct main"
     description:
       path: "libs/windows/media_kit_libs_windows_audio"
-      ref: "475a08cc97b94702f774bc906e1472b5bddc932b"
-      resolved-ref: "475a08cc97b94702f774bc906e1472b5bddc932b"
+      ref: bfbcea1976093311d6b0ab6bc004a0cc7cd25811
+      resolved-ref: bfbcea1976093311d6b0ab6bc004a0cc7cd25811
       url: "https://github.com/Komodo5197/media-kit.git"
     source: git
     version: "1.0.9"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -149,8 +149,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: e387fcaef4fabf7a24e8c7d9dbb9c967ab1582f4
-      resolved-ref: e387fcaef4fabf7a24e8c7d9dbb9c967ab1582f4
+      ref: "8f3603a639be6a7d5b0008ec54b0e90df7cd8323"
+      resolved-ref: "8f3603a639be6a7d5b0008ec54b0e90df7cd8323"
       url: "https://github.com/Komodo5197/flutter-balanced-text.git"
     source: git
     version: "0.0.3"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1515,10 +1515,11 @@ packages:
   smtc_windows:
     dependency: "direct main"
     description:
-      name: smtc_windows
-      sha256: dee279b0ddf663c4c729a88bca4e57fb4861aa1b3d01e230bdbf1277b8bfe664
-      url: "https://pub.dev"
-    source: hosted
+      path: "packages/smtc_windows"
+      ref: "7ece49cc16a459aaa0718ed23458802533daef37"
+      resolved-ref: "7ece49cc16a459aaa0718ed23458802533daef37"
+      url: "https://github.com/Komodo5197/frb_plugins.git"
+    source: git
     version: "1.1.0"
   source_gen:
     dependency: "direct main"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,7 +41,12 @@ dependencies:
       url: https://github.com/Komodo5197/media-kit.git
       ref: bfbcea1976093311d6b0ab6bc004a0cc7cd25811
       path: libs/windows/media_kit_libs_windows_audio
-  smtc_windows: ^1.0.0
+  smtc_windows:
+    git:
+      url: https://github.com/Komodo5197/frb_plugins.git
+      ref: 7ece49cc16a459aaa0718ed23458802533daef37
+      path: packages/smtc_windows/
+
   audio_service: ^0.18.17
   audio_service_mpris: ^0.2.0
   audio_service_platform_interface: ^0.1.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -102,7 +102,7 @@ dependencies:
   balanced_text:
     git:
       url: https://github.com/Komodo5197/flutter-balanced-text.git
-      ref: e387fcaef4fabf7a24e8c7d9dbb9c967ab1582f4
+      ref: 8f3603a639be6a7d5b0008ec54b0e90df7cd8323
   flutter_to_airplay: ^2.0.5
   flutter_blurhash: ^0.9.1
   scroll_to_index: ^3.0.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,6 +56,7 @@ dependencies:
   collection: ^1.18.0
   clipboard: ^0.1.3
   file_picker: ^10.1.9
+  file: ^7.0.1
   permission_handler: ^12.0.0
   provider: ^6.0.5
   uuid: ^4.5.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,7 +39,7 @@ dependencies:
   media_kit_libs_windows_audio: #^1.0.9
     git:
       url: https://github.com/Komodo5197/media-kit.git
-      ref: 475a08cc97b94702f774bc906e1472b5bddc932b
+      ref: bfbcea1976093311d6b0ab6bc004a0cc7cd25811
       path: libs/windows/media_kit_libs_windows_audio
   smtc_windows: ^1.0.0
   audio_service: ^0.18.17

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   background_downloader: ^9.2.3
   json_annotation: ^4.8.1
   chopper: ^8.0.0
-  get_it: ^7.2.0
+  get_it: ^8.2.0
   just_audio: ^0.9.43
   just_audio_media_kit: ^2.0.6
   media_kit_libs_linux: ^1.1.3
@@ -59,7 +59,7 @@ dependencies:
   file_sizes: ^1.0.6
   logging: ^1.3.0
   collection: ^1.18.0
-  clipboard: ^0.1.3
+  clipboard: ^2.0.2
   file_picker: ^10.1.9
   file: ^7.0.1
   permission_handler: ^12.0.0
@@ -74,9 +74,9 @@ dependencies:
     git:
       url: https://github.com/jfly/flutter_user_certificates_android.git
       ref: db81e4ff3222a7db1308ed03c4bc3142c0d271d5
-  device_info_plus: ^11.3.3
+  device_info_plus: ^12.1.0
   app_set_id: ^1.2.1
-  package_info_plus: ^8.3.0
+  package_info_plus: ^9.0.0
   octo_image: ^2.0.0
   # Main split view package does not seem actively maintained.  Use fork with ability to specify
   # handle visual vs grabbable sizes separately.
@@ -84,7 +84,7 @@ dependencies:
     git:
       url: https://github.com/odriverobotics/split_view.git
       ref: 8b2b0f0e1c8470183cb2df40815a05bfdb3fe219
-  share_plus: ^10.1.4
+  share_plus: ^12.0.0
   isar: ^3.1.0
   isar_flutter_libs:
     git: 
@@ -112,10 +112,10 @@ dependencies:
   flutter_to_airplay: ^2.0.5
   flutter_blurhash: ^0.9.1
   scroll_to_index: ^3.0.1
-  window_manager: ^0.4.3
+  window_manager: ^0.5.1
   url_launcher: ^6.3.1
   wakelock_plus: ^1.2.10
-  battery_plus: ^6.2.1
+  battery_plus: ^7.0.0
   focus_on_it: ^2.0.1
   flutter_svg: ^2.0.17
   meta: ^1.15.0
@@ -123,7 +123,7 @@ dependencies:
   build: ^2.4.2
   source_gen: ^2.0.0
   web_socket_channel: ^3.0.2
-  connectivity_plus: ^6.1.3
+  connectivity_plus: ^7.0.0
   progress_border: ^0.1.5
   visibility_detector: ^0.4.0+2
   gaimon: ^1.4.0
@@ -141,7 +141,7 @@ dev_dependencies:
   hive_ce_generator: ^1.8.1
   json_serializable: ^6.9.0
   flutter_launcher_icons: ^0.14.1
-  flutter_lints: ^5.0.0
+  flutter_lints: ^6.0.0
   riverpod_generator: ^2.6.1
   custom_lint: ^0.7.0
   riverpod_lint: ^2.6.3


### PR DESCRIPTION
An attempt to reduce the amount of unneeded widgets rebuilds occurring, primarily in the track list tiles.  This was mostly dealing with the excessive rebuilds when resizing the window on desktop, but I also caught a few other sources.  This should probably be tested to ensure something didn't get lost in the refactor.  Also:
- Changed overflow menu on track list tiles to depend on tile width instead of platform.  
- Changed the default value of the 'show text in grid view' value to false, but made text always be shown if no image is found for an item.