### PR TITLE
Fix failing build due to incomplete null check

### DIFF
--- a/lib/menus/components/icon_button_with_semantics.dart
+++ b/lib/menus/components/icon_button_with_semantics.dart
@@ -28,8 +28,9 @@ class IconButtonWithSemantics extends ConsumerWidget {
           icon: Icon(icon),
           visualDensity: VisualDensity.compact,
           onPressed: () {
-            if (onPressed != null) {
-              onPressed();
+            var callback = onPressed;
+            if (callback != null) {
+              callback();
               FeedbackHelper.feedback(FeedbackType.selection);
             }
           },


### PR DESCRIPTION
## Changes
As the property is mutable, it cannot smart cast to non-null.

This may only be happening since Flutter 3.35, to which I upgraded a little earlier.