### PR TITLE
Optimize link handler code

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -513,21 +513,19 @@ class _FinampState extends State<Finamp> with WindowListener {
   @override
   void initState() {
     super.initState();
-    // Subscribe to all events (initial link and further)
-    _uriLinkSubscription = AppLinks().uriLinkStream.listen((uri) async {
-      linkHandlingLogger.info("Received link: $uri");
-      int attempts = 0;
-      do {
+
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      _uriLinkSubscription = AppLinks().uriLinkStream.listen((uri) async {
+        linkHandlingLogger.info("Received link: $uri");
         var context = GlobalSnackbar.materialAppNavigatorKey.currentContext;
         if (context != null) {
           if (uri.host == "internal") {
             await Navigator.of(context).pushNamed(uri.path);
           }
-          break;
+        } else {
+          linkHandlingLogger.warning("No context available to handle link");
         }
-        // Wait for the context to be available
-        await Future<void>.delayed(const Duration(milliseconds: 250));
-      } while (++attempts < 10);
+      });
     });
 
     // If the app is running on desktop, we add a listener to the window manager


### PR DESCRIPTION
## Changes
As suggested by @Komodo5197, I replaced the retry loop with a SchedulerBinding frame callback to ensure the app is ready before handling links. Tested locally with the Linux build.

## Related Issues
Originally discussed in 254dc41d48d3065798d5928c7a636942b9ccc2a7.