### PR TITLE
Ensure timestamps of offline listen log are accurate

### DIFF
--- a/lib/services/offline_listen_helper.dart
+++ b/lib/services/offline_listen_helper.dart
@@ -33,13 +33,13 @@ class OfflineListenLogHelper {
   /// Logs a listen to a file.
   ///
   /// This is used when the user is offline or submitting live playback events fails.
-  Future<void> logOfflineListen(MediaItem item) async {
+  Future<void> logOfflineListen(MediaItem item, [DateTime? timestamp]) async {
     final itemJson = item.extras!["itemJson"];
 
     final deviceInfo = await getDeviceInfo();
 
     final offlineListen = OfflineListen(
-      timestamp: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+      timestamp: (timestamp ?? DateTime.now()).millisecondsSinceEpoch ~/ 1000,
       userId: _finampUserHelper.currentUserId!,
       itemId: itemJson["Id"] as String,
       name: itemJson["Name"] as String,


### PR DESCRIPTION
Previously, when sending the playback stop event failed, the offline timestamps were recorded after the network timeout occurred and thus were off by 10 seconds. Now, the timestamps are recorded before attempting the request.