### PR TITLE
Dynamic Accent Color & Colored Monochrome In-App-Icon

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,6 +150,13 @@ But since **making one request for each track that is queued up is simply not fe
 Notably, since we already have the full `BaseItemDto`s and additional metadata for each track, we could simply build client-side automatic transcoding. This would be needed anyway for considering network connectivity and such, so we're not losing much here.  
 
 Should the API for this improve in the future, for example by allowing us to submit the supported codecs and bitrate limits to an endpoint like [`/Sessions/Capabilities/Full`](https://api.jellyfin.org/#tag/Session/operation/PostFullCapabilities) (that part is already possible) and then getting the corresponding `PlaySessionId`s and transcode URLs via the regular `BaseItemDto`, then we could think about doing this the proper way. But until then we'll most likely handle the ID generation and transcoding settings client-side.
+### Android Debug Build stuck in 'assembleDebug'
+1. `cd android`
+2. `./gradlew clean`
+3. `cd ..`
+4. `flutter run -d <phone>`
+
+Now you need to wait a bit, but it'll finish :)
 
 ## The Redesign
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,6 +158,11 @@ Should the API for this improve in the future, for example by allowing us to sub
 
 Now you need to wait a bit, but it'll finish :)
 
+### Add dbus message
+1. Open `lib/services/dbus_manager.dart`
+2. Add another `else if (call.interface == 'com.unicornsonlsd.Finamp' && call.name == 'YOUR FUNCTION NAME')`
+3. Profit
+
 ## The Redesign
 
 The biggest main piece of work being done on Finamp at the moment is the redesign. The relevant meta-issue can be found [here](https://github.com/jmshrv/finamp/issues/220).  

--- a/README.md
+++ b/README.md
@@ -170,6 +170,29 @@ This app is still a work in progress, and has some bugs/issues that haven't been
 - Multiple users/servers
 - More customization options
 
+## Infos for advanced users
+On Linux you can force update accent Color using a dBus message to adapt Finamp to your new color scheme instantly. To do so, simply run update your active GTK theme and run the following command
+```sh
+gdbus call \
+    --session \
+    --dest 'com.unicornsonlsd.FinampSettings' \
+    --object-path '/com/unicornsonlsd/Finamp' \
+    --method 'com.unicornsonlsd.Finamp.updateAccentColor' \
+    ''
+```
+
+Alternatively you can use the following command while finamp is running to overwrite the accent color
+
+```sh
+gdbus call \
+    --session \
+    --dest 'com.unicornsonlsd.FinampSettings' \
+    --object-path '/com/unicornsonlsd/Finamp' \
+    --method 'com.unicornsonlsd.Finamp.setAccentColor' \
+    '#ff0000'
+```
+You should now see that finamp is Red!
+
 ## Screenshots (Stable Version, outdated)
 
 | | |

--- a/README.md
+++ b/README.md
@@ -170,29 +170,6 @@ This app is still a work in progress, and has some bugs/issues that haven't been
 - Multiple users/servers
 - More customization options
 
-## Infos for advanced users
-On Linux you can force update accent Color using a dBus message to adapt Finamp to your new color scheme instantly. To do so, simply run update your active GTK theme and run the following command
-```sh
-gdbus call \
-    --session \
-    --dest 'com.unicornsonlsd.FinampSettings' \
-    --object-path '/com/unicornsonlsd/Finamp' \
-    --method 'com.unicornsonlsd.Finamp.updateAccentColor' \
-    ''
-```
-
-Alternatively you can use the following command while finamp is running to overwrite the accent color
-
-```sh
-gdbus call \
-    --session \
-    --dest 'com.unicornsonlsd.FinampSettings' \
-    --object-path '/com/unicornsonlsd/Finamp' \
-    --method 'com.unicornsonlsd.Finamp.setAccentColor' \
-    '#ff0000'
-```
-You should now see that finamp is Red!
-
 ## Screenshots (Stable Version, outdated)
 
 | | |
@@ -201,3 +178,29 @@ You should now see that finamp is Red!
 | <img src=<https://raw.githubusercontent.com/jmshrv/finamp/master/fastlane/metadata/android/en-US/images/phoneScreenshots/3.png>> | <img src=<https://raw.githubusercontent.com/jmshrv/finamp/master/fastlane/metadata/android/en-US/images/phoneScreenshots/4.png>> |
 
 Name source: <https://www.reddit.com/r/jellyfin/comments/hjxshn/jellyamp_crossplatform_desktop_music_player/fwqs5i0/>
+
+
+## Infos for advanced users
+### Dynamic Theme
+On Linux Finamp registers itself to the DBus System, which means you can send messages locally to Finamp!
+This system allows you keep Finamps color theme up to date with your dynamic color theme without restarting the app.
+There are two color related "endpoints" you can call.
+
+1. Reload the system Theme from GTK (Use Dynamic System Color Theme needs to be *enabled*)
+```sh
+gdbus call \
+    --session \
+    --dest 'com.unicornsonlsd.FinampSettings' \
+    --object-path '/com/unicornsonlsd/Finamp' \
+    --method 'com.unicornsonlsd.Finamp.updateAccentColor'
+```
+
+2. Overwrite the accent color (Use Dynamic System Color Theme needs to be *disabled*) | Doesn't work when Finamp isn't running.
+```sh
+gdbus call \
+    --session \
+    --dest 'com.unicornsonlsd.FinampSettings' \
+    --object-path '/com/unicornsonlsd/Finamp' \
+    --method 'com.unicornsonlsd.Finamp.setAccentColor' \
+    '#ff0000' # you can also send "default" to clear the accent color
+```

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ On Linux, Finamp registers itself with the DBus system, which means you can send
 This system allows you keep Finamp's color theme up to date with your dynamic color theme without restarting the app.
 There are two color related "endpoints" you can call:
 
-1. Reload the system accent color from GTK ([Settings > Layout & Theme > "Use Dynamic System Color Theme"](https://intradeus.github.io/http-protocol-redirector?r=finamp://internal/settings/layout) needs to be *enabled*)
+1. Reload the system accent color from GTK ([Settings > Layout & Theme > "Use System Accent"](https://intradeus.github.io/http-protocol-redirector?r=finamp://internal/settings/layout) needs to be *enabled*)
 ```sh
 gdbus call \
     --session \
@@ -198,7 +198,7 @@ gdbus call \
     --method 'com.unicornsonlsd.Finamp.updateAccentColor'
 ```
 
-2. Overwrite the accent color ([Settings > Layout & Theme > "Use Dynamic System Color Theme"](https://intradeus.github.io/http-protocol-redirector?r=finamp://internal/settings/layout) needs to be *disabled*)  
+2. Overwrite the accent color ([Settings > Layout & Theme > "Use System Accent"](https://intradeus.github.io/http-protocol-redirector?r=finamp://internal/settings/layout) needs to be *disabled*)  
   Only works when Finamp is running.
 ```sh
 gdbus call \

--- a/README.md
+++ b/README.md
@@ -179,14 +179,17 @@ This app is still a work in progress, and has some bugs/issues that haven't been
 
 Name source: <https://www.reddit.com/r/jellyfin/comments/hjxshn/jellyamp_crossplatform_desktop_music_player/fwqs5i0/>
 
+---
 
-## Infos for advanced users
-### Dynamic Theme
-On Linux Finamp registers itself to the DBus System, which means you can send messages locally to Finamp!
-This system allows you keep Finamps color theme up to date with your dynamic color theme without restarting the app.
-There are two color related "endpoints" you can call.
+## Info For Advanced Users
 
-1. Reload the system Accent from GTK (Use Dynamic System Color Theme needs to be *enabled*)
+### Dynamic Theming On Linux
+
+On Linux, Finamp registers itself with the DBus system, which means you can send messages locally to Finamp!
+This system allows you keep Finamp's color theme up to date with your dynamic color theme without restarting the app.
+There are two color related "endpoints" you can call:
+
+1. Reload the system accent color from GTK ([Settings > Layout & Theme > "Use Dynamic System Color Theme"](https://intradeus.github.io/http-protocol-redirector?r=finamp://internal/settings/layout) needs to be *enabled*)
 ```sh
 gdbus call \
     --session \
@@ -195,7 +198,8 @@ gdbus call \
     --method 'com.unicornsonlsd.Finamp.updateAccentColor'
 ```
 
-2. Overwrite the accent color (Use Dynamic System Color Theme needs to be *disabled*) | Doesn't work when Finamp isn't running.
+2. Overwrite the accent color ([Settings > Layout & Theme > "Use Dynamic System Color Theme"](https://intradeus.github.io/http-protocol-redirector?r=finamp://internal/settings/layout) needs to be *disabled*)  
+  Only works when Finamp is running.
 ```sh
 gdbus call \
     --session \

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ On Linux Finamp registers itself to the DBus System, which means you can send me
 This system allows you keep Finamps color theme up to date with your dynamic color theme without restarting the app.
 There are two color related "endpoints" you can call.
 
-1. Reload the system Theme from GTK (Use Dynamic System Color Theme needs to be *enabled*)
+1. Reload the system Accent from GTK (Use Dynamic System Color Theme needs to be *enabled*)
 ```sh
 gdbus call \
     --session \

--- a/lib/color_schemes.g.dart
+++ b/lib/color_schemes.g.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:dynamic_color/dynamic_color.dart';
+import 'package:finamp/services/finamp_settings_helper.dart';
 
 const jellyfinBlueColor = Color(0xFF00A4DC);
 const jellyfinPurpleColor = Color(0xFFAA5CC3);
@@ -98,4 +100,17 @@ ColorScheme getColorScheme(Color? color, Brightness brightness) {
   }
 
   return brightness == Brightness.dark ? darkColorScheme : lightColorScheme;
+}
+
+Future<void> fetchSystemPalette() async {
+  final settingsHelper = FinampSettingsHelper.finampSettings;
+  if (!settingsHelper.useSystemAccentColor) return;
+  final palette = await DynamicColorPlugin.getCorePalette();
+  if (palette == null) return;
+  final scheme = palette.toColorScheme();
+  final primary = scheme.primary;
+  final current = settingsHelper.systemAccentColor;
+  if (primary != current) {
+    FinampSetters.setSystemAccentColor(primary);
+  }
 }

--- a/lib/color_schemes.g.dart
+++ b/lib/color_schemes.g.dart
@@ -101,23 +101,3 @@ ColorScheme getColorScheme(Color? color, Brightness brightness) {
 
   return brightness == Brightness.dark ? darkColorScheme : lightColorScheme;
 }
-
-Future<void> fetchSystemPalette() async {
-  // dont need to run when setting isnt enabled
-  final settingsHelper = FinampSettingsHelper.finampSettings;
-  if (!settingsHelper.useSystemAccentColor) return;
-
-  // skip if invalid palette
-  final palette = await DynamicColorPlugin.getCorePalette();
-  if (palette == null) return;
-
-  // get accent color
-  final scheme = palette.toColorScheme();
-  final primary = scheme.primary;
-  final current = settingsHelper.systemAccentColor;
-
-  // only update when needed (color transitions is laggy, no need to run it when not required)
-  if (primary != current) {
-    FinampSetters.setSystemAccentColor(primary);
-  }
-}

--- a/lib/color_schemes.g.dart
+++ b/lib/color_schemes.g.dart
@@ -103,13 +103,20 @@ ColorScheme getColorScheme(Color? color, Brightness brightness) {
 }
 
 Future<void> fetchSystemPalette() async {
+  // dont need to run when setting isnt enabled
   final settingsHelper = FinampSettingsHelper.finampSettings;
   if (!settingsHelper.useSystemAccentColor) return;
+
+  // skip if invalid palette
   final palette = await DynamicColorPlugin.getCorePalette();
   if (palette == null) return;
+
+  // get accent color
   final scheme = palette.toColorScheme();
   final primary = scheme.primary;
   final current = settingsHelper.systemAccentColor;
+
+  // only update when needed (color transitions is laggy, no need to run it when not required)
   if (primary != current) {
     FinampSetters.setSystemAccentColor(primary);
   }

--- a/lib/components/FinampIcon.dart
+++ b/lib/components/FinampIcon.dart
@@ -1,5 +1,5 @@
-import 'package:finamp/color_schemes.g.dart';
-import 'package:finamp/extensions/color_extensions.dart';
+  import 'package:finamp/color_schemes.g.dart';
+  import 'package:finamp/extensions/color_extensions.dart';
 import 'package:finamp/services/finamp_settings_helper.dart';
 import 'package:finamp/services/widget_bindings_observer_provider.dart';
 import 'package:flutter/material.dart';
@@ -28,7 +28,7 @@ class FinampIcon extends ConsumerWidget {
 
     final brightness = ref.watch(brightnessProvider);
     final colorScheme = getColorScheme(accent, brightness);
-    final color = colorScheme.primary;
+    final color = colorScheme.onSurface;
 
     return ColorFiltered(
       colorFilter: ColorFilter.mode(color, BlendMode.srcIn),

--- a/lib/components/FinampIcon.dart
+++ b/lib/components/FinampIcon.dart
@@ -11,49 +11,28 @@ class FinampIcon extends ConsumerWidget {
   final double width;
   const FinampIcon(this.width, this.height, {super.key});
 
-  String _getColoredSvg(ColorScheme scheme) {
-    Color c = scheme.primary;
-    String cstr = c.toHex();
-
-    return '''<svg width="1024" height="1024" viewBox="0 0 1024 1024" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M714.529 446.555C723.715 468.075 705.091 496.347 630.419 574.243C550.375 657.745 527.954 672.343 494.87 662.493C461.781 652.644 450.992 628.162 429.643 514.478C397.081 341.096 408.151 331.222 578.394 381.894C664.658 407.572 706.343 427.379 714.529 446.555Z" fill="$cstr" fill-opacity="0.97647"/>
-<path d="M714.529 446.555C723.715 468.075 705.091 496.347 630.419 574.243C550.375 657.745 527.954 672.343 494.87 662.493C461.781 652.644 450.992 628.162 429.643 514.478C397.081 341.096 408.151 331.222 578.394 381.894C664.658 407.572 706.343 427.379 714.529 446.555Z" fill="url(#paint0_linear_2111_18575)"/>
-<path d="M328.327 981.999C512.498 769.508 37.2345 154.135 515.922 233.788C574.611 242.892 624.828 246.977 710.922 238.42C830.701 166.298 817.98 145.145 895 72.3472C501.958 77.1111 650.674 101.298 434.486 64.238C362.004 51.8126 255.113 22.3151 186.481 62.0322C111.95 105.162 129.258 240.433 134.543 311.906C149.935 520.03 183.782 822.738 328.31 982" fill="$cstr"/>
-<path d="M328.327 981.999C512.498 769.508 37.2345 154.135 515.922 233.788C574.611 242.892 624.828 246.977 710.922 238.42C830.701 166.298 817.98 145.145 895 72.3472C501.958 77.1111 650.674 101.298 434.486 64.238C362.004 51.8126 255.113 22.3151 186.481 62.0322C111.95 105.162 129.258 240.433 134.543 311.906C149.935 520.03 183.782 822.738 328.31 982" fill="url(#paint1_linear_2111_18575)"/>
-<defs>
-<linearGradient id="paint0_linear_2111_18575" x1="714.565" y1="446.537" x2="528.174" y2="481.259" gradientUnits="userSpaceOnUse">
-<stop stop-color="$cstr"/>
-<stop offset="1" stop-color="$cstr" stop-opacity="0"/>
-</linearGradient>
-<linearGradient id="paint1_linear_2111_18575" x1="783.228" y1="484.384" x2="278.88" y2="516.201" gradientUnits="userSpaceOnUse">
-<stop stop-color="$cstr"/>
-<stop offset="1" stop-color="$cstr" stop-opacity="0"/>
-</linearGradient>
-</defs>
-</svg>''';
-  }
-
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final accent = ref.watch(finampSettingsProvider.accentColor);
 
-    if (accent==null) {
-      return SvgPicture.asset(
+    final icon = SvgPicture.asset(
         "images/finamp_cropped.svg",
         width: width,
         height: height
       );
+
+    if (accent==null) {
+      return icon;
     }
 
     final brightness = ref.watch(brightnessProvider);
     final colorScheme = getColorScheme(accent, brightness);
+    final color = colorScheme.primary;
 
-    return SvgPicture.string(
-      _getColoredSvg(colorScheme),
-      width: width,
-      height: height,
+    return ColorFiltered(
+      colorFilter: ColorFilter.mode(color, BlendMode.srcIn),
+      child: icon,
     );
-
   }
 }

--- a/lib/components/FinampIcon.dart
+++ b/lib/components/FinampIcon.dart
@@ -1,0 +1,59 @@
+import 'package:finamp/color_schemes.g.dart';
+import 'package:finamp/extensions/color_extensions.dart';
+import 'package:finamp/services/finamp_settings_helper.dart';
+import 'package:finamp/services/widget_bindings_observer_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_svg/svg.dart';
+
+class FinampIcon extends ConsumerWidget {
+  final double height;
+  final double width;
+  const FinampIcon(this.width, this.height, {super.key});
+
+  String _getColoredSvg(ColorScheme scheme) {
+    Color c = scheme.primary;
+    String cstr = c.toHex();
+
+    return '''<svg width="1024" height="1024" viewBox="0 0 1024 1024" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M714.529 446.555C723.715 468.075 705.091 496.347 630.419 574.243C550.375 657.745 527.954 672.343 494.87 662.493C461.781 652.644 450.992 628.162 429.643 514.478C397.081 341.096 408.151 331.222 578.394 381.894C664.658 407.572 706.343 427.379 714.529 446.555Z" fill="$cstr" fill-opacity="0.97647"/>
+<path d="M714.529 446.555C723.715 468.075 705.091 496.347 630.419 574.243C550.375 657.745 527.954 672.343 494.87 662.493C461.781 652.644 450.992 628.162 429.643 514.478C397.081 341.096 408.151 331.222 578.394 381.894C664.658 407.572 706.343 427.379 714.529 446.555Z" fill="url(#paint0_linear_2111_18575)"/>
+<path d="M328.327 981.999C512.498 769.508 37.2345 154.135 515.922 233.788C574.611 242.892 624.828 246.977 710.922 238.42C830.701 166.298 817.98 145.145 895 72.3472C501.958 77.1111 650.674 101.298 434.486 64.238C362.004 51.8126 255.113 22.3151 186.481 62.0322C111.95 105.162 129.258 240.433 134.543 311.906C149.935 520.03 183.782 822.738 328.31 982" fill="$cstr"/>
+<path d="M328.327 981.999C512.498 769.508 37.2345 154.135 515.922 233.788C574.611 242.892 624.828 246.977 710.922 238.42C830.701 166.298 817.98 145.145 895 72.3472C501.958 77.1111 650.674 101.298 434.486 64.238C362.004 51.8126 255.113 22.3151 186.481 62.0322C111.95 105.162 129.258 240.433 134.543 311.906C149.935 520.03 183.782 822.738 328.31 982" fill="url(#paint1_linear_2111_18575)"/>
+<defs>
+<linearGradient id="paint0_linear_2111_18575" x1="714.565" y1="446.537" x2="528.174" y2="481.259" gradientUnits="userSpaceOnUse">
+<stop stop-color="$cstr"/>
+<stop offset="1" stop-color="$cstr" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint1_linear_2111_18575" x1="783.228" y1="484.384" x2="278.88" y2="516.201" gradientUnits="userSpaceOnUse">
+<stop stop-color="$cstr"/>
+<stop offset="1" stop-color="$cstr" stop-opacity="0"/>
+</linearGradient>
+</defs>
+</svg>''';
+  }
+
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final accent = ref.watch(finampSettingsProvider.accentColor);
+
+    if (accent==null) {
+      return SvgPicture.asset(
+        "images/finamp_cropped.svg",
+        width: width,
+        height: height
+      );
+    }
+
+    final brightness = ref.watch(brightnessProvider);
+    final colorScheme = getColorScheme(accent, brightness);
+
+    return SvgPicture.string(
+      _getColoredSvg(colorScheme),
+      width: width,
+      height: height,
+    );
+
+  }
+}

--- a/lib/components/FinampIcon.dart
+++ b/lib/components/FinampIcon.dart
@@ -1,5 +1,5 @@
-  import 'package:finamp/color_schemes.g.dart';
-  import 'package:finamp/extensions/color_extensions.dart';
+import 'package:finamp/color_schemes.g.dart';
+import 'package:finamp/extensions/color_extensions.dart';
 import 'package:finamp/services/finamp_settings_helper.dart';
 import 'package:finamp/services/widget_bindings_observer_provider.dart';
 import 'package:flutter/material.dart';
@@ -11,18 +11,13 @@ class FinampIcon extends ConsumerWidget {
   final double width;
   const FinampIcon(this.width, this.height, {super.key});
 
-
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final accent = ref.watch(finampSettingsProvider.accentColor);
 
-    final icon = SvgPicture.asset(
-        "images/finamp_cropped.svg",
-        width: width,
-        height: height
-      );
+    final icon = SvgPicture.asset("images/finamp_cropped.svg", width: width, height: height);
 
-    if (accent==null) {
+    if (accent == null) {
       return icon;
     }
 
@@ -30,9 +25,6 @@ class FinampIcon extends ConsumerWidget {
     final colorScheme = getColorScheme(accent, brightness);
     final color = colorScheme.onSurface;
 
-    return ColorFiltered(
-      colorFilter: ColorFilter.mode(color, BlendMode.srcIn),
-      child: icon,
-    );
+    return ColorFiltered(colorFilter: ColorFilter.mode(color, BlendMode.srcIn), child: icon);
   }
 }

--- a/lib/components/LayoutSettingsScreen/accent_color_selector.dart
+++ b/lib/components/LayoutSettingsScreen/accent_color_selector.dart
@@ -13,16 +13,18 @@ class AccentColorSelector extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final useSystemColor = ref.watch(finampSettingsProvider.useSystemAccentColor);
+    final useSystemAccent = ref.watch(finampSettingsProvider.useSystemAccentColor);
     final color = ref.watch(finampSettingsProvider.accentColor);
     final isSet = color != null;
 
     return ListTile(
-      enabled: !useSystemColor,
-      subtitle: useSystemColor ? Text(AppLocalizations.of(context)!.systemAccentColorHasPriorityInfo) : null,
+      enabled: !useSystemAccent,
+      subtitle: useSystemAccent ? Text(AppLocalizations.of(context)!.systemAccentColorHasPriorityInfo) : null,
       title: Text(AppLocalizations.of(context)!.accentColor),
       trailing: GestureDetector(
         onTap: () {
+          // "Disable" when using systemAccent
+          if (useSystemAccent) return;
           showModalBottomSheet<void>(
             context: context,
             isScrollControlled: true,

--- a/lib/components/LayoutSettingsScreen/accent_color_selector.dart
+++ b/lib/components/LayoutSettingsScreen/accent_color_selector.dart
@@ -13,9 +13,13 @@ class AccentColorSelector extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final useSystemColor = ref.watch(finampSettingsProvider.useSystemAccentColor);
     final color = ref.watch(finampSettingsProvider.accentColor);
     final isSet = color != null;
+
     return ListTile(
+      enabled: !useSystemColor,
+      subtitle: useSystemColor ? Text(AppLocalizations.of(context)!.systemAccentColorHasPriorityInfo) : null,
       title: Text(AppLocalizations.of(context)!.accentColor),
       trailing: GestureDetector(
         onTap: () {

--- a/lib/components/LayoutSettingsScreen/accent_color_selector.dart
+++ b/lib/components/LayoutSettingsScreen/accent_color_selector.dart
@@ -22,9 +22,7 @@ class AccentColorSelector extends ConsumerWidget {
       subtitle: useSystemAccent ? Text(AppLocalizations.of(context)!.systemAccentColorHasPriorityInfo) : null,
       title: Text(AppLocalizations.of(context)!.accentColor),
       trailing: GestureDetector(
-        onTap: () {
-          // "Disable" when using systemAccent
-          if (useSystemAccent) return;
+        onTap: useSystemAccent ? null : () {
           showModalBottomSheet<void>(
             context: context,
             isScrollControlled: true,

--- a/lib/components/LayoutSettingsScreen/accent_color_selector.dart
+++ b/lib/components/LayoutSettingsScreen/accent_color_selector.dart
@@ -22,19 +22,21 @@ class AccentColorSelector extends ConsumerWidget {
       subtitle: useSystemAccent ? Text(AppLocalizations.of(context)!.systemAccentColorHasPriorityInfo) : null,
       title: Text(AppLocalizations.of(context)!.accentColor),
       trailing: GestureDetector(
-        onTap: useSystemAccent ? null : () {
-          showModalBottomSheet<void>(
-            context: context,
-            isScrollControlled: true,
-            useSafeArea: true,
-            builder: (context) {
-              return ScrollConfiguration(
-                behavior: ScrollConfiguration.of(context).copyWith(scrollbars: false),
-                child: SingleChildScrollView(child: const AccentColorPopup()),
-              );
-            },
-          );
-        },
+        onTap: useSystemAccent
+            ? null
+            : () {
+                showModalBottomSheet<void>(
+                  context: context,
+                  isScrollControlled: true,
+                  useSafeArea: true,
+                  builder: (context) {
+                    return ScrollConfiguration(
+                      behavior: ScrollConfiguration.of(context).copyWith(scrollbars: false),
+                      child: SingleChildScrollView(child: const AccentColorPopup()),
+                    );
+                  },
+                );
+              },
         child: Row(
           mainAxisSize: MainAxisSize.min,
           mainAxisAlignment: MainAxisAlignment.spaceBetween,

--- a/lib/components/LayoutSettingsScreen/automatic_accent_color_selector.dart
+++ b/lib/components/LayoutSettingsScreen/automatic_accent_color_selector.dart
@@ -23,16 +23,12 @@ class AutomaticAccentColorSelector extends ConsumerWidget {
         mainAxisSize: MainAxisSize.min,
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
-          
           Container(
             width: 20,
             height: 20,
             margin: EdgeInsets.fromLTRB(0, 0, 2, 0),
-            decoration: BoxDecoration(
-              color: sysColor ?? Colors.transparent,
-              borderRadius: BorderRadius.circular(13),
-            )
-          ),  
+            decoration: BoxDecoration(color: sysColor ?? Colors.transparent, borderRadius: BorderRadius.circular(13)),
+          ),
           SizedBox(width: 16),
           Switch.adaptive(
             value: ref.watch(finampSettingsProvider.useSystemAccentColor),

--- a/lib/components/LayoutSettingsScreen/automatic_accent_color_selector.dart
+++ b/lib/components/LayoutSettingsScreen/automatic_accent_color_selector.dart
@@ -13,7 +13,6 @@ class AutomaticAccentColorSelector extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final sysColor = ref.watch(finampSettingsProvider.systemAccentColor);
-
     final supportsSystemTheme = Platform.isAndroid || Platform.isWindows || Platform.isMacOS || Platform.isLinux;
     // Safe to assume that the System does not have Color Theme Support
     if (!supportsSystemTheme) return SizedBox.shrink();
@@ -24,18 +23,19 @@ class AutomaticAccentColorSelector extends ConsumerWidget {
         mainAxisSize: MainAxisSize.min,
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
-          Text(
-            sysColor?.toHex() ?? "",
-            style: TextStyle(
-              fontWeight: FontWeight.w400,
-              color: Theme.of(context).textTheme.bodySmall?.color,
-              fontSize: 16,
-            ),
-          ),
+          
+          Container(
+            width: 20,
+            height: 20,
+            margin: EdgeInsets.fromLTRB(0, 0, 2, 0),
+            decoration: BoxDecoration(
+              color: sysColor ?? Colors.transparent,
+              borderRadius: BorderRadius.circular(13),
+            )
+          ),  
           SizedBox(width: 16),
           Switch.adaptive(
             value: ref.watch(finampSettingsProvider.useSystemAccentColor),
-            inactiveThumbColor: sysColor,
             onChanged: (value) {
               FinampSetters.setUseSystemAccentColor(value);
               unawaited(fetchSystemPalette());

--- a/lib/components/LayoutSettingsScreen/automatic_accent_color_selector.dart
+++ b/lib/components/LayoutSettingsScreen/automatic_accent_color_selector.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:finamp/color_schemes.g.dart';
+import 'package:finamp/extensions/color_extensions.dart';
 import 'package:finamp/services/finamp_settings_helper.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -15,14 +16,33 @@ class AutomaticAccentColorSelector extends ConsumerWidget {
     // System does not have global color Theme Support
     if (sysColor == null) return SizedBox.shrink();
 
-    return SwitchListTile.adaptive(
-      title: Text("Use System Theme"),
-      subtitle: Text("Material You"),
-      value: ref.watch(finampSettingsProvider.useSystemAccentColor),
-      onChanged: (value) {
-        FinampSetters.setUseSystemAccentColor(value);
-        unawaited(fetchSystemPalette());
-      },
+    return ListTile(
+      title: Text("Use Dynamic System Theme"),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(
+            sysColor.toHex(),
+            style: TextStyle(
+              // fontStyle: FontStyle.italic,
+              fontWeight: FontWeight.w400,
+              color: Theme.of(context).textTheme.bodySmall?.color,
+              fontSize: 16,
+            ),
+          ),
+          SizedBox(width: 16),
+          Switch.adaptive(
+            value: ref.watch(finampSettingsProvider.useSystemAccentColor),
+            activeThumbColor: sysColor,
+            inactiveThumbColor: sysColor,
+            onChanged: (value) {
+              FinampSetters.setUseSystemAccentColor(value);
+              unawaited(fetchSystemPalette());
+            },
+          )
+        ],
+      )
     );
   }
 }

--- a/lib/components/LayoutSettingsScreen/automatic_accent_color_selector.dart
+++ b/lib/components/LayoutSettingsScreen/automatic_accent_color_selector.dart
@@ -11,7 +11,7 @@ class AutomaticAccentColorSelector extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final sysColor = FinampSettingsHelper.finampSettings.systemAccentColor;
-    
+
     // System does not have global color Theme Support
     if (sysColor == null) return SizedBox.shrink();
 

--- a/lib/components/LayoutSettingsScreen/automatic_accent_color_selector.dart
+++ b/lib/components/LayoutSettingsScreen/automatic_accent_color_selector.dart
@@ -1,9 +1,10 @@
 import 'dart:async';
-
+import 'dart:io';
 import 'package:finamp/color_schemes.g.dart';
 import 'package:finamp/extensions/color_extensions.dart';
 import 'package:finamp/l10n/app_localizations.dart';
 import 'package:finamp/services/finamp_settings_helper.dart';
+import 'package:finamp/services/theme_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -12,19 +13,20 @@ class AutomaticAccentColorSelector extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final sysColor = FinampSettingsHelper.finampSettings.systemAccentColor;
+    final sysColor = ref.watch(finampSettingsProvider.systemAccentColor);
 
     // Safe to assume that the System does not have Color Theme Support
-    if (sysColor == null) return SizedBox.shrink();
+    final supportsSystemTheme = Platform.isAndroid || Platform.isWindows || Platform.isMacOS || Platform.isLinux;
+    if (!supportsSystemTheme) return SizedBox.shrink();
 
     return ListTile(
-      title: Text(AppLocalizations.of(context)!.systemAccentColor),
+      title: Text(AppLocalizations.of(context)!.systemAccentColor(Platform.operatingSystem)),
       trailing: Row(
         mainAxisSize: MainAxisSize.min,
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
           Text(
-            sysColor.toHex(),
+            sysColor?.toHex() ?? "",
             style: TextStyle(
               fontWeight: FontWeight.w400,
               color: Theme.of(context).textTheme.bodySmall?.color,
@@ -34,7 +36,6 @@ class AutomaticAccentColorSelector extends ConsumerWidget {
           SizedBox(width: 16),
           Switch.adaptive(
             value: ref.watch(finampSettingsProvider.useSystemAccentColor),
-            activeThumbColor: sysColor,
             inactiveThumbColor: sysColor,
             onChanged: (value) {
               FinampSetters.setUseSystemAccentColor(value);

--- a/lib/components/LayoutSettingsScreen/automatic_accent_color_selector.dart
+++ b/lib/components/LayoutSettingsScreen/automatic_accent_color_selector.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:io';
-import 'package:finamp/color_schemes.g.dart';
 import 'package:finamp/extensions/color_extensions.dart';
 import 'package:finamp/l10n/app_localizations.dart';
 import 'package:finamp/services/finamp_settings_helper.dart';
@@ -15,12 +14,12 @@ class AutomaticAccentColorSelector extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final sysColor = ref.watch(finampSettingsProvider.systemAccentColor);
 
-    // Safe to assume that the System does not have Color Theme Support
     final supportsSystemTheme = Platform.isAndroid || Platform.isWindows || Platform.isMacOS || Platform.isLinux;
+    // Safe to assume that the System does not have Color Theme Support
     if (!supportsSystemTheme) return SizedBox.shrink();
 
     return ListTile(
-      title: Text(AppLocalizations.of(context)!.systemAccentColor(Platform.operatingSystem)),
+      title: Text(AppLocalizations.of(context)!.systemAccentColor),
       trailing: Row(
         mainAxisSize: MainAxisSize.min,
         mainAxisAlignment: MainAxisAlignment.spaceBetween,

--- a/lib/components/LayoutSettingsScreen/automatic_accent_color_selector.dart
+++ b/lib/components/LayoutSettingsScreen/automatic_accent_color_selector.dart
@@ -1,0 +1,28 @@
+import 'dart:async';
+
+import 'package:finamp/color_schemes.g.dart';
+import 'package:finamp/services/finamp_settings_helper.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class AutomaticAccentColorSelector extends ConsumerWidget {
+  const AutomaticAccentColorSelector({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final sysColor = FinampSettingsHelper.finampSettings.systemAccentColor;
+    
+    // System does not have global color Theme Support
+    if (sysColor == null) return SizedBox.shrink();
+
+    return SwitchListTile.adaptive(
+      title: Text("Use System Theme"),
+      subtitle: Text("Material You"),
+      value: ref.watch(finampSettingsProvider.useSystemAccentColor),
+      onChanged: (value) {
+        FinampSetters.setUseSystemAccentColor(value);
+        unawaited(fetchSystemPalette());
+      },
+    );
+  }
+}

--- a/lib/components/LayoutSettingsScreen/automatic_accent_color_selector.dart
+++ b/lib/components/LayoutSettingsScreen/automatic_accent_color_selector.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:finamp/color_schemes.g.dart';
 import 'package:finamp/extensions/color_extensions.dart';
+import 'package:finamp/l10n/app_localizations.dart';
 import 'package:finamp/services/finamp_settings_helper.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -13,11 +14,11 @@ class AutomaticAccentColorSelector extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final sysColor = FinampSettingsHelper.finampSettings.systemAccentColor;
 
-    // System does not have global color Theme Support
+    // Safe to assume that the System does not have Color Theme Support
     if (sysColor == null) return SizedBox.shrink();
 
     return ListTile(
-      title: Text("Use Dynamic System Theme"),
+      title: Text(AppLocalizations.of(context)!.systemAccentColor),
       trailing: Row(
         mainAxisSize: MainAxisSize.min,
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -25,7 +26,6 @@ class AutomaticAccentColorSelector extends ConsumerWidget {
           Text(
             sysColor.toHex(),
             style: TextStyle(
-              // fontStyle: FontStyle.italic,
               fontWeight: FontWeight.w400,
               color: Theme.of(context).textTheme.bodySmall?.color,
               fontSize: 16,
@@ -40,9 +40,9 @@ class AutomaticAccentColorSelector extends ConsumerWidget {
               FinampSetters.setUseSystemAccentColor(value);
               unawaited(fetchSystemPalette());
             },
-          )
+          ),
         ],
-      )
+      ),
     );
   }
 }

--- a/lib/components/LayoutSettingsScreen/automatic_accent_color_selector.dart
+++ b/lib/components/LayoutSettingsScreen/automatic_accent_color_selector.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:io';
-import 'package:finamp/extensions/color_extensions.dart';
 import 'package:finamp/l10n/app_localizations.dart';
 import 'package:finamp/services/finamp_settings_helper.dart';
 import 'package:finamp/services/theme_provider.dart';
@@ -24,10 +23,10 @@ class AutomaticAccentColorSelector extends ConsumerWidget {
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
           Container(
-            width: 20,
-            height: 20,
-            margin: EdgeInsets.fromLTRB(0, 0, 2, 0),
-            decoration: BoxDecoration(color: sysColor ?? Colors.transparent, borderRadius: BorderRadius.circular(13)),
+            width: 32,
+            height: 32,
+            margin: EdgeInsets.only(right: 2),
+            decoration: BoxDecoration(color: sysColor ?? Colors.transparent, borderRadius: BorderRadius.circular(16)),
           ),
           SizedBox(width: 16),
           Switch.adaptive(

--- a/lib/components/LayoutSettingsScreen/use_monochrome_icon.dart
+++ b/lib/components/LayoutSettingsScreen/use_monochrome_icon.dart
@@ -1,0 +1,18 @@
+import 'package:finamp/l10n/app_localizations.dart';
+import 'package:finamp/services/finamp_settings_helper.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class UseMonochromeIcon extends ConsumerWidget {
+  const UseMonochromeIcon({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return SwitchListTile.adaptive(
+      title: Text(AppLocalizations.of(context)!.useMonochromeIcon),
+      subtitle: Text(AppLocalizations.of(context)!.useMonochromeIconSubtitle),
+      value: ref.watch(finampSettingsProvider.useMonochromeIcon),
+      onChanged: (value) => FinampSetters.setUseMonochromeIcon(value),
+    );
+  }
+}

--- a/lib/components/LoginScreen/login_authentication_page.dart
+++ b/lib/components/LoginScreen/login_authentication_page.dart
@@ -1,12 +1,12 @@
 import 'package:finamp/components/Buttons/cta_medium.dart';
 import 'package:finamp/components/Buttons/simple_button.dart';
+import 'package:finamp/components/FinampIcon.dart';
 import 'package:finamp/components/LoginScreen/login_user_selection_page.dart';
 import 'package:finamp/components/global_snackbar.dart';
 import 'package:finamp/l10n/app_localizations.dart';
 import 'package:finamp/models/jellyfin_models.dart';
 import 'package:finamp/services/jellyfin_api_helper.dart';
 import 'package:flutter/material.dart' hide ConnectionState;
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
 import 'package:get_it/get_it.dart';
 import 'package:logging/logging.dart';
@@ -55,7 +55,7 @@ class _LoginAuthenticationPageState extends State<LoginAuthenticationPage> {
             children: [
               Padding(
                 padding: const EdgeInsets.only(top: 32.0, bottom: 20.0),
-                child: SvgPicture.asset('images/finamp_cropped.svg', width: 75, height: 75),
+                child: FinampIcon(75, 75),
               ),
               Text(
                 AppLocalizations.of(context)!.loginFlowAuthenticationHeading,

--- a/lib/components/LoginScreen/login_authentication_page.dart
+++ b/lib/components/LoginScreen/login_authentication_page.dart
@@ -1,6 +1,6 @@
 import 'package:finamp/components/Buttons/cta_medium.dart';
 import 'package:finamp/components/Buttons/simple_button.dart';
-import 'package:finamp/components/FinampIcon.dart';
+import 'package:finamp/components/finamp_icon.dart';
 import 'package:finamp/components/LoginScreen/login_user_selection_page.dart';
 import 'package:finamp/components/global_snackbar.dart';
 import 'package:finamp/l10n/app_localizations.dart';

--- a/lib/components/LoginScreen/login_authentication_page.dart
+++ b/lib/components/LoginScreen/login_authentication_page.dart
@@ -53,10 +53,7 @@ class _LoginAuthenticationPageState extends State<LoginAuthenticationPage> {
         child: Center(
           child: Column(
             children: [
-              Padding(
-                padding: const EdgeInsets.only(top: 32.0, bottom: 20.0),
-                child: FinampIcon(75, 75),
-              ),
+              Padding(padding: const EdgeInsets.only(top: 32.0, bottom: 20.0), child: FinampIcon(75, 75)),
               Text(
                 AppLocalizations.of(context)!.loginFlowAuthenticationHeading,
                 style: Theme.of(context).textTheme.headlineMedium,

--- a/lib/components/LoginScreen/login_server_selection_page.dart
+++ b/lib/components/LoginScreen/login_server_selection_page.dart
@@ -75,10 +75,7 @@ class _LoginServerSelectionPageState extends State<LoginServerSelectionPage> {
             children: [
               Padding(
                 padding: const EdgeInsets.only(top: 32.0, bottom: 20.0),
-                child: Hero(
-                  tag: "finamp_logo",
-                  child: FinampIcon(75, 75),
-                ),
+                child: Hero(tag: "finamp_logo", child: FinampIcon(75, 75)),
               ),
               Text(
                 AppLocalizations.of(context)!.loginFlowServerSelectionHeading,

--- a/lib/components/LoginScreen/login_server_selection_page.dart
+++ b/lib/components/LoginScreen/login_server_selection_page.dart
@@ -1,5 +1,5 @@
 import 'package:finamp/components/Buttons/simple_button.dart';
-import 'package:finamp/components/FinampIcon.dart';
+import 'package:finamp/components/finamp_icon.dart';
 import 'package:finamp/models/jellyfin_models.dart';
 import 'package:finamp/services/jellyfin_api_helper.dart';
 import 'package:flutter/material.dart';

--- a/lib/components/LoginScreen/login_server_selection_page.dart
+++ b/lib/components/LoginScreen/login_server_selection_page.dart
@@ -1,9 +1,9 @@
 import 'package:finamp/components/Buttons/simple_button.dart';
+import 'package:finamp/components/FinampIcon.dart';
 import 'package:finamp/models/jellyfin_models.dart';
 import 'package:finamp/services/jellyfin_api_helper.dart';
 import 'package:flutter/material.dart';
 import 'package:finamp/l10n/app_localizations.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
 import 'package:get_it/get_it.dart';
 import 'package:logging/logging.dart';
@@ -77,7 +77,7 @@ class _LoginServerSelectionPageState extends State<LoginServerSelectionPage> {
                 padding: const EdgeInsets.only(top: 32.0, bottom: 20.0),
                 child: Hero(
                   tag: "finamp_logo",
-                  child: SvgPicture.asset('images/finamp_cropped.svg', width: 75, height: 75),
+                  child: FinampIcon(75, 75),
                 ),
               ),
               Text(

--- a/lib/components/LoginScreen/login_splash_page.dart
+++ b/lib/components/LoginScreen/login_splash_page.dart
@@ -1,5 +1,5 @@
 import 'package:finamp/components/Buttons/cta_large.dart';
-import 'package:finamp/components/FinampIcon.dart';
+import 'package:finamp/components/finamp_icon.dart';
 import 'package:finamp/l10n/app_localizations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';

--- a/lib/components/LoginScreen/login_splash_page.dart
+++ b/lib/components/LoginScreen/login_splash_page.dart
@@ -24,10 +24,7 @@ class LoginSplashPage extends StatelessWidget {
             children: [
               Padding(
                 padding: const EdgeInsets.only(top: 80.0, bottom: 40.0),
-                child: Hero(
-                  tag: "finamp_logo",
-                  child: FinampIcon(150, 150),
-                ),
+                child: Hero(tag: "finamp_logo", child: FinampIcon(150, 150)),
               ),
               RichText(
                 text: TextSpan(

--- a/lib/components/LoginScreen/login_splash_page.dart
+++ b/lib/components/LoginScreen/login_splash_page.dart
@@ -1,4 +1,5 @@
 import 'package:finamp/components/Buttons/cta_large.dart';
+import 'package:finamp/components/FinampIcon.dart';
 import 'package:finamp/l10n/app_localizations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -25,7 +26,7 @@ class LoginSplashPage extends StatelessWidget {
                 padding: const EdgeInsets.only(top: 80.0, bottom: 40.0),
                 child: Hero(
                   tag: "finamp_logo",
-                  child: SvgPicture.asset('images/finamp_cropped.svg', width: 150, height: 150),
+                  child: FinampIcon(150, 150),
                 ),
               ),
               RichText(

--- a/lib/components/LoginScreen/login_user_selection_page.dart
+++ b/lib/components/LoginScreen/login_user_selection_page.dart
@@ -1,4 +1,5 @@
 import 'package:finamp/components/Buttons/simple_button.dart';
+import 'package:finamp/components/FinampIcon.dart';
 import 'package:finamp/l10n/app_localizations.dart';
 import 'package:finamp/models/jellyfin_models.dart';
 import 'package:finamp/services/feedback_helper.dart';
@@ -75,7 +76,7 @@ class _LoginUserSelectionPageState extends State<LoginUserSelectionPage> {
             children: [
               Padding(
                 padding: const EdgeInsets.only(top: 32.0, bottom: 20.0),
-                child: SvgPicture.asset('images/finamp_cropped.svg', width: 75, height: 75),
+                child: FinampIcon(75, 75),
               ),
               Text(
                 AppLocalizations.of(context)!.loginFlowAccountSelectionHeading,

--- a/lib/components/LoginScreen/login_user_selection_page.dart
+++ b/lib/components/LoginScreen/login_user_selection_page.dart
@@ -74,10 +74,7 @@ class _LoginUserSelectionPageState extends State<LoginUserSelectionPage> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              Padding(
-                padding: const EdgeInsets.only(top: 32.0, bottom: 20.0),
-                child: FinampIcon(75, 75),
-              ),
+              Padding(padding: const EdgeInsets.only(top: 32.0, bottom: 20.0), child: FinampIcon(75, 75)),
               Text(
                 AppLocalizations.of(context)!.loginFlowAccountSelectionHeading,
                 style: Theme.of(context).textTheme.headlineMedium,

--- a/lib/components/LoginScreen/login_user_selection_page.dart
+++ b/lib/components/LoginScreen/login_user_selection_page.dart
@@ -1,5 +1,5 @@
 import 'package:finamp/components/Buttons/simple_button.dart';
-import 'package:finamp/components/FinampIcon.dart';
+import 'package:finamp/components/finamp_icon.dart';
 import 'package:finamp/l10n/app_localizations.dart';
 import 'package:finamp/models/jellyfin_models.dart';
 import 'package:finamp/services/feedback_helper.dart';

--- a/lib/components/finamp_icon.dart
+++ b/lib/components/finamp_icon.dart
@@ -1,5 +1,4 @@
 import 'package:finamp/color_schemes.g.dart';
-import 'package:finamp/extensions/color_extensions.dart';
 import 'package:finamp/services/finamp_settings_helper.dart';
 import 'package:finamp/services/widget_bindings_observer_provider.dart';
 import 'package:flutter/material.dart';

--- a/lib/components/finamp_icon.dart
+++ b/lib/components/finamp_icon.dart
@@ -16,10 +16,7 @@ class FinampIcon extends ConsumerWidget {
     final useMonochromeIcon = ref.watch(finampSettingsProvider.useMonochromeIcon);
     if (!useMonochromeIcon) return icon;
 
-    final accent = ref.watch(finampSettingsProvider.accentColor);
-    final brightness = ref.watch(brightnessProvider);
-    final colorScheme = getColorScheme(accent, brightness);
-    final color = colorScheme.onSurface;
+    final color = Theme.of(context).colorScheme.tertiary;
 
     // Basically this uses the icon as a mask on top of a solid color
     return ColorFiltered(colorFilter: ColorFilter.mode(color, BlendMode.srcIn), child: icon);

--- a/lib/components/finamp_icon.dart
+++ b/lib/components/finamp_icon.dart
@@ -16,7 +16,7 @@ class FinampIcon extends ConsumerWidget {
     final useMonochromeIcon = ref.watch(finampSettingsProvider.useMonochromeIcon);
     if (!useMonochromeIcon) return icon;
 
-    final color = Theme.of(context).colorScheme.tertiary;
+    final color = Theme.of(context).colorScheme.primary;
 
     // Basically this uses the icon as a mask on top of a solid color
     return ColorFiltered(colorFilter: ColorFilter.mode(color, BlendMode.srcIn), child: icon);

--- a/lib/components/finamp_icon.dart
+++ b/lib/components/finamp_icon.dart
@@ -24,6 +24,7 @@ class FinampIcon extends ConsumerWidget {
     final colorScheme = getColorScheme(accent, brightness);
     final color = colorScheme.onSurface;
 
+    // Basically this uses the icon as a mask on top of a solid color
     return ColorFiltered(colorFilter: ColorFilter.mode(color, BlendMode.srcIn), child: icon);
   }
 }

--- a/lib/components/finamp_icon.dart
+++ b/lib/components/finamp_icon.dart
@@ -12,14 +12,11 @@ class FinampIcon extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final accent = ref.watch(finampSettingsProvider.accentColor);
-
     final icon = SvgPicture.asset("images/finamp_cropped.svg", width: width, height: height);
+    final useMonochromeIcon = ref.watch(finampSettingsProvider.useMonochromeIcon);
+    if (!useMonochromeIcon) return icon;
 
-    if (accent == null) {
-      return icon;
-    }
-
+    final accent = ref.watch(finampSettingsProvider.accentColor);
     final brightness = ref.watch(brightnessProvider);
     final colorScheme = getColorScheme(accent, brightness);
     final color = colorScheme.onSurface;

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -724,21 +724,21 @@
   "@accentColorTitle": {
     "description": "Title for the accent color picker sheet"
   },
-  "systemAccentColor": "Use System Theme",
+  "systemAccentColor": "Use System Accent",
   "@systemAccentColor": {
     "description": "Title of the System Accent Color setting."
   },
-  "systemAccentColorHasPriorityInfo": "Custom Accent Color disabled because System Theme is currently in use",
+  "systemAccentColorHasPriorityInfo": "Custom Accent Color disabled because System Accent is currently in use",
   "@systemAccentColorHasPriorityInfo": {
     "description": "Text under the AccentColorTitle which is only visible when the system color is enabled since the system color will be prioritized over custom accent color"
   },
-  "useMonochromeIcon": "Use Monochrome Icon",
+  "useMonochromeIcon": "Use Monochrome Logo",
   "@useMonochromeIcon": {
-    "description": "Toggles the finamp icon between classic and "
+    "description": "Toggles the finamp icon between classic and it being monochromic. THis does not change the outside-app-icon"
   },
-  "useMonochromeIconSubtitle": "This does not change the App-Icon.",
+  "useMonochromeIconSubtitle": "This does not change the Ouside-App-Icon.",
   "@useMonochromeIconSubtitle": {
-    "description": "It may be confusing for the user since in-app icons and app-icon can be used interchangeably. But this in fact does not change the App-Icon"
+    "description": "It may be confusing for the user since in-app icons and app-icon can be used interchangeably. But this in fact does not change the Ouside-App-Icon"
   },
   "defaultWord": "Default",
   "@defaultWord": {},

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -724,9 +724,9 @@
   "@accentColorTitle": {
     "description": "Title for the accent color picker sheet"
   },
-  "systemAccentColor": "Use {type, select, android{Material You Theme} linux{GTK+ Theme} macOS{App Accent Color} windows{Accent Color} other{System Theme}}",
+  "systemAccentColor": "Use System Theme",
   "@systemAccentColor": {
-    "description": "Title of the System Accent Color setting, sadly different OSs call Dynamic themes differently."
+    "description": "Title of the System Accent Color setting."
   },
   "systemAccentColorHasPriorityInfo": "Custom Accent Color disabled because System Theme is currently in use",
   "@systemAccentColorHasPriorityInfo": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -724,6 +724,10 @@
   "@accentColorTitle": {
     "description": "Title for the accent color picker sheet"
   },
+  "systemAccentColor": "Use System Theme",
+  "@systemAccentColor": {
+    "description": "Title of the system accent color setting"
+  },
   "defaultWord": "Default",
   "@defaultWord": {},
   "useDefaultButton": "Reset to Default Accent Color",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -724,9 +724,21 @@
   "@accentColorTitle": {
     "description": "Title for the accent color picker sheet"
   },
-  "systemAccentColor": "Use System Theme",
+  "systemAccentColor": "Use {type, select, android{Material You Theme} linux{GTK+ Theme} macOS{App Accent Color} windows{Accent Color} other{System Theme}}",
   "@systemAccentColor": {
-    "description": "Title of the system accent color setting"
+    "description": "Title of the System Accent Color setting, sadly different OSs call Dynamic themes differently."
+  },
+  "systemAccentColorHasPriorityInfo": "Custom Accent Color disabled because System Theme is currently in use",
+  "@systemAccentColorHasPriorityInfo": {
+    "description": "Text under the AccentColorTitle which is only visible when the system color is enabled since the system color will be prioritized over custom accent color"
+  },
+  "useMonochromeIcon": "Use Monochrome Icon",
+  "@useMonochromeIcon": {
+    "description": "Toggles the finamp icon between classic and "
+  },
+  "useMonochromeIconSubtitle": "This does not change the App-Icon.",
+  "@useMonochromeIconSubtitle": {
+    "description": "It may be confusing for the user since in-app icons and app-icon can be used interchangeably. But this in fact does not change the App-Icon"
   },
   "defaultWord": "Default",
   "@defaultWord": {},

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -734,11 +734,11 @@
   },
   "useMonochromeIcon": "Use Monochrome Logo",
   "@useMonochromeIcon": {
-    "description": "Toggles the finamp icon between classic and it being monochromic. THis does not change the outside-app-icon"
+    "description": "Toggles the Finamp icon between classic and it being monochromic. This does not change the outside-app-icon"
   },
-  "useMonochromeIconSubtitle": "This does not change the Ouside-App-Icon.",
+  "useMonochromeIconSubtitle": "This only affect the icon within the app, not the launcher icon.",
   "@useMonochromeIconSubtitle": {
-    "description": "It may be confusing for the user since in-app icons and app-icon can be used interchangeably. But this in fact does not change the Ouside-App-Icon"
+    "description": "Subtitle for the toggle that switches the Finamp icon between classic and it being monochromic."
   },
   "defaultWord": "Default",
   "@defaultWord": {},
@@ -750,7 +750,7 @@
   },
   "colorCodeHint": "e.g. #FFFFFF or #coffee",
   "@colorCodeHint": {
-    "description": "Hint text for the color code input field"
+    "description": "Hint text for the color code input field. Don't translate 'coffee', unless the translation is also a valid hex color code."
   },
   "save": "Save",
   "@save": {},

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:app_links/app_links.dart';
 import 'package:audio_service/audio_service.dart';
 import 'package:audio_session/audio_session.dart';
 import 'package:background_downloader/background_downloader.dart';
+import 'package:dynamic_color/dynamic_color.dart';
 import 'package:finamp/color_schemes.g.dart';
 import 'package:finamp/components/Buttons/cta_medium.dart';
 import 'package:finamp/gen/assets.gen.dart';
@@ -166,6 +167,7 @@ void main() async {
 
     await findSystemLocale();
     await initializeDateFormatting();
+    unawaited(fetchSystemPalette());
 
     _mainLog.info("Launching main app");
 
@@ -612,7 +614,10 @@ class FinampApp extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final accentColor = ref.watch(finampSettingsProvider.accentColor);
+    final useSystemTheme = ref.watch(finampSettingsProvider.useSystemAccentColor);
+    Color? accentColor = ref.watch(useSystemTheme
+     ? finampSettingsProvider.systemAccentColor
+     : finampSettingsProvider.accentColor);
     final themeMode = ref.watch(finampSettingsProvider.themeMode);
     final locale = ref.watch(finampSettingsProvider.locale);
     final transitionBuilder = MediaQuery.disableAnimationsOf(context)

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -45,6 +45,7 @@ import 'package:finamp/services/offline_listen_helper.dart';
 import 'package:finamp/services/playback_history_service.dart';
 import 'package:finamp/services/playon_service.dart';
 import 'package:finamp/services/queue_service.dart';
+import 'package:finamp/services/theme_provider.dart';
 import 'package:finamp/services/ui_overlay_setter_observer.dart';
 import 'package:finamp/services/widget_bindings_observer_provider.dart';
 import 'package:flutter/foundation.dart';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -38,6 +38,7 @@ import 'package:finamp/services/downloads_service_backend.dart';
 import 'package:finamp/services/finamp_logs_helper.dart';
 import 'package:finamp/services/finamp_settings_helper.dart';
 import 'package:finamp/services/finamp_user_helper.dart';
+import 'package:finamp/services/dbus_manager.dart';
 import 'package:finamp/services/keep_screen_on_helper.dart';
 import 'package:finamp/services/network_manager.dart';
 import 'package:finamp/services/offline_listen_helper.dart';
@@ -102,6 +103,7 @@ final _mainLog = Logger("Main()");
 late DateTime startTime;
 
 final providerScopeKey = GlobalKey();
+
 
 void main() async {
   // If the app has failed, this is set to true. If true, we don't attempt to run the main app since the error app has started.
@@ -168,6 +170,7 @@ void main() async {
     await findSystemLocale();
     await initializeDateFormatting();
     unawaited(fetchSystemPalette());
+    await initDBus();
 
     _mainLog.info("Launching main app");
 
@@ -615,9 +618,9 @@ class FinampApp extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final useSystemTheme = ref.watch(finampSettingsProvider.useSystemAccentColor);
-    Color? accentColor = ref.watch(
-      useSystemTheme ? finampSettingsProvider.systemAccentColor : finampSettingsProvider.accentColor,
-    );
+    Color? accentColor = ref.watch(useSystemTheme
+     ? finampSettingsProvider.systemAccentColor
+     : finampSettingsProvider.accentColor);
     final themeMode = ref.watch(finampSettingsProvider.themeMode);
     final locale = ref.watch(finampSettingsProvider.locale);
     final transitionBuilder = MediaQuery.disableAnimationsOf(context)

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -615,9 +615,9 @@ class FinampApp extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final useSystemTheme = ref.watch(finampSettingsProvider.useSystemAccentColor);
-    Color? accentColor = ref.watch(useSystemTheme
-     ? finampSettingsProvider.systemAccentColor
-     : finampSettingsProvider.accentColor);
+    Color? accentColor = ref.watch(
+      useSystemTheme ? finampSettingsProvider.systemAccentColor : finampSettingsProvider.accentColor,
+    );
     final themeMode = ref.watch(finampSettingsProvider.themeMode);
     final locale = ref.watch(finampSettingsProvider.locale);
     final transitionBuilder = MediaQuery.disableAnimationsOf(context)

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -104,7 +104,6 @@ late DateTime startTime;
 
 final providerScopeKey = GlobalKey();
 
-
 void main() async {
   // If the app has failed, this is set to true. If true, we don't attempt to run the main app since the error app has started.
   bool hasFailed = false;
@@ -618,9 +617,10 @@ class FinampApp extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final useSystemTheme = ref.watch(finampSettingsProvider.useSystemAccentColor);
-    Color? accentColor = ref.watch(useSystemTheme
-     ? finampSettingsProvider.systemAccentColor
-     : finampSettingsProvider.accentColor);
+    // System Accent has priority over custom Accent
+    Color? accentColor = ref.watch(
+      useSystemTheme ? finampSettingsProvider.systemAccentColor : finampSettingsProvider.accentColor,
+    );
     final themeMode = ref.watch(finampSettingsProvider.themeMode);
     final locale = ref.watch(finampSettingsProvider.locale);
     final transitionBuilder = MediaQuery.disableAnimationsOf(context)

--- a/lib/menus/music_screen_drawer.dart
+++ b/lib/menus/music_screen_drawer.dart
@@ -1,3 +1,4 @@
+import 'package:finamp/components/FinampIcon.dart';
 import 'package:finamp/components/MusicScreen/offline_mode_switch_list_tile.dart';
 import 'package:finamp/components/MusicScreen/view_list_tile.dart';
 import 'package:finamp/screens/downloads_screen.dart';
@@ -37,7 +38,7 @@ class MusicScreenDrawer extends StatelessWidget {
                         alignment: Alignment.topCenter,
                         child: Padding(
                           padding: const EdgeInsets.all(16.0),
-                          child: SvgPicture.asset('images/finamp_cropped.svg', width: 56, height: 56),
+                          child: FinampIcon(56, 56),
                         ),
                       ),
                       Align(

--- a/lib/menus/music_screen_drawer.dart
+++ b/lib/menus/music_screen_drawer.dart
@@ -36,10 +36,7 @@ class MusicScreenDrawer extends StatelessWidget {
                     children: [
                       Align(
                         alignment: Alignment.topCenter,
-                        child: Padding(
-                          padding: const EdgeInsets.all(16.0),
-                          child: FinampIcon(56, 56),
-                        ),
+                        child: Padding(padding: const EdgeInsets.all(16.0), child: FinampIcon(56, 56)),
                       ),
                       Align(
                         alignment: Alignment.bottomCenter - const Alignment(0, 0.2),

--- a/lib/menus/music_screen_drawer.dart
+++ b/lib/menus/music_screen_drawer.dart
@@ -1,4 +1,4 @@
-import 'package:finamp/components/FinampIcon.dart';
+import 'package:finamp/components/finamp_icon.dart';
 import 'package:finamp/components/MusicScreen/offline_mode_switch_list_tile.dart';
 import 'package:finamp/components/MusicScreen/view_list_tile.dart';
 import 'package:finamp/screens/downloads_screen.dart';

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -234,6 +234,7 @@ class DefaultSettings {
   static const preferNextUpPrepending = true;
   static const rememberLastUsedPlaybackActionRowPage = true;
   static const lastUsedPlaybackActionRowPage = PlaybackActionRowPage.newQueue;
+  static const useSystemAccentColor = false;
 }
 
 @HiveType(typeId: 28)
@@ -369,6 +370,8 @@ class FinampSettings {
     this.locale = DefaultSettings.locale,
     // !!! Don't touch this default value, it's supposed to be hard coded to run the migration only once
     this.hasCompletedThemeModeLocaleMigration = true,
+    this.systemAccentColor = DefaultSettings.accentColor,
+    this.useSystemAccentColor = DefaultSettings.useSystemAccentColor,
   });
 
   @HiveField(0, defaultValue: DefaultSettings.isOffline)
@@ -792,6 +795,12 @@ class FinampSettings {
   // !!! don't touch this default value, it's supposed to be hard coded to run the migration only once
   @HiveField(135, defaultValue: false)
   bool hasCompletedThemeModeLocaleMigration;
+
+  @HiveField(136, defaultValue: DefaultSettings.accentColor)
+  Color? systemAccentColor = DefaultSettings.accentColor;
+
+  @HiveField(137, defaultValue: DefaultSettings.useSystemAccentColor)
+  bool useSystemAccentColor;
 
   static Future<FinampSettings> create() async {
     final downloadLocation = await DownloadLocation.create(

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -235,7 +235,7 @@ class DefaultSettings {
   static const rememberLastUsedPlaybackActionRowPage = true;
   static const lastUsedPlaybackActionRowPage = PlaybackActionRowPage.newQueue;
   static const useSystemAccentColor = false;
-  static const useMonochromeIcon = true;
+  static const useMonochromeIcon = false;
 }
 
 @HiveType(typeId: 28)

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -235,6 +235,7 @@ class DefaultSettings {
   static const rememberLastUsedPlaybackActionRowPage = true;
   static const lastUsedPlaybackActionRowPage = PlaybackActionRowPage.newQueue;
   static const useSystemAccentColor = false;
+  static const useMonochromeIcon = true;
 }
 
 @HiveType(typeId: 28)
@@ -372,6 +373,7 @@ class FinampSettings {
     this.hasCompletedThemeModeLocaleMigration = true,
     this.systemAccentColor = DefaultSettings.accentColor,
     this.useSystemAccentColor = DefaultSettings.useSystemAccentColor,
+    this.useMonochromeIcon = DefaultSettings.useMonochromeIcon,
   });
 
   @HiveField(0, defaultValue: DefaultSettings.isOffline)
@@ -801,6 +803,9 @@ class FinampSettings {
 
   @HiveField(137, defaultValue: DefaultSettings.useSystemAccentColor)
   bool useSystemAccentColor;
+
+  @HiveField(138, defaultValue: DefaultSettings.useMonochromeIcon)
+  bool useMonochromeIcon = DefaultSettings.useMonochromeIcon;
 
   static Future<FinampSettings> create() async {
     final downloadLocation = await DownloadLocation.create(

--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -434,7 +434,7 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
             ? DefaultSettings.accentColor
             : fields[136] as Color?,
         useSystemAccentColor: fields[137] == null ? false : fields[137] as bool,
-        useMonochromeIcon: fields[138] == null ? true : fields[138] as bool,
+        useMonochromeIcon: fields[138] == null ? false : fields[138] as bool,
       )
       ..disableGesture = fields[19] == null ? false : fields[19] as bool
       ..showFastScroller = fields[25] == null ? true : fields[25] as bool

--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -434,6 +434,7 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
             ? DefaultSettings.accentColor
             : fields[136] as Color?,
         useSystemAccentColor: fields[137] == null ? false : fields[137] as bool,
+        useMonochromeIcon: fields[138] == null ? true : fields[138] as bool,
       )
       ..disableGesture = fields[19] == null ? false : fields[19] as bool
       ..showFastScroller = fields[25] == null ? true : fields[25] as bool
@@ -448,7 +449,7 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
   @override
   void write(BinaryWriter writer, FinampSettings obj) {
     writer
-      ..writeByte(131)
+      ..writeByte(132)
       ..writeByte(0)
       ..write(obj.isOffline)
       ..writeByte(1)
@@ -710,7 +711,9 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       ..writeByte(136)
       ..write(obj.systemAccentColor)
       ..writeByte(137)
-      ..write(obj.useSystemAccentColor);
+      ..write(obj.useSystemAccentColor)
+      ..writeByte(138)
+      ..write(obj.useMonochromeIcon);
   }
 
   @override

--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -430,6 +430,10 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
         hasCompletedThemeModeLocaleMigration: fields[135] == null
             ? false
             : fields[135] as bool,
+        systemAccentColor: fields[136] == null
+            ? DefaultSettings.accentColor
+            : fields[136] as Color?,
+        useSystemAccentColor: fields[137] == null ? false : fields[137] as bool,
       )
       ..disableGesture = fields[19] == null ? false : fields[19] as bool
       ..showFastScroller = fields[25] == null ? true : fields[25] as bool
@@ -444,7 +448,7 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
   @override
   void write(BinaryWriter writer, FinampSettings obj) {
     writer
-      ..writeByte(129)
+      ..writeByte(131)
       ..writeByte(0)
       ..write(obj.isOffline)
       ..writeByte(1)
@@ -702,7 +706,11 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       ..writeByte(134)
       ..write(obj.locale)
       ..writeByte(135)
-      ..write(obj.hasCompletedThemeModeLocaleMigration);
+      ..write(obj.hasCompletedThemeModeLocaleMigration)
+      ..writeByte(136)
+      ..write(obj.systemAccentColor)
+      ..writeByte(137)
+      ..write(obj.useSystemAccentColor);
   }
 
   @override

--- a/lib/screens/layout_settings_screen.dart
+++ b/lib/screens/layout_settings_screen.dart
@@ -1,4 +1,5 @@
 import 'package:finamp/components/LayoutSettingsScreen/automatic_accent_color_selector.dart';
+import 'package:finamp/components/LayoutSettingsScreen/use_monochrome_icon.dart';
 import 'package:finamp/l10n/app_localizations.dart';
 import 'package:finamp/screens/album_settings_screen.dart';
 import 'package:finamp/screens/artist_settings_screen.dart';
@@ -76,6 +77,7 @@ class _LayoutSettingsScreenState extends ConsumerState<LayoutSettingsScreen> {
           ),
           const Divider(),
           const ThemeSelector(),
+          const UseMonochromeIcon(),
           const AccentColorSelector(),
           const AutomaticAccentColorSelector(),
           const Divider(),

--- a/lib/screens/layout_settings_screen.dart
+++ b/lib/screens/layout_settings_screen.dart
@@ -1,3 +1,4 @@
+import 'package:finamp/components/LayoutSettingsScreen/automatic_accent_color_selector.dart';
 import 'package:finamp/l10n/app_localizations.dart';
 import 'package:finamp/screens/album_settings_screen.dart';
 import 'package:finamp/screens/artist_settings_screen.dart';
@@ -76,6 +77,8 @@ class _LayoutSettingsScreenState extends ConsumerState<LayoutSettingsScreen> {
           const Divider(),
           const ThemeSelector(),
           const AccentColorSelector(),
+          const AutomaticAccentColorSelector(),
+          const Divider(),
           const ContentViewTypeDropdownListTile(),
           const FixedSizeGridSwitch(),
           if (!ref.watch(finampSettingsProvider.useFixedSizeGridTiles))

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -66,10 +66,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                   context: context,
                   applicationName: packageInfo.appName,
                   applicationVersion: packageInfo.version,
-                  applicationIcon: Padding(
-                    padding: const EdgeInsets.only(top: 8.0),
-                    child: FinampIcon(56, 56),
-                  ),
+                  applicationIcon: Padding(padding: const EdgeInsets.only(top: 8.0), child: FinampIcon(56, 56)),
                   applicationLegalese: applicationLegalese,
                   children: [
                     const SizedBox(height: 20),

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -4,7 +4,7 @@ import 'package:finamp/menus/server_sharing_menu.dart';
 import 'package:finamp/screens/accessibility_settings_screen.dart';
 import 'package:finamp/screens/interaction_settings_screen.dart';
 import 'package:finamp/screens/network_settings_screen.dart';
-import 'package:finamp/components/FinampIcon.dart';
+import 'package:finamp/components/finamp_icon.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -4,11 +4,11 @@ import 'package:finamp/menus/server_sharing_menu.dart';
 import 'package:finamp/screens/accessibility_settings_screen.dart';
 import 'package:finamp/screens/interaction_settings_screen.dart';
 import 'package:finamp/screens/network_settings_screen.dart';
+import 'package:finamp/components/FinampIcon.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
 import 'package:locale_names/locale_names.dart';
 import 'package:package_info_plus/package_info_plus.dart';
@@ -68,7 +68,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                   applicationVersion: packageInfo.version,
                   applicationIcon: Padding(
                     padding: const EdgeInsets.only(top: 8.0),
-                    child: SvgPicture.asset('images/finamp_cropped.svg', width: 56, height: 56),
+                    child: FinampIcon(56, 56),
                   ),
                   applicationLegalese: applicationLegalese,
                   children: [

--- a/lib/services/dbus_manager.dart
+++ b/lib/services/dbus_manager.dart
@@ -1,8 +1,8 @@
 import 'dart:io';
 import 'package:dbus/dbus.dart';
-import 'package:finamp/color_schemes.g.dart';
 import 'package:finamp/extensions/string.dart';
 import 'package:finamp/services/finamp_settings_helper.dart';
+import 'package:finamp/services/theme_provider.dart';
 import 'package:logging/logging.dart';
 
 final _logger = Logger("dBus");

--- a/lib/services/dbus_manager.dart
+++ b/lib/services/dbus_manager.dart
@@ -7,44 +7,58 @@ import 'package:logging/logging.dart';
 
 final _logger = Logger("dBus");
 
-bool shouldUseDBus() {
+bool _shouldUseDBus() {
   return Platform.isLinux;
 }
 
-class _ChangeAccentColorService extends DBusObject {
-  _ChangeAccentColorService() : super(DBusObjectPath('/com/unicornsonlsd/Finamp'));
+Future<DBusMethodResponse> _updateAccentColor() async {
+  await fetchSystemPalette();
+  return DBusMethodSuccessResponse([DBusBoolean(true)]);
+}
+
+Future<DBusMethodResponse> _setAccentColor(String text) async {
+  _logger.fine("request to set Accent color to $text");
+
+  if (text == "default") {
+    FinampSetters.setAccentColor(null);
+    return DBusMethodSuccessResponse([DBusBoolean(true)]);
+  }
+
+  final color = text.toColorOrNull();
+  if (color == null) return DBusMethodErrorResponse.failed("Invalid color");
+
+  FinampSetters.setAccentColor(color);
+  return DBusMethodSuccessResponse([DBusBoolean(true)]);
+}
+
+class _DBusEndpoints extends DBusObject {
+  _DBusEndpoints() : super(DBusObjectPath('/com/unicornsonlsd/Finamp'));
 
   @override
   Future<DBusMethodResponse> handleMethodCall(DBusMethodCall call) async {
-    if (call.interface == 'com.unicornsonlsd.Finamp' && call.name == 'updateAccentColor') {
-      await fetchSystemPalette();
-      return DBusMethodSuccessResponse([DBusBoolean(true)]);
-    }
-    else if (call.interface == 'com.unicornsonlsd.Finamp' && call.name == 'setAccentColor') {
-      final text = call.values[0].asString();
-      _logger.fine("request to set Accent color to $text");
-      final color = text.toColorOrNull();
+    if (call.interface != 'com.unicornsonlsd.Finamp') return DBusMethodErrorResponse.unknownInterface();
 
-      if (color == null) return DBusMethodErrorResponse.failed("Invalid color");
-
-      FinampSetters.setAccentColor(color);
-      return DBusMethodSuccessResponse([DBusBoolean(true)]);
+    switch (call.name) {
+      case "updateAccentColor":
+        return _updateAccentColor();
+      case "setAccentColor":
+        return _setAccentColor(call.values[0].asString());
     }
+
     _logger.info("Received message but couldn't handle it");
     return super.handleMethodCall(call);
   }
 }
 
-
 Future<void> initDBus() async {
-  if (!shouldUseDBus()) return;
+  if (!_shouldUseDBus()) return;
   _logger.info("Device is allowed to use dBus");
 
   final client = DBusClient.session();
 
   try {
     await client.requestName('com.unicornsonlsd.FinampSettings');
-    await client.registerObject(_ChangeAccentColorService());
+    await client.registerObject(_DBusEndpoints());
   } catch (e) {
     _logger.warning("Failed to register object: $e");
     await client.close();

--- a/lib/services/dbus_manager.dart
+++ b/lib/services/dbus_manager.dart
@@ -1,0 +1,54 @@
+import 'dart:io';
+import 'package:dbus/dbus.dart';
+import 'package:finamp/color_schemes.g.dart';
+import 'package:finamp/extensions/string.dart';
+import 'package:finamp/services/finamp_settings_helper.dart';
+import 'package:logging/logging.dart';
+
+final _logger = Logger("dBus");
+
+bool shouldUseDBus() {
+  return Platform.isLinux;
+}
+
+class _ChangeAccentColorService extends DBusObject {
+  _ChangeAccentColorService() : super(DBusObjectPath('/com/unicornsonlsd/Finamp'));
+
+  @override
+  Future<DBusMethodResponse> handleMethodCall(DBusMethodCall call) async {
+    if (call.interface == 'com.unicornsonlsd.Finamp' && call.name == 'updateAccentColor') {
+      await fetchSystemPalette();
+      return DBusMethodSuccessResponse([DBusBoolean(true)]);
+    }
+    else if (call.interface == 'com.unicornsonlsd.Finamp' && call.name == 'setAccentColor') {
+      final text = call.values[0].asString();
+      _logger.fine("request to set Accent color to $text");
+      final color = text.toColorOrNull();
+
+      if (color == null) return DBusMethodErrorResponse.failed("Invalid color");
+
+      FinampSetters.setAccentColor(color);
+      return DBusMethodSuccessResponse([DBusBoolean(true)]);
+    }
+    _logger.info("Received message but couldn't handle it");
+    return super.handleMethodCall(call);
+  }
+}
+
+
+Future<void> initDBus() async {
+  if (!shouldUseDBus()) return;
+  _logger.info("Device is allowed to use dBus");
+
+  final client = DBusClient.session();
+
+  try {
+    await client.requestName('com.unicornsonlsd.FinampSettings');
+    await client.registerObject(_ChangeAccentColorService());
+  } catch (e) {
+    _logger.warning("Failed to register object: $e");
+    await client.close();
+  }
+
+  _logger.info("init finished");
+}

--- a/lib/services/finamp_settings_helper.dart
+++ b/lib/services/finamp_settings_helper.dart
@@ -123,7 +123,9 @@ class FinampSettingsHelper {
     FinampSettings finampSettingsTemp = finampSettings;
 
     FinampSetters.setThemeMode(DefaultSettings.themeMode);
-    FinampSetters.setAccentColor(null);
+    FinampSetters.setAccentColor(DefaultSettings.accentColor);
+    FinampSetters.setSystemAccentColor(DefaultSettings.accentColor);
+    FinampSetters.setUseSystemAccentColor(DefaultSettings.useSystemAccentColor);
     FinampSetters.setContentViewType(DefaultSettings.contentViewType);
     finampSettingsTemp.useFixedSizeGridTiles = DefaultSettings.useFixedSizeGridTiles;
     FinampSetters.setContentGridViewCrossAxisCountPortrait(DefaultSettings.contentGridViewCrossAxisCountPortrait);

--- a/lib/services/finamp_settings_helper.g.dart
+++ b/lib/services/finamp_settings_helper.g.dart
@@ -1178,6 +1178,22 @@ extension FinampSetters on FinampSettingsHelper {
     ).put("FinampSettings", finampSettingsTemp);
   }
 
+  static void setSystemAccentColor(Color? newSystemAccentColor) {
+    FinampSettings finampSettingsTemp = FinampSettingsHelper.finampSettings;
+    finampSettingsTemp.systemAccentColor = newSystemAccentColor;
+    Hive.box<FinampSettings>(
+      "FinampSettings",
+    ).put("FinampSettings", finampSettingsTemp);
+  }
+
+  static void setUseSystemAccentColor(bool newUseSystemAccentColor) {
+    FinampSettings finampSettingsTemp = FinampSettingsHelper.finampSettings;
+    finampSettingsTemp.useSystemAccentColor = newUseSystemAccentColor;
+    Hive.box<FinampSettings>(
+      "FinampSettings",
+    ).put("FinampSettings", finampSettingsTemp);
+  }
+
   static void setBufferDuration(Duration newBufferDuration) {
     FinampSettings finampSettingsTemp = FinampSettingsHelper.finampSettings;
     finampSettingsTemp.bufferDuration = newBufferDuration;
@@ -1588,6 +1604,10 @@ extension FinampSettingsProviderSelectors on StreamProvider<FinampSettings> {
       finampSettingsProvider.select(
         (value) => value.requireValue.hasCompletedThemeModeLocaleMigration,
       );
+  ProviderListenable<Color?> get systemAccentColor => finampSettingsProvider
+      .select((value) => value.requireValue.systemAccentColor);
+  ProviderListenable<bool> get useSystemAccentColor => finampSettingsProvider
+      .select((value) => value.requireValue.useSystemAccentColor);
   ProviderListenable<DownloadProfile> get downloadTranscodingProfile =>
       finampSettingsProvider.select(
         (value) => value.requireValue.downloadTranscodingProfile,

--- a/lib/services/finamp_settings_helper.g.dart
+++ b/lib/services/finamp_settings_helper.g.dart
@@ -1194,6 +1194,14 @@ extension FinampSetters on FinampSettingsHelper {
     ).put("FinampSettings", finampSettingsTemp);
   }
 
+  static void setUseMonochromeIcon(bool newUseMonochromeIcon) {
+    FinampSettings finampSettingsTemp = FinampSettingsHelper.finampSettings;
+    finampSettingsTemp.useMonochromeIcon = newUseMonochromeIcon;
+    Hive.box<FinampSettings>(
+      "FinampSettings",
+    ).put("FinampSettings", finampSettingsTemp);
+  }
+
   static void setBufferDuration(Duration newBufferDuration) {
     FinampSettings finampSettingsTemp = FinampSettingsHelper.finampSettings;
     finampSettingsTemp.bufferDuration = newBufferDuration;
@@ -1608,6 +1616,8 @@ extension FinampSettingsProviderSelectors on StreamProvider<FinampSettings> {
       .select((value) => value.requireValue.systemAccentColor);
   ProviderListenable<bool> get useSystemAccentColor => finampSettingsProvider
       .select((value) => value.requireValue.useSystemAccentColor);
+  ProviderListenable<bool> get useMonochromeIcon => finampSettingsProvider
+      .select((value) => value.requireValue.useMonochromeIcon);
   ProviderListenable<DownloadProfile> get downloadTranscodingProfile =>
       finampSettingsProvider.select(
         (value) => value.requireValue.downloadTranscodingProfile,

--- a/lib/services/theme_provider.dart
+++ b/lib/services/theme_provider.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
+import 'dart:io';
 
-import 'package:finamp/color_schemes.g.dart';
+import 'package:dynamic_color/dynamic_color.dart';
 import 'package:finamp/extensions/color_extensions.dart';
 import 'package:finamp/services/album_image_provider.dart';
 import 'package:finamp/services/current_album_image_provider.dart';
@@ -495,5 +496,26 @@ class _ThemeTransitionCalculator {
     return (context.mounted && (ModalRoute.isCurrentOf(context) ?? true))
         ? duration ?? const Duration(milliseconds: 1000)
         : Duration.zero;
+  }
+}
+
+Future<void> fetchSystemPalette() async {
+  // dont need to run when setting isnt enabled
+  final settingsHelper = FinampSettingsHelper.finampSettings;
+  if (!settingsHelper.useSystemAccentColor) return;
+
+  final currentColor = settingsHelper.systemAccentColor;
+  Color? newColor;
+
+  if (Platform.isAndroid) {
+    final palette = await DynamicColorPlugin.getCorePalette();
+    newColor = palette?.toColorScheme().primary;
+  } else {
+    newColor = await DynamicColorPlugin.getAccentColor();
+  }
+
+  // only update when needed (color transitions is laggy, no need to run it when not required)
+  if (newColor != currentColor) {
+    FinampSetters.setSystemAccentColor(newColor);
   }
 }

--- a/lib/services/theme_provider.dart
+++ b/lib/services/theme_provider.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:finamp/color_schemes.g.dart';
 import 'package:finamp/extensions/color_extensions.dart';
 import 'package:finamp/services/album_image_provider.dart';
 import 'package:finamp/services/current_album_image_provider.dart';
@@ -469,10 +470,17 @@ class _ThemeTransitionCalculator {
       onShow: () {
         // Continue skipping until we get a foreground track change.
         _skipAllTransitions = true;
+        unawaited(fetchSystemPalette());
       },
       onHide: () {
         _skipAllTransitions = true;
       },
+      onRestart: () {
+        unawaited(fetchSystemPalette());
+      },
+      onResume: () {
+        unawaited(fetchSystemPalette());
+      }
     );
     GetIt.instance<QueueService>().getCurrentTrackStream().listen((value) {
       _skipAllTransitions = false;

--- a/lib/services/theme_provider.dart
+++ b/lib/services/theme_provider.dart
@@ -500,11 +500,7 @@ class _ThemeTransitionCalculator {
 }
 
 Future<void> fetchSystemPalette() async {
-  // dont need to run when setting isnt enabled
-  final settingsHelper = FinampSettingsHelper.finampSettings;
-  if (!settingsHelper.useSystemAccentColor) return;
-
-  final currentColor = settingsHelper.systemAccentColor;
+  final currentColor = FinampSettingsHelper.finampSettings.systemAccentColor;
   Color? newColor;
 
   if (Platform.isAndroid) {

--- a/lib/services/theme_provider.dart
+++ b/lib/services/theme_provider.dart
@@ -470,7 +470,6 @@ class _ThemeTransitionCalculator {
       onShow: () {
         // Continue skipping until we get a foreground track change.
         _skipAllTransitions = true;
-        unawaited(fetchSystemPalette());
       },
       onHide: () {
         _skipAllTransitions = true;

--- a/lib/services/theme_provider.dart
+++ b/lib/services/theme_provider.dart
@@ -480,7 +480,7 @@ class _ThemeTransitionCalculator {
       },
       onResume: () {
         unawaited(fetchSystemPalette());
-      }
+      },
     );
     GetIt.instance<QueueService>().getCurrentTrackStream().listen((value) {
       _skipAllTransitions = false;

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -53,6 +53,7 @@ add_subdirectory(${FLUTTER_MANAGED_DIR})
 # System-level dependencies.
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(GTK REQUIRED IMPORTED_TARGET gtk+-3.0)
+pkg_check_modules(DBUS REQUIRED dbus-1)
 
 add_definitions(-DAPPLICATION_ID="${APPLICATION_ID}")
 
@@ -73,6 +74,7 @@ apply_standard_settings(${BINARY_NAME})
 # Add dependency libraries. Add any application-specific dependencies here.
 target_link_libraries(${BINARY_NAME} PRIVATE flutter)
 target_link_libraries(${BINARY_NAME} PRIVATE PkgConfig::GTK)
+target_link_libraries(${BINARY_NAME} PRIVATE ${DBUS_LIBRARIES})
 
 # Run the Flutter tool portions of the build. This must not be removed.
 add_dependencies(${BINARY_NAME} flutter_assemble)

--- a/linux/finamp_application.cc
+++ b/linux/finamp_application.cc
@@ -1,8 +1,4 @@
 #include "finamp_application.h"
-#include <cstdio>
-#include <dbus/dbus.h>
-
-
 
 #include <flutter_linux/flutter_linux.h>
 #ifdef GDK_WINDOWING_X11
@@ -11,8 +7,6 @@
 
 #include "flutter/generated_plugin_registrant.h"
 
-#include <iostream>
-
 struct _FinampApplication {
   GtkApplication parent_instance;
   char** dart_entrypoint_arguments;
@@ -20,49 +14,8 @@ struct _FinampApplication {
 
 G_DEFINE_TYPE(FinampApplication, finamp_application, GTK_TYPE_APPLICATION);
 
-static void sendDBusColorUpdateMessage() {
-    // setup
-    DBusConnection* conn = NULL;
-    DBusError err; dbus_error_init(&err);
-    DBusMessage* msg = NULL;
-    conn = dbus_bus_get(DBUS_BUS_SESSION, &err);
-
-    // error handling
-    if (dbus_error_is_set(&err)) return;
-    if (conn == nullptr) return;
-
-    msg = dbus_message_new_method_call(
-            "com.unicornsonlsd.FinampSettings", // Destination  (--dest)
-            "/com/unicornsonlsd/Finamp",        // path (--object-path)
-            "com.unicornsonlsd.Finamp",         // Interface (--method)
-            "updateAccentColor"                 // Method
-        );
-
-    // error handling
-    if (msg == nullptr) return dbus_connection_unref(conn);
-
-    const char* message_data = "";
-
-    // error handling
-    if (!dbus_message_append_args(msg, DBUS_TYPE_STRING, &message_data, DBUS_TYPE_INVALID)) {
-        dbus_message_unref(msg);     // Memory cleanup
-        dbus_connection_unref(conn); // Memory cleanup
-        return;
-    }
-
-    // send message
-    dbus_connection_send_with_reply_and_block(conn, msg, DBUS_TIMEOUT_USE_DEFAULT, &err);
-    dbus_connection_flush(conn);
-
-    // Memory cleanup
-    dbus_message_unref(msg);
-    dbus_connection_unref(conn);
-}
-
-
 // Implements GApplication::activate.
 static void finamp_application_activate(GApplication* application) {
-
   FinampApplication* self = FINAMP_APPLICATION(application);
 
   // handle link handling
@@ -70,9 +23,6 @@ static void finamp_application_activate(GApplication* application) {
   if (windows) {
       // If there is already a window, we just present it and do not create a new one
     gtk_window_present(GTK_WINDOW(windows->data));
-    try {
-        sendDBusColorUpdateMessage();
-    } catch (...) {/* Empty */}
     return;
   }
 
@@ -147,8 +97,6 @@ static void finamp_application_dispose(GObject* object) {
 }
 
 static void finamp_application_class_init(FinampApplicationClass* klass) {
-    
-
   G_APPLICATION_CLASS(klass)->activate = finamp_application_activate;
   G_APPLICATION_CLASS(klass)->local_command_line = finamp_application_local_command_line;
   G_OBJECT_CLASS(klass)->dispose = finamp_application_dispose;

--- a/linux/finamp_application.cc
+++ b/linux/finamp_application.cc
@@ -1,4 +1,8 @@
 #include "finamp_application.h"
+#include <cstdio>
+#include <dbus/dbus.h>
+
+
 
 #include <flutter_linux/flutter_linux.h>
 #ifdef GDK_WINDOWING_X11
@@ -7,22 +11,68 @@
 
 #include "flutter/generated_plugin_registrant.h"
 
+#include <iostream>
+
 struct _FinampApplication {
   GtkApplication parent_instance;
   char** dart_entrypoint_arguments;
 };
 
-G_DEFINE_TYPE(FinampApplication, finamp_application, GTK_TYPE_APPLICATION)
+G_DEFINE_TYPE(FinampApplication, finamp_application, GTK_TYPE_APPLICATION);
+
+static void sendDBusColorUpdateMessage() {
+    // setup
+    DBusConnection* conn = NULL;
+    DBusError err; dbus_error_init(&err);
+    DBusMessage* msg = NULL;
+    conn = dbus_bus_get(DBUS_BUS_SESSION, &err);
+
+    // error handling
+    if (dbus_error_is_set(&err)) return;
+    if (conn == nullptr) return;
+
+    msg = dbus_message_new_method_call(
+            "com.unicornsonlsd.FinampSettings", // Destination  (--dest)
+            "/com/unicornsonlsd/Finamp",        // path (--object-path)
+            "com.unicornsonlsd.Finamp",         // Interface (--method)
+            "updateAccentColor"                 // Method
+        );
+
+    // error handling
+    if (msg == nullptr) return dbus_connection_unref(conn);
+
+    const char* message_data = "";
+
+    // error handling
+    if (!dbus_message_append_args(msg, DBUS_TYPE_STRING, &message_data, DBUS_TYPE_INVALID)) {
+        dbus_message_unref(msg);     // Memory cleanup
+        dbus_connection_unref(conn); // Memory cleanup
+        return;
+    }
+
+    // send message
+    dbus_connection_send_with_reply_and_block(conn, msg, DBUS_TIMEOUT_USE_DEFAULT, &err);
+    dbus_connection_flush(conn);
+
+    // Memory cleanup
+    dbus_message_unref(msg);
+    dbus_connection_unref(conn);
+}
+
 
 // Implements GApplication::activate.
 static void finamp_application_activate(GApplication* application) {
+
   FinampApplication* self = FINAMP_APPLICATION(application);
 
   // handle link handling
   GList* windows = gtk_application_get_windows(GTK_APPLICATION(application));
   if (windows) {
+      // If there is already a window, we just present it and do not create a new one
     gtk_window_present(GTK_WINDOW(windows->data));
-    // If there is already a window, we just present it and do not create a new one.
+    try {
+        sendDBusColorUpdateMessage();
+    } catch (...) {/* Empty */}
     return;
   }
 
@@ -97,6 +147,8 @@ static void finamp_application_dispose(GObject* object) {
 }
 
 static void finamp_application_class_init(FinampApplicationClass* klass) {
+    
+
   G_APPLICATION_CLASS(klass)->activate = finamp_application_activate;
   G_APPLICATION_CLASS(klass)->local_command_line = finamp_application_local_command_line;
   G_OBJECT_CLASS(klass)->dispose = finamp_application_dispose;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -435,7 +435,7 @@ packages:
     source: hosted
     version: "1.2.0"
   dbus:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: dbus
       sha256: "79e0c23480ff85dc68de79e2cd6334add97e48f7f4865d17686dd6ea81a47e8c"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -458,6 +458,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.3"
+  dynamic_color:
+    dependency: "direct main"
+    description:
+      name: dynamic_color
+      sha256: "43a5a6679649a7731ab860334a5812f2067c2d9ce6452cf069c5e0c25336c17c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.8.1"
   equatable:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -132,6 +132,7 @@ dependencies:
   flutter_discord_rpc: ^1.0.0
   shared_preferences: ^2.5.3
   flex_color_picker: ^3.7.1
+  dynamic_color: ^1.8.1
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -133,6 +133,7 @@ dependencies:
   shared_preferences: ^2.5.3
   flex_color_picker: ^3.7.1
   dynamic_color: ^1.8.1
+  dbus: ^0.7.11
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Changes
Swapped all In-app Finamp Logos to an dynamically colored Logo tinted with the active accent color.
If no Accent color is set, the normal finamp logo gets used

<img width="367" height="549" alt="image" src="https://github.com/user-attachments/assets/570ee455-aee2-48d4-99ee-6d2421ec6dc3" />

<img width="552" height="529" alt="image" src="https://github.com/user-attachments/assets/f37efde4-3f8b-410e-a364-c6701b50a0e3" />

<img width="360" height="471" alt="image" src="https://github.com/user-attachments/assets/b3c15f31-ea19-4940-9b07-96aef33477c7" />


## Todo before merging

- [x] Get the icon to adapt
- [x] Setting to allow automatic theme changing. This should then disable the custom input
    - [x] Translations
    - [x] Reset Settings
- [x] Extended CONTRIBUTING.md
- [x] (Maybe) Material You integration
- [x] (Very Maybe) Investigate if finamp can change accent color via a command for dynamic color themes on linux

#### Note to my self
Useful article for material color https://fivedottwelve.com/blog/themes-in-flutter-and-how-to-use-material-you-dynamic-colors/
useful post for cmd args https://stackoverflow.com/questions/55004302/how-do-you-pass-arguments-from-command-line-to-main-in-flutter-dart // https://dart.dev/tutorials/server/cmdline // https://stackoverflow.com/questions/77057678/communication-between-two-apps