### PR TITLE
Fix shown index in playlist reordering screen

### DIFF
--- a/lib/components/AlbumScreen/track_list_tile.dart
+++ b/lib/components/AlbumScreen/track_list_tile.dart
@@ -761,7 +761,7 @@ class TrackListItemTile extends ConsumerWidget {
               constraints: const BoxConstraints(minWidth: 22.0),
               child: Text(
                 features.contains(TrackListItemFeatures.listIndex)
-                    ? (listIndex ?? 0 + 1).toString()
+                    ? ((listIndex ?? 0) + 1).toString()
                     : actualIndex.toString(),
                 textAlign: TextAlign.center,
                 maxLines: 1,


### PR DESCRIPTION
When editing a playlist, the shown indices were off by one. I guess regular users expect the list to start at 1. (It was just an operator precedence issue.)