### PR TITLE
Allow moving tracks within queue using track menu

### DIFF
--- a/lib/components/AlbumScreen/track_list_tile.dart
+++ b/lib/components/AlbumScreen/track_list_tile.dart
@@ -401,6 +401,7 @@ DismissDirection getAllowedDismissDirection({required bool swipeLeftEnabled, req
 
 class QueueListTile extends StatelessWidget {
   final BaseItemDto item;
+  final FinampQueueItem queueItem;
   final BaseItemDto? parentItem;
   final int? listIndex;
   final bool isCurrentTrack;
@@ -417,6 +418,7 @@ class QueueListTile extends StatelessWidget {
   const QueueListTile({
     super.key,
     required this.item,
+    required this.queueItem,
     required this.listIndex,
     required this.onTap,
     required this.isCurrentTrack,
@@ -432,6 +434,7 @@ class QueueListTile extends StatelessWidget {
   Widget build(BuildContext context) {
     return TrackListItem(
       baseItem: item,
+      queueItem: queueItem,
       parentItem: parentItem,
       listIndex: listIndex,
       actualIndex: item.indexNumber,
@@ -503,6 +506,7 @@ class EditListTile extends StatelessWidget {
 class TrackListItem extends ConsumerWidget {
   final BaseItemDto baseItem;
   final BaseItemDto? parentItem;
+  final FinampQueueItem? queueItem;
   final int? listIndex;
   final int? actualIndex;
   final bool showArtists;
@@ -529,6 +533,7 @@ class TrackListItem extends ConsumerWidget {
     required this.confirmDismiss,
     required this.features,
     this.parentItem,
+    this.queueItem,
     this.isInPlaylist = false,
     this.allowDismiss = true,
     this.showArtists = true,
@@ -564,6 +569,7 @@ class TrackListItem extends ConsumerWidget {
       padding: const EdgeInsets.only(left: 8.0, right: 8.0, top: 6.0),
       child: TrackListItemTile(
         baseItem: baseItem,
+        queueItem: queueItem,
         listIndex: listIndex,
         actualIndex: actualIndex,
         showArtists: showArtists,
@@ -594,6 +600,7 @@ class TrackListItem extends ConsumerWidget {
               parentItem: parentItem,
               onRemoveFromList: onRemoveFromList,
               confirmPlaylistRemoval: false,
+              queueItem: queueItem,
             );
           }
         }
@@ -686,6 +693,7 @@ class TrackListItemTile extends ConsumerWidget {
     required this.onTap,
     required this.actualIndex,
     required this.features,
+    this.queueItem,
     this.listIndex,
     this.showArtists = true,
     this.forceAlbumArtists = false,
@@ -697,6 +705,7 @@ class TrackListItemTile extends ConsumerWidget {
   });
 
   final BaseItemDto baseItem;
+  final FinampQueueItem? queueItem;
   final bool isCurrentTrack;
   final int? listIndex;
   final int? actualIndex;
@@ -1049,7 +1058,7 @@ class TrackListItemTile extends ConsumerWidget {
                   ),
                 if (showOverflowMenu)
                   OverflowMenuButton(
-                    onPressed: () => showModalTrackMenu(context: context, item: baseItem),
+                    onPressed: () => showModalTrackMenu(context: context, item: baseItem, queueItem: queueItem),
                     color: Theme.of(context).textTheme.bodyMedium?.color ?? Colors.white,
                     label: AppLocalizations.of(context)!.menuButtonLabel,
                   ),

--- a/lib/components/AlbumScreen/track_list_tile.dart
+++ b/lib/components/AlbumScreen/track_list_tile.dart
@@ -365,7 +365,6 @@ Widget buildSwipeActionBackground({
   required ItemSwipeActions action,
   double? iconSize,
 }) {
-
   final icon = getSwipeActionIcon(action);
   final label = action.toLocalisedString(context);
 

--- a/lib/components/PlayerScreen/queue_list.dart
+++ b/lib/components/PlayerScreen/queue_list.dart
@@ -440,6 +440,7 @@ class _PreviousTracksListState extends State<PreviousTracksList> with TickerProv
                   listIndex: index,
                   isInPlaylist: queueItemInPlaylist(item),
                   parentItem: item.source.item,
+                  queueItem: item,
                   allowReorder: _queueService.playbackOrder == FinampPlaybackOrder.linear,
                   onTap: (bool playable) async {
                     FeedbackHelper.feedback(FeedbackType.selection);
@@ -523,6 +524,7 @@ class _NextUpTracksListState extends State<NextUpTracksList> {
                     listIndex: index,
                     isInPlaylist: queueItemInPlaylist(item),
                     parentItem: item.source.item,
+                    queueItem: item,
                     allowReorder: _queueService.playbackOrder == FinampPlaybackOrder.linear,
                     onRemoveFromList: () {
                       unawaited(_queueService.removeAtOffset(indexOffset));
@@ -611,6 +613,7 @@ class _QueueTracksListState extends State<QueueTracksList> {
                   listIndex: index,
                   isInPlaylist: queueItemInPlaylist(item),
                   parentItem: item.source.item,
+                  queueItem: item,
                   allowReorder: _queueService.playbackOrder == FinampPlaybackOrder.linear,
                   onRemoveFromList: () {
                     unawaited(_queueService.removeAtOffset(indexOffset));

--- a/lib/components/themed_bottom_sheet.dart
+++ b/lib/components/themed_bottom_sheet.dart
@@ -87,14 +87,16 @@ class ThemedBottomSheet extends ConsumerStatefulWidget {
     required BuildContext context,
     required List<HideableMenuEntry> menuEntries,
     double? extraHeight,
-    bool includePlaybackrow = true,
+    bool includePlaybackRow = true,
+    bool includePlaybackRowPageIndicator = true,
   }) {
     double stackHeight = infoHeaderFullExtent;
     stackHeight +=
         menuEntries.where((element) => element.isVisible).length *
         (Theme.of(context).visualDensity == VisualDensity.compact ? 48 : 56);
     stackHeight += extraHeight ?? 0.0;
-    stackHeight += includePlaybackrow ? (playActionPageIndicatorHeightDefault + playActionRowHeightDefault) : 0;
+    stackHeight += playActionRowHeightDefault;
+    stackHeight += includePlaybackRowPageIndicator ? playActionPageIndicatorHeightDefault : 0;
     return stackHeight;
   }
 

--- a/lib/components/themed_bottom_sheet.dart
+++ b/lib/components/themed_bottom_sheet.dart
@@ -95,7 +95,7 @@ class ThemedBottomSheet extends ConsumerStatefulWidget {
         menuEntries.where((element) => element.isVisible).length *
         (Theme.of(context).visualDensity == VisualDensity.compact ? 48 : 56);
     stackHeight += extraHeight ?? 0.0;
-    stackHeight += playActionRowHeightDefault;
+    stackHeight += includePlaybackRow ? playActionRowHeightDefault : 0;
     stackHeight += includePlaybackRowPageIndicator ? playActionPageIndicatorHeightDefault : 0;
     return stackHeight;
   }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -438,9 +438,9 @@
   "@playbackActionPageMoveWithinQueue": {
     "description": "Label for the playback action page that contains all actions related to moving tracks within the queue"
   },
-  "playbackActionPageDuplicate": "Duplicate",
-  "@playbackActionPageDuplicate": {
-    "description": "Label for the playback action page that contains all actions related to duplicating tracks within the queue"
+  "playbackActionPageRegularTrackOptions": "Play",
+  "@playbackActionPageRegularTrackOptions": {
+    "description": "Label for the playback action page that contains all actions of the normal track menu, like starting a new queue or duplicating the track within the existing queue"
   },
   "playbackActionPageNewQueue": "New Queue",
   "@playbackActionPageNewQueue": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -434,6 +434,14 @@
       }
     }
   },
+  "playbackActionPageMoveWithinQueue": "Move Within Queue",
+  "@playbackActionPageMoveWithinQueue": {
+    "description": "Label for the playback action page that contains all actions related to moving tracks within the queue"
+  },
+  "playbackActionPageDuplicate": "Duplicate",
+  "@playbackActionPageDuplicate": {
+    "description": "Label for the playback action page that contains all actions related to duplicating tracks within the queue"
+  },
   "playbackActionPageNewQueue": "New Queue",
   "@playbackActionPageNewQueue": {
     "description": "Label for the playback action page that contains all actions related to starting a new queue"
@@ -1069,6 +1077,18 @@
   "shuffleSomeToQueue": "Shuffle some to Queue",
   "@shuffleSomeToQueue": {
     "description": "Used for shuffling some tracks to the end of the regular queue, to play after all prior tracks from the queue have played"
+  },
+  "movePlayNext": "Play next",
+  "@movePlayNext": {
+    "description": "Used for moving a track to the \"Next Up\" queue at the first position, to play right after the current track finishes playing"
+  },
+  "moveAddToNextUp": "Move to Next Up",
+  "@moveAddToNextUp": {
+    "description": "Used for moving a track to the \"Next Up\" queue at the end, to play after all prior tracks from Next Up have played"
+  },
+  "moveAddToQueue": "Move to end",
+  "@moveAddToQueue": {
+    "description": "Used for moving a track to the end of the queue, to play after all prior tracks from the queue have played"
   },
   "confirmPlayNext": "{type, select, track{Track} album{Album} artist{Artist} playlist{Playlist} genre{Genre} other{Item}} will play next",
   "@confirmPlayNext": {

--- a/lib/menus/components/menuEntries/remove_from_current_playlist_menu_entry.dart
+++ b/lib/menus/components/menuEntries/remove_from_current_playlist_menu_entry.dart
@@ -22,7 +22,6 @@ class RemoveFromCurrentPlaylistMenuEntry extends ConsumerWidget implements Hidea
     this.onRemove,
     this.confirmRemoval = false,
   });
-
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Visibility(

--- a/lib/menus/components/playbackActions/playback_action_page_indicator.dart
+++ b/lib/menus/components/playbackActions/playback_action_page_indicator.dart
@@ -1,3 +1,4 @@
+import 'package:finamp/models/finamp_models.dart';
 import 'package:flutter/material.dart';
 
 class PlaybackActionPageIndicator extends StatelessWidget {
@@ -8,7 +9,7 @@ class PlaybackActionPageIndicator extends StatelessWidget {
     this.compactLayout = false,
   });
 
-  final Map<String, Widget> pages;
+  final Map<PlaybackActionRowPage, Widget> pages;
   final PageController pageController;
   final bool compactLayout;
 
@@ -48,7 +49,7 @@ class PlaybackActionPageIndicator extends StatelessWidget {
                       borderRadius: BorderRadius.circular(9999.0),
                     ),
                     child: Text(
-                      pages.keys.elementAt(index),
+                      pages.keys.elementAt(index).toLocalisedString(context),
                       style: (pageController.page ?? pageController.initialPage).round() == index
                           ? textColorSelected
                           : textColor,

--- a/lib/menus/components/playbackActions/playback_action_row.dart
+++ b/lib/menus/components/playbackActions/playback_action_row.dart
@@ -36,20 +36,13 @@ class _PlaybackActionRowState extends ConsumerState<PlaybackActionRow> {
 
   @override
   Widget build(BuildContext context) {
-    final nextUpNotEmpty = ref.watch(QueueService.queueInfoStreamProvider).valueOrNull?.nextUp.isNotEmpty ?? false;
-    final lastUsedPlaybackActionRowPage = ref.watch(finampSettingsProvider.lastUsedPlaybackActionRowPage);
-    final lastUsedPlaybackActionRowPageIndex = lastUsedPlaybackActionRowPage.pageIndexFor(
-      nextUpIsEmpty: !nextUpNotEmpty,
-    );
-    final initialPageViewIndex = ref.watch(finampSettingsProvider.rememberLastUsedPlaybackActionRowPage)
-        ? lastUsedPlaybackActionRowPageIndex
-        : 0;
-    controller = PageController(initialPage: initialPageViewIndex);
+    final nextUpEmpty = ref.watch(QueueService.queueInfoStreamProvider).valueOrNull?.nextUp.isEmpty ?? true;
+    final preferPreprendingToNextUp = ref.watch(finampSettingsProvider.preferNextUpPrepending);
 
-    final Map<String, Widget> playbackActionPages = getPlaybackActionPages(
+    final Map<PlaybackActionRowPage, Widget> playbackActionPages = getPlaybackActionPages(
       context: context,
       item: widget.item,
-      nextUpNotEmpty: nextUpNotEmpty,
+      nextUpNotEmpty: !nextUpEmpty,
       popContext: widget.popContext,
       compactLayout: widget.compactLayout,
       genreFilter: widget.genreFilter,
@@ -57,6 +50,35 @@ class _PlaybackActionRowState extends ConsumerState<PlaybackActionRow> {
       queueItem: widget.queueItem,
     );
 
+    // initial page for regular playback action row
+    var lastUsedPlaybackActionRowPage = ref.watch(finampSettingsProvider.lastUsedPlaybackActionRowPage);
+    lastUsedPlaybackActionRowPage =
+        nextUpEmpty && preferPreprendingToNextUp && lastUsedPlaybackActionRowPage == PlaybackActionRowPage.appendNext
+        ? PlaybackActionRowPage.playNext
+        : lastUsedPlaybackActionRowPage;
+    final lastUsedPlaybackActionRowPageIndex = playbackActionPages.keys.toList().indexOf(lastUsedPlaybackActionRowPage);
+    // initial page for playback action row in queue menu
+    var lastUsedPlaybackActionRowPageForQueueMenu = ref.watch(
+      finampSettingsProvider.lastUsedPlaybackActionRowPageForQueueMenu,
+    );
+    lastUsedPlaybackActionRowPageForQueueMenu =
+        nextUpEmpty &&
+            preferPreprendingToNextUp &&
+            lastUsedPlaybackActionRowPageForQueueMenu == PlaybackActionRowPage.appendNext
+        ? PlaybackActionRowPage.playNext
+        : lastUsedPlaybackActionRowPageForQueueMenu;
+    final lastUsedPlaybackActionRowPageForQueueMenuIndex = playbackActionPages.keys.toList().indexOf(
+      lastUsedPlaybackActionRowPageForQueueMenu,
+    );
+    final initialPageViewIndex = ref.watch(finampSettingsProvider.rememberLastUsedPlaybackActionRowPage)
+        ? lastUsedPlaybackActionRowPageIndex
+        : 0;
+    final initialPageViewQueueIndex = ref.watch(finampSettingsProvider.rememberLastUsedPlaybackActionRowPage)
+        ? lastUsedPlaybackActionRowPageForQueueMenuIndex
+        : 0;
+    controller = PageController(
+      initialPage: widget.queueItem != null ? initialPageViewQueueIndex : initialPageViewIndex,
+    );
     final double playActionRowHeight = widget.compactLayout ? 76.0 : playActionRowHeightDefault;
     final rememberLastUsedPlaybackActionRowPage = ref.read(
       finampSettingsProvider.rememberLastUsedPlaybackActionRowPage,
@@ -77,29 +99,21 @@ class _PlaybackActionRowState extends ConsumerState<PlaybackActionRow> {
             onPageChanged: (index) {
               if (!rememberLastUsedPlaybackActionRowPage) return;
 
-              final nextUpDefault = ref.read(finampSettingsProvider.preferNextUpPrepending)
-                  ? PlaybackActionRowPage.playNext
-                  : PlaybackActionRowPage.appendNext;
-
-              final pageMap = ref.read(QueueService.queueInfoStreamProvider).value?.nextUp.isEmpty ?? true
-                  ? {0: PlaybackActionRowPage.newQueue, 1: nextUpDefault, 2: PlaybackActionRowPage.playLast}
-                  : {
-                      0: PlaybackActionRowPage.newQueue,
-                      1: PlaybackActionRowPage.playNext,
-                      2: PlaybackActionRowPage.appendNext,
-                      3: PlaybackActionRowPage.playLast,
-                    };
-
-              final newPage = pageMap[index] ?? PlaybackActionRowPage.newQueue;
-              FinampSetters.setLastUsedPlaybackActionRowPage(newPage);
+              final newPage = playbackActionPages.keys.toList()[index];
+              if (widget.queueItem != null) {
+                FinampSetters.setLastUsedPlaybackActionRowPageForQueueMenu(newPage);
+              } else {
+                FinampSetters.setLastUsedPlaybackActionRowPage(newPage);
+              }
             },
           ),
         ),
-        PlaybackActionPageIndicator(
-          pages: playbackActionPages,
-          pageController: controller,
-          compactLayout: widget.compactLayout,
-        ),
+        if (playbackActionPages.keys.length > 1)
+          PlaybackActionPageIndicator(
+            pages: playbackActionPages,
+            pageController: controller,
+            compactLayout: widget.compactLayout,
+          ),
       ],
     );
   }

--- a/lib/menus/components/playbackActions/playback_action_row.dart
+++ b/lib/menus/components/playbackActions/playback_action_row.dart
@@ -18,12 +18,14 @@ class PlaybackActionRow extends ConsumerStatefulWidget {
     this.popContext = true,
     this.compactLayout = false,
     this.genreFilter,
+    this.queueItem,
   });
 
   final PlayableItem item;
   final bool popContext;
   final bool compactLayout;
   final BaseItemDto? genreFilter;
+  final FinampQueueItem? queueItem;
 
   @override
   ConsumerState<PlaybackActionRow> createState() => _PlaybackActionRowState();
@@ -51,7 +53,8 @@ class _PlaybackActionRowState extends ConsumerState<PlaybackActionRow> {
       popContext: widget.popContext,
       compactLayout: widget.compactLayout,
       genreFilter: widget.genreFilter,
-      preferNextUp: ref.watch(finampSettingsProvider.preferNextUpPrepending),
+      preferPrependingToNextUp: ref.watch(finampSettingsProvider.preferNextUpPrepending),
+      queueItem: widget.queueItem,
     );
 
     final double playActionRowHeight = widget.compactLayout ? 76.0 : playActionRowHeightDefault;

--- a/lib/menus/components/playbackActions/playback_actions.dart
+++ b/lib/menus/components/playbackActions/playback_actions.dart
@@ -25,78 +25,63 @@ Map<PlaybackActionRowPage, Widget> getPlaybackActionPages({
 }) {
   final BaseItemDtoType? itemType = item is BaseItemDto ? BaseItemDtoType.fromItem(item) : null;
 
-  return {
-    if (itemType == BaseItemDtoType.track && queueItem != null)
-      // Move within queue
-      PlaybackActionRowPage.moveWithinQueue: Row(
+  if (itemType == BaseItemDtoType.track) {
+    return {
+      if (queueItem != null)
+        // Move within queue
+        PlaybackActionRowPage.moveWithinQueue: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            if (nextUpNotEmpty || preferPrependingToNextUp)
+              MovePlayNextPlaybackAction(
+                item: queueItem,
+                popContext: popContext,
+                compactLayout: compactLayout,
+                genreFilter: genreFilter,
+              ),
+            if (nextUpNotEmpty || !preferPrependingToNextUp)
+              MoveAddToNextUpPlaybackAction(
+                item: queueItem,
+                popContext: popContext,
+                compactLayout: compactLayout,
+                genreFilter: genreFilter,
+              ),
+            MoveAddToQueuePlaybackAction(
+              item: queueItem,
+              popContext: popContext,
+              compactLayout: compactLayout,
+              genreFilter: genreFilter,
+            ),
+          ],
+        ),
+      // Regular Options
+      PlaybackActionRowPage.regularTrackOptions: Row(
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
-          if (nextUpNotEmpty || preferPrependingToNextUp)
-            MovePlayNextPlaybackAction(
-              item: queueItem,
-              popContext: popContext,
-              compactLayout: compactLayout,
-              genreFilter: genreFilter,
-            ),
-          if (nextUpNotEmpty || !preferPrependingToNextUp)
-            MoveAddToNextUpPlaybackAction(
-              item: queueItem,
-              popContext: popContext,
-              compactLayout: compactLayout,
-              genreFilter: genreFilter,
-            ),
-          MoveAddToQueuePlaybackAction(
-            item: queueItem,
-            popContext: popContext,
-            compactLayout: compactLayout,
-            genreFilter: genreFilter,
-          ),
+          PlayPlaybackAction(item: item),
+          if (nextUpNotEmpty || preferPrependingToNextUp) PlayNextPlaybackAction(item: item),
+          if (nextUpNotEmpty || !preferPrependingToNextUp) AddToNextUpPlaybackAction(item: item),
+          AddToQueuePlaybackAction(item: item),
         ],
       ),
-    // New Queue
-    PlaybackActionRowPage.newQueue: Row(
-      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-      crossAxisAlignment: CrossAxisAlignment.center,
-      children: [
-        if (itemType != BaseItemDtoType.genre)
-          PlayPlaybackAction(
-            item: item,
-            popContext: popContext,
-            compactLayout: compactLayout,
-            genreFilter: genreFilter,
-          ),
-        ShufflePlaybackAction(
-          item: item,
-          itemType: itemType,
-          popContext: popContext,
-          compactLayout: compactLayout,
-          genreFilter: genreFilter,
-        ),
-        if (itemType == BaseItemDtoType.artist || itemType == BaseItemDtoType.genre)
-          ShuffleAlbumsPlaybackAction(
-            item: item,
-            itemType: itemType,
-            popContext: popContext,
-            compactLayout: compactLayout,
-            genreFilter: genreFilter,
-          ),
-      ],
-    ),
-    // Next
-    if (nextUpNotEmpty || preferPrependingToNextUp)
-      PlaybackActionRowPage.playNext: Row(
+    };
+  } else {
+    return {
+      // New Queue
+      PlaybackActionRowPage.newQueue: Row(
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
           if (itemType != BaseItemDtoType.genre)
-            PlayNextPlaybackAction(
+            PlayPlaybackAction(
               item: item,
               popContext: popContext,
               compactLayout: compactLayout,
               genreFilter: genreFilter,
             ),
-          ShuffleNextPlaybackAction(
+          ShufflePlaybackAction(
             item: item,
             itemType: itemType,
             popContext: popContext,
@@ -104,7 +89,7 @@ Map<PlaybackActionRowPage, Widget> getPlaybackActionPages({
             genreFilter: genreFilter,
           ),
           if (itemType == BaseItemDtoType.artist || itemType == BaseItemDtoType.genre)
-            ShuffleAlbumsNextPlaybackAction(
+            ShuffleAlbumsPlaybackAction(
               item: item,
               itemType: itemType,
               popContext: popContext,
@@ -113,20 +98,79 @@ Map<PlaybackActionRowPage, Widget> getPlaybackActionPages({
             ),
         ],
       ),
-    // Append to Next Up
-    if (nextUpNotEmpty || !preferPrependingToNextUp)
-      PlaybackActionRowPage.appendNext: Row(
+      // Next
+      if (nextUpNotEmpty || preferPrependingToNextUp)
+        PlaybackActionRowPage.playNext: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            if (itemType != BaseItemDtoType.genre)
+              PlayNextPlaybackAction(
+                item: item,
+                popContext: popContext,
+                compactLayout: compactLayout,
+                genreFilter: genreFilter,
+              ),
+            ShuffleNextPlaybackAction(
+              item: item,
+              itemType: itemType,
+              popContext: popContext,
+              compactLayout: compactLayout,
+              genreFilter: genreFilter,
+            ),
+            if (itemType == BaseItemDtoType.artist || itemType == BaseItemDtoType.genre)
+              ShuffleAlbumsNextPlaybackAction(
+                item: item,
+                itemType: itemType,
+                popContext: popContext,
+                compactLayout: compactLayout,
+                genreFilter: genreFilter,
+              ),
+          ],
+        ),
+      // Append to Next Up
+      if (nextUpNotEmpty || !preferPrependingToNextUp)
+        PlaybackActionRowPage.appendNext: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            if (itemType != BaseItemDtoType.genre)
+              AddToNextUpPlaybackAction(
+                item: item,
+                popContext: popContext,
+                compactLayout: compactLayout,
+                genreFilter: genreFilter,
+              ),
+            ShuffleToNextUpPlaybackAction(
+              item: item,
+              itemType: itemType,
+              popContext: popContext,
+              compactLayout: compactLayout,
+              genreFilter: genreFilter,
+            ),
+            if (itemType == BaseItemDtoType.artist || itemType == BaseItemDtoType.genre)
+              ShuffleAlbumsToNextUpPlaybackAction(
+                item: item,
+                itemType: itemType,
+                popContext: popContext,
+                compactLayout: compactLayout,
+                genreFilter: genreFilter,
+              ),
+          ],
+        ),
+      // Append to Queue
+      PlaybackActionRowPage.playLast: Row(
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
           if (itemType != BaseItemDtoType.genre)
-            AddToNextUpPlaybackAction(
+            AddToQueuePlaybackAction(
               item: item,
               popContext: popContext,
               compactLayout: compactLayout,
               genreFilter: genreFilter,
             ),
-          ShuffleToNextUpPlaybackAction(
+          ShuffleToQueuePlaybackAction(
             item: item,
             itemType: itemType,
             popContext: popContext,
@@ -134,7 +178,7 @@ Map<PlaybackActionRowPage, Widget> getPlaybackActionPages({
             genreFilter: genreFilter,
           ),
           if (itemType == BaseItemDtoType.artist || itemType == BaseItemDtoType.genre)
-            ShuffleAlbumsToNextUpPlaybackAction(
+            ShuffleAlbumsToQueuePlaybackAction(
               item: item,
               itemType: itemType,
               popContext: popContext,
@@ -143,36 +187,8 @@ Map<PlaybackActionRowPage, Widget> getPlaybackActionPages({
             ),
         ],
       ),
-    // Append to Queue
-    PlaybackActionRowPage.playLast: Row(
-      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-      crossAxisAlignment: CrossAxisAlignment.center,
-      children: [
-        if (itemType != BaseItemDtoType.genre)
-          AddToQueuePlaybackAction(
-            item: item,
-            popContext: popContext,
-            compactLayout: compactLayout,
-            genreFilter: genreFilter,
-          ),
-        ShuffleToQueuePlaybackAction(
-          item: item,
-          itemType: itemType,
-          popContext: popContext,
-          compactLayout: compactLayout,
-          genreFilter: genreFilter,
-        ),
-        if (itemType == BaseItemDtoType.artist || itemType == BaseItemDtoType.genre)
-          ShuffleAlbumsToQueuePlaybackAction(
-            item: item,
-            itemType: itemType,
-            popContext: popContext,
-            compactLayout: compactLayout,
-            genreFilter: genreFilter,
-          ),
-      ],
-    ),
-  };
+    };
+  }
 }
 
 class PlayPlaybackAction extends ConsumerWidget {

--- a/lib/menus/components/playbackActions/playback_actions.dart
+++ b/lib/menus/components/playbackActions/playback_actions.dart
@@ -13,7 +13,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
 import 'package:get_it/get_it.dart';
 
-Map<String, Widget> getPlaybackActionPages({
+Map<PlaybackActionRowPage, Widget> getPlaybackActionPages({
   required BuildContext context,
   required PlayableItem item,
   required bool nextUpNotEmpty,
@@ -25,178 +25,154 @@ Map<String, Widget> getPlaybackActionPages({
 }) {
   final BaseItemDtoType? itemType = item is BaseItemDto ? BaseItemDtoType.fromItem(item) : null;
 
-  return queueItem != null
-      ? {
-          // Move within queue
-          AppLocalizations.of(context)!.playbackActionPageMoveWithinQueue: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              if (nextUpNotEmpty || preferPrependingToNextUp)
-                MovePlayNextPlaybackAction(
-                  item: queueItem,
-                  popContext: popContext,
-                  compactLayout: compactLayout,
-                  genreFilter: genreFilter,
-                ),
-              if (nextUpNotEmpty || !preferPrependingToNextUp)
-                MoveAddToNextUpPlaybackAction(
-                  item: queueItem,
-                  popContext: popContext,
-                  compactLayout: compactLayout,
-                  genreFilter: genreFilter,
-                ),
-              MoveAddToQueuePlaybackAction(
-                item: queueItem,
-                popContext: popContext,
-                compactLayout: compactLayout,
-                genreFilter: genreFilter,
-              ),
-            ],
-          ),
-          // New Queue
-          AppLocalizations.of(context)!.playbackActionPageNewQueue: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              PlayPlaybackAction(
-                item: item,
-                popContext: popContext,
-                compactLayout: compactLayout,
-                genreFilter: genreFilter,
-              ),
-            ],
-          ),
-          AppLocalizations.of(context)!.playbackActionPageDuplicate: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              if (nextUpNotEmpty || preferPrependingToNextUp) PlayNextPlaybackAction(item: item),
-              if (nextUpNotEmpty || !preferPrependingToNextUp) AddToNextUpPlaybackAction(item: item),
-              AddToQueuePlaybackAction(item: item),
-            ],
-          ),
-        }
-      : {
-          // New Queue
-          AppLocalizations.of(context)!.playbackActionPageNewQueue: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              if (itemType != BaseItemDtoType.genre)
-                PlayPlaybackAction(
-                  item: item,
-                  popContext: popContext,
-                  compactLayout: compactLayout,
-                  genreFilter: genreFilter,
-                ),
-              ShufflePlaybackAction(
-                item: item,
-                itemType: itemType,
-                popContext: popContext,
-                compactLayout: compactLayout,
-                genreFilter: genreFilter,
-              ),
-              if (itemType == BaseItemDtoType.artist || itemType == BaseItemDtoType.genre)
-                ShuffleAlbumsPlaybackAction(
-                  item: item,
-                  itemType: itemType,
-                  popContext: popContext,
-                  compactLayout: compactLayout,
-                  genreFilter: genreFilter,
-                ),
-            ],
-          ),
-          // Next
+  return {
+    if (itemType == BaseItemDtoType.track && queueItem != null)
+      // Move within queue
+      PlaybackActionRowPage.moveWithinQueue: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
           if (nextUpNotEmpty || preferPrependingToNextUp)
-            AppLocalizations.of(context)!.playbackActionPageNext: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                if (itemType != BaseItemDtoType.genre)
-                  PlayNextPlaybackAction(
-                    item: item,
-                    popContext: popContext,
-                    compactLayout: compactLayout,
-                    genreFilter: genreFilter,
-                  ),
-                ShuffleNextPlaybackAction(
-                  item: item,
-                  itemType: itemType,
-                  popContext: popContext,
-                  compactLayout: compactLayout,
-                  genreFilter: genreFilter,
-                ),
-                if (itemType == BaseItemDtoType.artist || itemType == BaseItemDtoType.genre)
-                  ShuffleAlbumsNextPlaybackAction(
-                    item: item,
-                    itemType: itemType,
-                    popContext: popContext,
-                    compactLayout: compactLayout,
-                    genreFilter: genreFilter,
-                  ),
-              ],
+            MovePlayNextPlaybackAction(
+              item: queueItem,
+              popContext: popContext,
+              compactLayout: compactLayout,
+              genreFilter: genreFilter,
             ),
-          // Append to Next Up
           if (nextUpNotEmpty || !preferPrependingToNextUp)
-            AppLocalizations.of(context)!.playbackActionPageNextUp: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                if (itemType != BaseItemDtoType.genre)
-                  AddToNextUpPlaybackAction(
-                    item: item,
-                    popContext: popContext,
-                    compactLayout: compactLayout,
-                    genreFilter: genreFilter,
-                  ),
-                ShuffleToNextUpPlaybackAction(
-                  item: item,
-                  itemType: itemType,
-                  popContext: popContext,
-                  compactLayout: compactLayout,
-                  genreFilter: genreFilter,
-                ),
-                if (itemType == BaseItemDtoType.artist || itemType == BaseItemDtoType.genre)
-                  ShuffleAlbumsToNextUpPlaybackAction(
-                    item: item,
-                    itemType: itemType,
-                    popContext: popContext,
-                    compactLayout: compactLayout,
-                    genreFilter: genreFilter,
-                  ),
-              ],
+            MoveAddToNextUpPlaybackAction(
+              item: queueItem,
+              popContext: popContext,
+              compactLayout: compactLayout,
+              genreFilter: genreFilter,
             ),
-          // Append to Queue
-          AppLocalizations.of(context)!.playbackActionPageAppendToQueue: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              if (itemType != BaseItemDtoType.genre)
-                AddToQueuePlaybackAction(
-                  item: item,
-                  popContext: popContext,
-                  compactLayout: compactLayout,
-                  genreFilter: genreFilter,
-                ),
-              ShuffleToQueuePlaybackAction(
-                item: item,
-                itemType: itemType,
-                popContext: popContext,
-                compactLayout: compactLayout,
-                genreFilter: genreFilter,
-              ),
-              if (itemType == BaseItemDtoType.artist || itemType == BaseItemDtoType.genre)
-                ShuffleAlbumsToQueuePlaybackAction(
-                  item: item,
-                  itemType: itemType,
-                  popContext: popContext,
-                  compactLayout: compactLayout,
-                  genreFilter: genreFilter,
-                ),
-            ],
+          MoveAddToQueuePlaybackAction(
+            item: queueItem,
+            popContext: popContext,
+            compactLayout: compactLayout,
+            genreFilter: genreFilter,
           ),
-        };
+        ],
+      ),
+    // New Queue
+    PlaybackActionRowPage.newQueue: Row(
+      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        if (itemType != BaseItemDtoType.genre)
+          PlayPlaybackAction(
+            item: item,
+            popContext: popContext,
+            compactLayout: compactLayout,
+            genreFilter: genreFilter,
+          ),
+        ShufflePlaybackAction(
+          item: item,
+          itemType: itemType,
+          popContext: popContext,
+          compactLayout: compactLayout,
+          genreFilter: genreFilter,
+        ),
+        if (itemType == BaseItemDtoType.artist || itemType == BaseItemDtoType.genre)
+          ShuffleAlbumsPlaybackAction(
+            item: item,
+            itemType: itemType,
+            popContext: popContext,
+            compactLayout: compactLayout,
+            genreFilter: genreFilter,
+          ),
+      ],
+    ),
+    // Next
+    if (nextUpNotEmpty || preferPrependingToNextUp)
+      PlaybackActionRowPage.playNext: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          if (itemType != BaseItemDtoType.genre)
+            PlayNextPlaybackAction(
+              item: item,
+              popContext: popContext,
+              compactLayout: compactLayout,
+              genreFilter: genreFilter,
+            ),
+          ShuffleNextPlaybackAction(
+            item: item,
+            itemType: itemType,
+            popContext: popContext,
+            compactLayout: compactLayout,
+            genreFilter: genreFilter,
+          ),
+          if (itemType == BaseItemDtoType.artist || itemType == BaseItemDtoType.genre)
+            ShuffleAlbumsNextPlaybackAction(
+              item: item,
+              itemType: itemType,
+              popContext: popContext,
+              compactLayout: compactLayout,
+              genreFilter: genreFilter,
+            ),
+        ],
+      ),
+    // Append to Next Up
+    if (nextUpNotEmpty || !preferPrependingToNextUp)
+      PlaybackActionRowPage.appendNext: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          if (itemType != BaseItemDtoType.genre)
+            AddToNextUpPlaybackAction(
+              item: item,
+              popContext: popContext,
+              compactLayout: compactLayout,
+              genreFilter: genreFilter,
+            ),
+          ShuffleToNextUpPlaybackAction(
+            item: item,
+            itemType: itemType,
+            popContext: popContext,
+            compactLayout: compactLayout,
+            genreFilter: genreFilter,
+          ),
+          if (itemType == BaseItemDtoType.artist || itemType == BaseItemDtoType.genre)
+            ShuffleAlbumsToNextUpPlaybackAction(
+              item: item,
+              itemType: itemType,
+              popContext: popContext,
+              compactLayout: compactLayout,
+              genreFilter: genreFilter,
+            ),
+        ],
+      ),
+    // Append to Queue
+    PlaybackActionRowPage.playLast: Row(
+      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        if (itemType != BaseItemDtoType.genre)
+          AddToQueuePlaybackAction(
+            item: item,
+            popContext: popContext,
+            compactLayout: compactLayout,
+            genreFilter: genreFilter,
+          ),
+        ShuffleToQueuePlaybackAction(
+          item: item,
+          itemType: itemType,
+          popContext: popContext,
+          compactLayout: compactLayout,
+          genreFilter: genreFilter,
+        ),
+        if (itemType == BaseItemDtoType.artist || itemType == BaseItemDtoType.genre)
+          ShuffleAlbumsToQueuePlaybackAction(
+            item: item,
+            itemType: itemType,
+            popContext: popContext,
+            compactLayout: compactLayout,
+            genreFilter: genreFilter,
+          ),
+      ],
+    ),
+  };
 }
 
 class PlayPlaybackAction extends ConsumerWidget {
@@ -307,10 +283,7 @@ class MovePlayNextPlaybackAction extends ConsumerWidget {
           Navigator.pop(context);
         }
 
-        final offset = queueService.getQueue().getOffsetForQueueItem(item);
-        if (offset != null) {
-          unawaited(queueService.removeAtOffset(offset));
-        }
+        unawaited(queueService.removeQueueItem(item));
         await queueService.addNext(items: [item.baseItem!], source: item.source);
 
         GlobalSnackbar.message(
@@ -395,10 +368,7 @@ class MoveAddToNextUpPlaybackAction extends ConsumerWidget {
           Navigator.pop(context);
         }
 
-        final offset = queueService.getQueue().getOffsetForQueueItem(item);
-        if (offset != null) {
-          unawaited(queueService.removeAtOffset(offset));
-        }
+        unawaited(queueService.removeQueueItem(item));
         await queueService.addToNextUp(items: [item.baseItem!], source: item.source);
 
         GlobalSnackbar.message(
@@ -481,10 +451,7 @@ class MoveAddToQueuePlaybackAction extends ConsumerWidget {
           Navigator.pop(context);
         }
 
-        final offset = queueService.getQueue().getOffsetForQueueItem(item);
-        if (offset != null) {
-          unawaited(queueService.removeAtOffset(offset));
-        }
+        unawaited(queueService.removeQueueItem(item));
         await queueService.addToQueue(items: [item.baseItem!], source: item.source);
 
         GlobalSnackbar.message(

--- a/lib/menus/components/playbackActions/playback_actions.dart
+++ b/lib/menus/components/playbackActions/playback_actions.dart
@@ -78,125 +78,125 @@ Map<String, Widget> getPlaybackActionPages({
           ),
         }
       : {
-    // New Queue
-    AppLocalizations.of(context)!.playbackActionPageNewQueue: Row(
-      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-      crossAxisAlignment: CrossAxisAlignment.center,
-      children: [
-        if (itemType != BaseItemDtoType.genre)
-          PlayPlaybackAction(
-            item: item,
-            popContext: popContext,
-            compactLayout: compactLayout,
-            genreFilter: genreFilter,
+          // New Queue
+          AppLocalizations.of(context)!.playbackActionPageNewQueue: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              if (itemType != BaseItemDtoType.genre)
+                PlayPlaybackAction(
+                  item: item,
+                  popContext: popContext,
+                  compactLayout: compactLayout,
+                  genreFilter: genreFilter,
+                ),
+              ShufflePlaybackAction(
+                item: item,
+                itemType: itemType,
+                popContext: popContext,
+                compactLayout: compactLayout,
+                genreFilter: genreFilter,
+              ),
+              if (itemType == BaseItemDtoType.artist || itemType == BaseItemDtoType.genre)
+                ShuffleAlbumsPlaybackAction(
+                  item: item,
+                  itemType: itemType,
+                  popContext: popContext,
+                  compactLayout: compactLayout,
+                  genreFilter: genreFilter,
+                ),
+            ],
           ),
-        ShufflePlaybackAction(
-          item: item,
-          itemType: itemType,
-          popContext: popContext,
-          compactLayout: compactLayout,
-          genreFilter: genreFilter,
-        ),
-        if (itemType == BaseItemDtoType.artist || itemType == BaseItemDtoType.genre)
-          ShuffleAlbumsPlaybackAction(
-            item: item,
-            itemType: itemType,
-            popContext: popContext,
-            compactLayout: compactLayout,
-            genreFilter: genreFilter,
-          ),
-      ],
-    ),
-    // Next
+          // Next
           if (nextUpNotEmpty || preferPrependingToNextUp)
-      AppLocalizations.of(context)!.playbackActionPageNext: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          if (itemType != BaseItemDtoType.genre)
-            PlayNextPlaybackAction(
-              item: item,
-              popContext: popContext,
-              compactLayout: compactLayout,
-              genreFilter: genreFilter,
+            AppLocalizations.of(context)!.playbackActionPageNext: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                if (itemType != BaseItemDtoType.genre)
+                  PlayNextPlaybackAction(
+                    item: item,
+                    popContext: popContext,
+                    compactLayout: compactLayout,
+                    genreFilter: genreFilter,
+                  ),
+                ShuffleNextPlaybackAction(
+                  item: item,
+                  itemType: itemType,
+                  popContext: popContext,
+                  compactLayout: compactLayout,
+                  genreFilter: genreFilter,
+                ),
+                if (itemType == BaseItemDtoType.artist || itemType == BaseItemDtoType.genre)
+                  ShuffleAlbumsNextPlaybackAction(
+                    item: item,
+                    itemType: itemType,
+                    popContext: popContext,
+                    compactLayout: compactLayout,
+                    genreFilter: genreFilter,
+                  ),
+              ],
             ),
-          ShuffleNextPlaybackAction(
-            item: item,
-            itemType: itemType,
-            popContext: popContext,
-            compactLayout: compactLayout,
-            genreFilter: genreFilter,
-          ),
-          if (itemType == BaseItemDtoType.artist || itemType == BaseItemDtoType.genre)
-            ShuffleAlbumsNextPlaybackAction(
-              item: item,
-              itemType: itemType,
-              popContext: popContext,
-              compactLayout: compactLayout,
-              genreFilter: genreFilter,
-            ),
-        ],
-      ),
-    // Append to Next Up
+          // Append to Next Up
           if (nextUpNotEmpty || !preferPrependingToNextUp)
-      AppLocalizations.of(context)!.playbackActionPageNextUp: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          if (itemType != BaseItemDtoType.genre)
-            AddToNextUpPlaybackAction(
-              item: item,
-              popContext: popContext,
-              compactLayout: compactLayout,
-              genreFilter: genreFilter,
+            AppLocalizations.of(context)!.playbackActionPageNextUp: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                if (itemType != BaseItemDtoType.genre)
+                  AddToNextUpPlaybackAction(
+                    item: item,
+                    popContext: popContext,
+                    compactLayout: compactLayout,
+                    genreFilter: genreFilter,
+                  ),
+                ShuffleToNextUpPlaybackAction(
+                  item: item,
+                  itemType: itemType,
+                  popContext: popContext,
+                  compactLayout: compactLayout,
+                  genreFilter: genreFilter,
+                ),
+                if (itemType == BaseItemDtoType.artist || itemType == BaseItemDtoType.genre)
+                  ShuffleAlbumsToNextUpPlaybackAction(
+                    item: item,
+                    itemType: itemType,
+                    popContext: popContext,
+                    compactLayout: compactLayout,
+                    genreFilter: genreFilter,
+                  ),
+              ],
             ),
-          ShuffleToNextUpPlaybackAction(
-            item: item,
-            itemType: itemType,
-            popContext: popContext,
-            compactLayout: compactLayout,
-            genreFilter: genreFilter,
+          // Append to Queue
+          AppLocalizations.of(context)!.playbackActionPageAppendToQueue: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              if (itemType != BaseItemDtoType.genre)
+                AddToQueuePlaybackAction(
+                  item: item,
+                  popContext: popContext,
+                  compactLayout: compactLayout,
+                  genreFilter: genreFilter,
+                ),
+              ShuffleToQueuePlaybackAction(
+                item: item,
+                itemType: itemType,
+                popContext: popContext,
+                compactLayout: compactLayout,
+                genreFilter: genreFilter,
+              ),
+              if (itemType == BaseItemDtoType.artist || itemType == BaseItemDtoType.genre)
+                ShuffleAlbumsToQueuePlaybackAction(
+                  item: item,
+                  itemType: itemType,
+                  popContext: popContext,
+                  compactLayout: compactLayout,
+                  genreFilter: genreFilter,
+                ),
+            ],
           ),
-          if (itemType == BaseItemDtoType.artist || itemType == BaseItemDtoType.genre)
-            ShuffleAlbumsToNextUpPlaybackAction(
-              item: item,
-              itemType: itemType,
-              popContext: popContext,
-              compactLayout: compactLayout,
-              genreFilter: genreFilter,
-            ),
-        ],
-      ),
-    // Append to Queue
-    AppLocalizations.of(context)!.playbackActionPageAppendToQueue: Row(
-      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-      crossAxisAlignment: CrossAxisAlignment.center,
-      children: [
-        if (itemType != BaseItemDtoType.genre)
-          AddToQueuePlaybackAction(
-            item: item,
-            popContext: popContext,
-            compactLayout: compactLayout,
-            genreFilter: genreFilter,
-          ),
-        ShuffleToQueuePlaybackAction(
-          item: item,
-          itemType: itemType,
-          popContext: popContext,
-          compactLayout: compactLayout,
-          genreFilter: genreFilter,
-        ),
-        if (itemType == BaseItemDtoType.artist || itemType == BaseItemDtoType.genre)
-          ShuffleAlbumsToQueuePlaybackAction(
-            item: item,
-            itemType: itemType,
-            popContext: popContext,
-            compactLayout: compactLayout,
-            genreFilter: genreFilter,
-          ),
-      ],
-    ),
-  };
+        };
 }
 
 class PlayPlaybackAction extends ConsumerWidget {
@@ -278,6 +278,7 @@ class PlayNextPlaybackAction extends ConsumerWidget {
     );
   }
 }
+
 class MovePlayNextPlaybackAction extends ConsumerWidget {
   const MovePlayNextPlaybackAction({
     super.key,
@@ -365,6 +366,7 @@ class AddToNextUpPlaybackAction extends ConsumerWidget {
     );
   }
 }
+
 class MoveAddToNextUpPlaybackAction extends ConsumerWidget {
   const MoveAddToNextUpPlaybackAction({
     super.key,
@@ -451,6 +453,7 @@ class AddToQueuePlaybackAction extends ConsumerWidget {
     );
   }
 }
+
 class MoveAddToQueuePlaybackAction extends ConsumerWidget {
   const MoveAddToQueuePlaybackAction({
     super.key,

--- a/lib/menus/track_menu.dart
+++ b/lib/menus/track_menu.dart
@@ -481,18 +481,7 @@ class _TrackMenuState extends ConsumerState<TrackMenu> with TickerProviderStateM
       MenuMask(
         height: MenuItemInfoSliverHeader.defaultHeight,
         child: SliverToBoxAdapter(
-          child: widget.queueItem != null
-              ? PlaybackActionRow(item: widget.item, queueItem: widget.queueItem)
-              : Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  children: [
-                    PlayPlaybackAction(item: widget.item),
-                    if (nextUpNotEmpty || preferPrependingToNextUp) PlayNextPlaybackAction(item: widget.item),
-                    if (nextUpNotEmpty || !preferPrependingToNextUp) AddToNextUpPlaybackAction(item: widget.item),
-                    AddToQueuePlaybackAction(item: widget.item),
-                  ],
-                ),
+          child: PlaybackActionRow(item: widget.item, queueItem: widget.queueItem),
         ),
       ),
       MenuMask(

--- a/lib/menus/track_menu.dart
+++ b/lib/menus/track_menu.dart
@@ -484,15 +484,15 @@ class _TrackMenuState extends ConsumerState<TrackMenu> with TickerProviderStateM
           child: widget.queueItem != null
               ? PlaybackActionRow(item: widget.item, queueItem: widget.queueItem)
               : Row(
-            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              PlayPlaybackAction(item: widget.item),
+                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    PlayPlaybackAction(item: widget.item),
                     if (nextUpNotEmpty || preferPrependingToNextUp) PlayNextPlaybackAction(item: widget.item),
                     if (nextUpNotEmpty || !preferPrependingToNextUp) AddToNextUpPlaybackAction(item: widget.item),
-              AddToQueuePlaybackAction(item: widget.item),
-            ],
-          ),
+                    AddToQueuePlaybackAction(item: widget.item),
+                  ],
+                ),
         ),
       ),
       MenuMask(

--- a/lib/menus/track_menu.dart
+++ b/lib/menus/track_menu.dart
@@ -216,9 +216,9 @@ class _TrackMenuState extends ConsumerState<TrackMenu> with TickerProviderStateM
     final stackHeight = ThemedBottomSheet.calculateStackHeight(
       context: context,
       menuEntries: menuEntries,
-      // Include 60 height of shorter track playback row
-      extraHeight: widget.showPlaybackControls ? 160 : 60,
-      includePlaybackrow: false,
+      extraHeight: widget.showPlaybackControls ? 100 : 00,
+      includePlaybackRow: true,
+      includePlaybackRowPageIndicator: widget.queueItem != null,
     );
 
     return Consumer(
@@ -270,9 +270,6 @@ class _TrackMenuState extends ConsumerState<TrackMenu> with TickerProviderStateM
         menuHeight = closedHeight;
     }
 
-    final nextUpNotEmpty = ref.watch(QueueService.queueInfoStreamProvider).valueOrNull?.nextUp.isNotEmpty ?? false;
-    final preferPrependingToNextUp = ref.watch(finampSettingsProvider.preferNextUpPrepending);
-
     return [
       if (widget.showPlaybackControls) ...[
         StreamBuilder<PlaybackBehaviorInfo>(
@@ -311,7 +308,7 @@ class _TrackMenuState extends ConsumerState<TrackMenu> with TickerProviderStateM
               PlaybackAction(
                 icon: playbackOrderIcons[playbackBehavior.order]!,
                 onPressed: () async {
-                  _queueService.togglePlaybackOrder();
+                  await _queueService.togglePlaybackOrder();
                 },
                 label: playbackOrderTooltips[playbackBehavior.order]!,
                 iconColor: playbackBehavior.order == FinampPlaybackOrder.shuffled

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -2169,6 +2169,23 @@ class FinampQueueInfo {
     return null;
   }
 
+  FinampQueueItem? getQueueItemByOffset(int offset) {
+    final index = currentTrackIndex + offset;
+    if (index < 0 || index >= fullQueue.length) {
+      return null;
+    }
+    return fullQueue[index];
+  }
+
+  int? getOffsetForQueueItem(FinampQueueItem item) {
+    final absoluteIndex = fullQueue.indexWhere((q) => q.id == item.id);
+    if (absoluteIndex == -1) {
+      return null;
+    }
+    final relativeOffset = absoluteIndex - currentTrackIndex;
+    return relativeOffset > 0 ? relativeOffset + 1 : relativeOffset + 1;
+  }
+
   Duration get totalDuration {
     var total = 0;
     for (var item in fullQueue) {

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -3584,7 +3584,9 @@ enum PlaybackActionRowPage {
   @HiveField(3)
   playLast,
   @HiveField(4)
-  moveWithinQueue;
+  moveWithinQueue,
+  @HiveField(5)
+  regularTrackOptions;
 
   /// Human-readable version of this enum.
   @override
@@ -3605,6 +3607,8 @@ enum PlaybackActionRowPage {
         return "Play Last";
       case PlaybackActionRowPage.moveWithinQueue:
         return "Move Within Queue";
+      case PlaybackActionRowPage.regularTrackOptions:
+        return "Play";
     }
   }
 
@@ -3620,6 +3624,8 @@ enum PlaybackActionRowPage {
         return AppLocalizations.of(context)!.playbackActionPageAppendToQueue;
       case PlaybackActionRowPage.moveWithinQueue:
         return AppLocalizations.of(context)!.playbackActionPageMoveWithinQueue;
+      case PlaybackActionRowPage.regularTrackOptions:
+        return AppLocalizations.of(context)!.playbackActionPageRegularTrackOptions;
     }
   }
 }

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -234,6 +234,7 @@ class DefaultSettings {
   static const preferNextUpPrepending = true;
   static const rememberLastUsedPlaybackActionRowPage = true;
   static const lastUsedPlaybackActionRowPage = PlaybackActionRowPage.newQueue;
+  static const lastUsedPlaybackActionRowPageForQueueMenu = PlaybackActionRowPage.moveWithinQueue;
   static const useSystemAccentColor = false;
   static const useMonochromeIcon = false;
 }
@@ -366,6 +367,7 @@ class FinampSettings {
     this.preferNextUpPrepending = DefaultSettings.preferNextUpPrepending,
     this.rememberLastUsedPlaybackActionRowPage = DefaultSettings.rememberLastUsedPlaybackActionRowPage,
     this.lastUsedPlaybackActionRowPage = DefaultSettings.lastUsedPlaybackActionRowPage,
+    this.lastUsedPlaybackActionRowPageForQueueMenu = DefaultSettings.lastUsedPlaybackActionRowPageForQueueMenu,
     this.accentColor = DefaultSettings.accentColor,
     this.themeMode = DefaultSettings.themeMode,
     this.locale = DefaultSettings.locale,
@@ -806,6 +808,10 @@ class FinampSettings {
 
   @HiveField(138, defaultValue: DefaultSettings.useMonochromeIcon)
   bool useMonochromeIcon = DefaultSettings.useMonochromeIcon;
+
+  @HiveField(139, defaultValue: DefaultSettings.lastUsedPlaybackActionRowPageForQueueMenu)
+  PlaybackActionRowPage lastUsedPlaybackActionRowPageForQueueMenu =
+      DefaultSettings.lastUsedPlaybackActionRowPageForQueueMenu;
 
   static Future<FinampSettings> create() async {
     final downloadLocation = await DownloadLocation.create(
@@ -3576,7 +3582,9 @@ enum PlaybackActionRowPage {
   @HiveField(2)
   appendNext,
   @HiveField(3)
-  playLast;
+  playLast,
+  @HiveField(4)
+  moveWithinQueue;
 
   /// Human-readable version of this enum.
   @override
@@ -3595,6 +3603,8 @@ enum PlaybackActionRowPage {
         return "Append Next";
       case PlaybackActionRowPage.playLast:
         return "Play Last";
+      case PlaybackActionRowPage.moveWithinQueue:
+        return "Move Within Queue";
     }
   }
 
@@ -3608,22 +3618,8 @@ enum PlaybackActionRowPage {
         return AppLocalizations.of(context)!.playbackActionPageNextUp;
       case PlaybackActionRowPage.playLast:
         return AppLocalizations.of(context)!.playbackActionPageAppendToQueue;
-    }
-  }
-
-  int pageIndexFor({required bool nextUpIsEmpty}) {
-    if (!nextUpIsEmpty) {
-      return index;
-    }
-
-    switch (this) {
-      case PlaybackActionRowPage.newQueue:
-        return 0;
-      case PlaybackActionRowPage.playNext:
-      case PlaybackActionRowPage.appendNext:
-        return 1;
-      case PlaybackActionRowPage.playLast:
-        return 2;
+      case PlaybackActionRowPage.moveWithinQueue:
+        return AppLocalizations.of(context)!.playbackActionPageMoveWithinQueue;
     }
   }
 }

--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -2979,6 +2979,8 @@ class PlaybackActionRowPageAdapter extends TypeAdapter<PlaybackActionRowPage> {
         return PlaybackActionRowPage.playLast;
       case 4:
         return PlaybackActionRowPage.moveWithinQueue;
+      case 5:
+        return PlaybackActionRowPage.regularTrackOptions;
       default:
         return PlaybackActionRowPage.newQueue;
     }
@@ -2997,6 +2999,8 @@ class PlaybackActionRowPageAdapter extends TypeAdapter<PlaybackActionRowPage> {
         writer.writeByte(3);
       case PlaybackActionRowPage.moveWithinQueue:
         writer.writeByte(4);
+      case PlaybackActionRowPage.regularTrackOptions:
+        writer.writeByte(5);
     }
   }
 

--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -418,6 +418,9 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
         lastUsedPlaybackActionRowPage: fields[131] == null
             ? PlaybackActionRowPage.newQueue
             : fields[131] as PlaybackActionRowPage,
+        lastUsedPlaybackActionRowPageForQueueMenu: fields[139] == null
+            ? PlaybackActionRowPage.moveWithinQueue
+            : fields[139] as PlaybackActionRowPage,
         accentColor: fields[132] == null
             ? DefaultSettings.accentColor
             : fields[132] as Color?,
@@ -449,7 +452,7 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
   @override
   void write(BinaryWriter writer, FinampSettings obj) {
     writer
-      ..writeByte(132)
+      ..writeByte(133)
       ..writeByte(0)
       ..write(obj.isOffline)
       ..writeByte(1)
@@ -713,7 +716,9 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       ..writeByte(137)
       ..write(obj.useSystemAccentColor)
       ..writeByte(138)
-      ..write(obj.useMonochromeIcon);
+      ..write(obj.useMonochromeIcon)
+      ..writeByte(139)
+      ..write(obj.lastUsedPlaybackActionRowPageForQueueMenu);
   }
 
   @override
@@ -2972,6 +2977,8 @@ class PlaybackActionRowPageAdapter extends TypeAdapter<PlaybackActionRowPage> {
         return PlaybackActionRowPage.appendNext;
       case 3:
         return PlaybackActionRowPage.playLast;
+      case 4:
+        return PlaybackActionRowPage.moveWithinQueue;
       default:
         return PlaybackActionRowPage.newQueue;
     }
@@ -2988,6 +2995,8 @@ class PlaybackActionRowPageAdapter extends TypeAdapter<PlaybackActionRowPage> {
         writer.writeByte(2);
       case PlaybackActionRowPage.playLast:
         writer.writeByte(3);
+      case PlaybackActionRowPage.moveWithinQueue:
+        writer.writeByte(4);
     }
   }
 

--- a/lib/services/finamp_settings_helper.g.dart
+++ b/lib/services/finamp_settings_helper.g.dart
@@ -1202,6 +1202,17 @@ extension FinampSetters on FinampSettingsHelper {
     ).put("FinampSettings", finampSettingsTemp);
   }
 
+  static void setLastUsedPlaybackActionRowPageForQueueMenu(
+    PlaybackActionRowPage newLastUsedPlaybackActionRowPageForQueueMenu,
+  ) {
+    FinampSettings finampSettingsTemp = FinampSettingsHelper.finampSettings;
+    finampSettingsTemp.lastUsedPlaybackActionRowPageForQueueMenu =
+        newLastUsedPlaybackActionRowPageForQueueMenu;
+    Hive.box<FinampSettings>(
+      "FinampSettings",
+    ).put("FinampSettings", finampSettingsTemp);
+  }
+
   static void setBufferDuration(Duration newBufferDuration) {
     FinampSettings finampSettingsTemp = FinampSettingsHelper.finampSettings;
     finampSettingsTemp.bufferDuration = newBufferDuration;
@@ -1618,6 +1629,11 @@ extension FinampSettingsProviderSelectors on StreamProvider<FinampSettings> {
       .select((value) => value.requireValue.useSystemAccentColor);
   ProviderListenable<bool> get useMonochromeIcon => finampSettingsProvider
       .select((value) => value.requireValue.useMonochromeIcon);
+  ProviderListenable<PlaybackActionRowPage>
+  get lastUsedPlaybackActionRowPageForQueueMenu =>
+      finampSettingsProvider.select(
+        (value) => value.requireValue.lastUsedPlaybackActionRowPageForQueueMenu,
+      );
   ProviderListenable<DownloadProfile> get downloadTranscodingProfile =>
       finampSettingsProvider.select(
         (value) => value.requireValue.downloadTranscodingProfile,

--- a/lib/services/queue_service.dart
+++ b/lib/services/queue_service.dart
@@ -106,7 +106,7 @@ class QueueService {
 
       final previousIndex = _queueAudioSourceIndex;
       _queueAudioSourceIndex = event.queueIndex ?? 0;
-      
+
       // Ignore playback events if queue is empty.
       if (previousIndex != _queueAudioSourceIndex && _currentTrack != null) {
         _queueServiceLogger.finer("Play queue index changed, new index: $_queueAudioSourceIndex");

--- a/lib/services/queue_service.dart
+++ b/lib/services/queue_service.dart
@@ -888,6 +888,14 @@ class QueueService {
     _queueFromConcatenatingAudioSource();
   }
 
+  Future<void> removeQueueItem(FinampQueueItem queueItem) async {
+    int? offset = getQueue().getOffsetForQueueItem(queueItem);
+    if (offset == null) {
+      return;
+    }
+    return removeAtOffset(offset);
+  }
+
   Future<void> reorderByOffset(int oldOffset, int newOffset) async {
     _queueServiceLogger.fine("Reordering queue item at offset $oldOffset to offset $newOffset");
 


### PR DESCRIPTION
Implements #1434

<!-- Just a reminder that text in these brackets is not visible in the rendered output.
You also do **not** need to use this template. You can remove and modify anything however you like!
Its just a suggestion :)
-->

## Changes
<!-- Please describe what this Pull request adds or changes. Possibly with images -->
- Added `PlaybackActionRow` if needed
- Implemented move logic via removing and re-adding
  - Simply reordering doesn't work since we can't change a `FinampQueueItem`'s `QueueItemQueueType` after it was added to the queue

## Todo before merging
<!-- Add custom todos if deemed necessary to give others an overview on how far this PR is progressing -->

<!-- Did you add UI text? 
No? Just check or remove the box
Yes? Make sure you replace hardcoded strings with translations -->
- [x] Translations

## Related Issues
<!-- List relevant issues to this PR using a format like this
- closes #xyz 
- fixes #abc
- follow up to #pr-name
-->
- closes #1434
