### PR TITLE
Migrate to just_audio 0.10

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -88,8 +88,6 @@ post_install do |installer|
 
         ## dart: PermissionGroup.appTrackingTransparency
         'PERMISSION_APP_TRACKING_TRANSPARENCY=0',
-
-        'AUDIO_SESSION_MICROPHONE=0'
       ]
 
     end

--- a/lib/components/PlayerScreen/player_buttons_repeating.dart
+++ b/lib/components/PlayerScreen/player_buttons_repeating.dart
@@ -1,12 +1,11 @@
+import 'package:finamp/l10n/app_localizations.dart';
 import 'package:finamp/models/finamp_models.dart';
 import 'package:finamp/services/feedback_helper.dart';
-import 'package:finamp/services/media_state_stream.dart';
 import 'package:finamp/services/music_player_background_task.dart';
 import 'package:finamp/services/queue_service.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
 import 'package:get_it/get_it.dart';
-import 'package:finamp/l10n/app_localizations.dart';
 
 class PlayerButtonsRepeating extends StatelessWidget {
   final audioHandler = GetIt.instance<MusicPlayerBackgroundTask>();
@@ -17,8 +16,9 @@ class PlayerButtonsRepeating extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return StreamBuilder(
-      stream: mediaStateStream,
-      builder: (BuildContext context, AsyncSnapshot<dynamic> snapshot) {
+      stream: queueService.getLoopModeStream(),
+      initialData: queueService.loopMode,
+      builder: (BuildContext context, snapshot) {
         return IconButton(
           tooltip:
               "${getLocalizedLoopMode(context, queueService.loopMode)}. ${AppLocalizations.of(context)!.genericToggleButtonTooltip}",
@@ -26,7 +26,7 @@ class PlayerButtonsRepeating extends StatelessWidget {
             FeedbackHelper.feedback(FeedbackType.light);
             queueService.toggleLoopMode();
           },
-          icon: _getRepeatingIcon(queueService.loopMode, Theme.of(context).colorScheme.secondary),
+          icon: _getRepeatingIcon(snapshot.data!, Theme.of(context).colorScheme.secondary),
         );
       },
     );

--- a/lib/components/PlayerScreen/player_buttons_shuffle.dart
+++ b/lib/components/PlayerScreen/player_buttons_shuffle.dart
@@ -1,12 +1,11 @@
+import 'package:finamp/l10n/app_localizations.dart';
 import 'package:finamp/models/finamp_models.dart';
-import 'package:finamp/services/media_state_stream.dart';
+import 'package:finamp/services/feedback_helper.dart';
 import 'package:finamp/services/music_player_background_task.dart';
 import 'package:finamp/services/queue_service.dart';
-import 'package:finamp/services/feedback_helper.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
 import 'package:get_it/get_it.dart';
-import 'package:finamp/l10n/app_localizations.dart';
 
 class PlayerButtonsShuffle extends StatelessWidget {
   final audioHandler = GetIt.instance<MusicPlayerBackgroundTask>();
@@ -17,18 +16,17 @@ class PlayerButtonsShuffle extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return StreamBuilder(
-      stream: mediaStateStream,
-      builder: (BuildContext context, AsyncSnapshot<dynamic> snapshot) {
+      stream: _queueService.getPlaybackOrderStream(),
+      initialData: _queueService.playbackOrder,
+      builder: (BuildContext context, snapshot) {
         return IconButton(
           tooltip: getLocalizedPlaybackOrder(context, _queueService.playbackOrder),
           onPressed: () async {
             FeedbackHelper.feedback(FeedbackType.light);
-            _queueService.togglePlaybackOrder();
+            await _queueService.togglePlaybackOrder();
           },
           icon: Icon(
-            (_queueService.playbackOrder == FinampPlaybackOrder.shuffled
-                ? TablerIcons.arrows_shuffle
-                : TablerIcons.arrows_right),
+            (snapshot.data! == FinampPlaybackOrder.shuffled ? TablerIcons.arrows_shuffle : TablerIcons.arrows_right),
           ),
         );
       },

--- a/lib/components/PlayerScreen/queue_list.dart
+++ b/lib/components/PlayerScreen/queue_list.dart
@@ -89,6 +89,7 @@ class _QueueListState extends State<QueueList> {
   late List<Widget> _contents;
 
   // Used to jump when changing playback order
+  final nextUpHeaderKey = GlobalKey();
   final queueHeaderKey = GlobalKey();
 
   @override
@@ -174,6 +175,7 @@ class _QueueListState extends State<QueueList> {
       ),
       const CurrentTrack(),
       // next up
+      SliverToBoxAdapter(key: nextUpHeaderKey),
       StreamBuilder(
         stream: _queueService.getQueueStream(),
         initialData: _queueService.getQueue(),
@@ -210,6 +212,7 @@ class _QueueListState extends State<QueueList> {
             ],
           ),
           controls: true,
+          nextUpHeaderKey: nextUpHeaderKey,
           queueHeaderKey: queueHeaderKey,
           scrollController: widget.scrollController,
         ),
@@ -939,6 +942,7 @@ class QueueSectionHeader extends StatelessWidget {
   final Widget title;
   final QueueItemSource? source;
   final bool controls;
+  final GlobalKey nextUpHeaderKey;
   final GlobalKey queueHeaderKey;
   final ScrollController scrollController;
 
@@ -946,6 +950,7 @@ class QueueSectionHeader extends StatelessWidget {
     super.key,
     required this.title,
     required this.source,
+    required this.nextUpHeaderKey,
     required this.queueHeaderKey,
     required this.scrollController,
     this.controls = false,
@@ -1034,7 +1039,11 @@ class QueueSectionHeader extends StatelessWidget {
                       onPressed: () async {
                         await queueService.togglePlaybackOrder();
                         FeedbackHelper.feedback(FeedbackType.selection);
+                        if (queueService.getQueue().nextUp.isNotEmpty) {
+                          scrollToKey(key: nextUpHeaderKey);
+                        } else {
                         scrollToKey(key: queueHeaderKey);
+                        }
                       },
                     ),
                     IconButton(

--- a/lib/components/PlayerScreen/queue_list.dart
+++ b/lib/components/PlayerScreen/queue_list.dart
@@ -530,7 +530,7 @@ class _NextUpTracksListState extends State<NextUpTracksList> {
                     listIndex: index,
                     isInPlaylist: queueItemInPlaylist(item),
                     parentItem: item.source.item,
-                    allowReorder: _queueService.playbackOrder == FinampPlaybackOrder.linear,
+                    allowReorder: true,
                     onRemoveFromList: () {
                       unawaited(_queueService.removeAtOffset(indexOffset));
                     },
@@ -703,12 +703,7 @@ class _CurrentTrackState extends ConsumerState<CurrentTrack> {
               child: Container(
                 clipBehavior: Clip.antiAlias,
                 decoration: ShapeDecoration(
-                  color: Color.alphaBlend(
-                    Theme.brightnessOf(context) == Brightness.dark
-                        ? IconTheme.of(context).color!.withOpacity(0.35)
-                        : IconTheme.of(context).color!.withOpacity(0.65),
-                    Theme.brightnessOf(context) == Brightness.dark ? Colors.black : Colors.white,
-                  ),
+                  color: ColorScheme.of(context).primary.withOpacity(0.7),
                   shape: const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(12.0))),
                 ),
                 child: Row(
@@ -762,7 +757,7 @@ class _CurrentTrackState extends ConsumerState<CurrentTrack> {
                                         : playbackPosition!.inMilliseconds / itemLength.inMilliseconds,
                                     child: DecoratedBox(
                                       decoration: ShapeDecoration(
-                                        color: IconTheme.of(context).color!.withOpacity(0.75),
+                                        color: ColorScheme.of(context).primary,
                                         shape: const RoundedRectangleBorder(
                                           borderRadius: BorderRadius.only(
                                             topRight: Radius.circular(12),
@@ -799,7 +794,7 @@ class _CurrentTrackState extends ConsumerState<CurrentTrack> {
                                           style: TextStyle(
                                             fontSize: 16,
                                             height: 26 / 20,
-                                            color: Colors.white,
+                                            color: ColorScheme.of(context).onPrimary,
                                             fontWeight: Theme.brightnessOf(context) == Brightness.light
                                                 ? FontWeight.w500
                                                 : FontWeight.w600,
@@ -814,9 +809,9 @@ class _CurrentTrackState extends ConsumerState<CurrentTrack> {
                                             child: Text(
                                               processArtist(currentTrack!.item.artist, context),
                                               style: TextStyle(
-                                                color: (Colors.white).withOpacity(0.85),
+                                                color: ColorScheme.of(context).onPrimary,
                                                 fontSize: 13,
-                                                fontWeight: FontWeight.w300,
+                                                fontWeight: FontWeight.w400,
                                                 overflow: TextOverflow.ellipsis,
                                               ),
                                             ),
@@ -828,7 +823,7 @@ class _CurrentTrackState extends ConsumerState<CurrentTrack> {
                                                 initialData: _audioHandler.playbackState.value.position,
                                                 builder: (context, snapshot) {
                                                   final TextStyle style = TextStyle(
-                                                    color: (Colors.white).withOpacity(0.8),
+                                                    color: ColorScheme.of(context).onPrimary,
                                                     fontSize: 14,
                                                     fontWeight: FontWeight.w400,
                                                   );
@@ -850,7 +845,7 @@ class _CurrentTrackState extends ConsumerState<CurrentTrack> {
                                               Text(
                                                 '/',
                                                 style: TextStyle(
-                                                  color: (Colors.white).withOpacity(0.8),
+                                                  color: ColorScheme.of(context).onPrimary,
                                                   fontSize: 14,
                                                   fontWeight: FontWeight.w400,
                                                 ),
@@ -862,7 +857,7 @@ class _CurrentTrackState extends ConsumerState<CurrentTrack> {
                                                     ? "${mediaState?.mediaItem?.duration?.inHours.toString()}:${((mediaState?.mediaItem?.duration?.inMinutes ?? 0) % 60).toString().padLeft(2, '0')}:${((mediaState?.mediaItem?.duration?.inSeconds ?? 0) % 60).toString().padLeft(2, '0')}"
                                                     : "${mediaState?.mediaItem?.duration?.inMinutes.toString()}:${((mediaState?.mediaItem?.duration?.inSeconds ?? 0) % 60).toString().padLeft(2, '0')}",
                                                 style: TextStyle(
-                                                  color: (Colors.white).withOpacity(0.8),
+                                                  color: ColorScheme.of(context).onPrimary,
                                                   fontSize: 14,
                                                   fontWeight: FontWeight.w400,
                                                 ),
@@ -883,7 +878,7 @@ class _CurrentTrackState extends ConsumerState<CurrentTrack> {
                                     child: AddToPlaylistButton(
                                       item: currentTrackBaseItem,
                                       queueItem: currentTrack,
-                                      color: Colors.white,
+                                      color: ColorScheme.of(context).onPrimary,
                                       size: 28,
                                       visualDensity: const VisualDensity(horizontal: -4),
                                     ),
@@ -892,10 +887,10 @@ class _CurrentTrackState extends ConsumerState<CurrentTrack> {
                                     iconSize: 28,
                                     visualDensity: const VisualDensity(horizontal: -4),
                                     // visualDensity: VisualDensity.compact,
-                                    icon: const Icon(
+                                    icon: Icon(
                                       TablerIcons.dots_vertical,
                                       size: 28,
-                                      color: Colors.white,
+                                      color: ColorScheme.of(context).onPrimary,
                                       weight: 1.5,
                                     ),
                                     onPressed: () {
@@ -1042,7 +1037,7 @@ class QueueSectionHeader extends StatelessWidget {
                         if (queueService.getQueue().nextUp.isNotEmpty) {
                           scrollToKey(key: nextUpHeaderKey);
                         } else {
-                        scrollToKey(key: queueHeaderKey);
+                          scrollToKey(key: queueHeaderKey);
                         }
                       },
                     ),

--- a/lib/components/PlayerScreen/queue_list.dart
+++ b/lib/components/PlayerScreen/queue_list.dart
@@ -446,6 +446,10 @@ class _PreviousTracksListState extends State<PreviousTracksList> with TickerProv
                     await _queueService.skipByOffset(indexOffset);
                     scrollToKey(key: widget.previousTracksHeaderKey, duration: const Duration(milliseconds: 500));
                   },
+                  allowDismiss: true,
+                  onRemoveFromList: () {
+                    unawaited(_queueService.removeAtOffset(indexOffset));
+                  },
                   isCurrentTrack: false,
                 );
               },

--- a/lib/menus/components/menuEntries/remove_from_current_playlist_menu_entry.dart
+++ b/lib/menus/components/menuEntries/remove_from_current_playlist_menu_entry.dart
@@ -33,7 +33,8 @@ class RemoveFromCurrentPlaylistMenuEntry extends ConsumerWidget implements Hidea
       child: MenuEntry(
         icon: TablerIcons.playlist_x,
         title: AppLocalizations.of(context)!.removeFromPlaylistTitle,
-        enabled: parentItem != null && ref.watch(canEditPlaylistProvider(parentItem!)),
+        enabled:
+            parentItem != null && parentItem!.type == "Playlist" && ref.watch(canEditPlaylistProvider(parentItem!)),
         onTap: () async {
           Navigator.pop(context); // close menu
           var removed = await removeFromPlaylist(

--- a/lib/menus/components/playbackActions/playback_actions.dart
+++ b/lib/menus/components/playbackActions/playback_actions.dart
@@ -1,11 +1,8 @@
-import 'dart:io';
-
 import 'package:finamp/components/global_snackbar.dart';
 import 'package:finamp/l10n/app_localizations.dart';
 import 'package:finamp/menus/components/playbackActions/playback_action.dart';
 import 'package:finamp/models/finamp_models.dart';
 import 'package:finamp/models/jellyfin_models.dart';
-import 'package:finamp/services/finamp_settings_helper.dart';
 import 'package:finamp/services/item_helper.dart';
 import 'package:finamp/services/queue_service.dart';
 import 'package:flutter/material.dart';
@@ -202,7 +199,6 @@ class PlayNextPlaybackAction extends ConsumerWidget {
     final queueService = GetIt.instance<QueueService>();
 
     return PlaybackAction(
-      enabled: !(Platform.isWindows || Platform.isLinux),
       icon: TablerIcons.corner_right_down,
       label: AppLocalizations.of(context)!.playNext,
       compactLayout: compactLayout,
@@ -245,7 +241,6 @@ class AddToNextUpPlaybackAction extends ConsumerWidget {
     final queueService = GetIt.instance<QueueService>();
 
     return PlaybackAction(
-      enabled: !(Platform.isWindows || Platform.isLinux),
       icon: TablerIcons.corner_right_down_double,
       label: AppLocalizations.of(context)!.addToNextUp,
       compactLayout: compactLayout,
@@ -374,7 +369,6 @@ class ShuffleNextPlaybackAction extends ConsumerWidget {
     final queueService = GetIt.instance<QueueService>();
 
     return PlaybackAction(
-      enabled: !(Platform.isWindows || Platform.isLinux),
       icon: TablerIcons.corner_right_down,
       addShuffleIcon: true,
       label: (itemType == BaseItemDtoType.genre)
@@ -420,7 +414,6 @@ class ShuffleToNextUpPlaybackAction extends ConsumerWidget {
     final queueService = GetIt.instance<QueueService>();
 
     return PlaybackAction(
-      enabled: !(Platform.isWindows || Platform.isLinux),
       icon: TablerIcons.corner_right_down_double,
       addShuffleIcon: true,
       label: (itemType == BaseItemDtoType.genre)
@@ -566,7 +559,6 @@ class ShuffleAlbumsNextPlaybackAction extends ConsumerWidget {
     final queueService = GetIt.instance<QueueService>();
 
     return PlaybackAction(
-      enabled: !(Platform.isWindows || Platform.isLinux),
       icon: TablerIcons.corner_right_down,
       addShuffleIcon: true,
       label: (itemType == BaseItemDtoType.genre)
@@ -619,7 +611,6 @@ class ShuffleAlbumsToNextUpPlaybackAction extends ConsumerWidget {
     final queueService = GetIt.instance<QueueService>();
 
     return PlaybackAction(
-      enabled: !(Platform.isWindows || Platform.isLinux),
       icon: TablerIcons.corner_right_down_double,
       addShuffleIcon: true,
       label: (itemType == BaseItemDtoType.genre)

--- a/lib/services/music_player_background_task.dart
+++ b/lib/services/music_player_background_task.dart
@@ -10,6 +10,7 @@ import 'package:finamp/models/finamp_models.dart';
 import 'package:finamp/models/jellyfin_models.dart' as jellyfin_models;
 import 'package:finamp/services/current_track_metadata_provider.dart';
 import 'package:finamp/services/favorite_provider.dart';
+import 'package:finamp/services/finamp_user_helper.dart';
 import 'package:finamp/services/jellyfin_api_helper.dart';
 import 'package:finamp/services/queue_service.dart';
 import 'package:flutter/foundation.dart';
@@ -108,7 +109,7 @@ class PlayerVolumeController {
 
 /// This provider handles the currently playing music so that multiple widgets
 /// can control music.
-class MusicPlayerBackgroundTask extends BaseAudioHandler {
+class MusicPlayerBackgroundTask extends BaseAudioHandler with SeekHandler, QueueHandler {
   final _androidAutoHelper = GetIt.instance<AndroidAutoHelper>();
 
   AppLocalizations? _appLocalizations;
@@ -119,14 +120,9 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
   late final List<DarwinAudioEffect> _iosAudioEffects;
   late final AndroidLoudnessEnhancer? _loudnessEnhancerEffect;
 
-  ConcatenatingAudioSource _queueAudioSource = ConcatenatingAudioSource(children: []);
   final _audioServiceBackgroundTaskLogger = Logger("MusicPlayerBackgroundTask");
   final _volumeNormalizationLogger = Logger("VolumeNormalization");
   final _outputLogger = Logger("Output");
-
-  /// Set when creating a new queue. Will be used to set the first index in a
-  /// new queue.
-  int? nextInitialIndex;
 
   // Init the new sleep timer with a length of 0
   // SleepTimer sleepTimer = SleepTimer(SleepTimerType.duration, 0);
@@ -414,15 +410,19 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
     _queueCallbackPreviousTrack = previousTrackCallback;
   }
 
-  Future<Duration?> setAudioSources(
-    List<AudioSource> audioSources, {
+  Future<Duration?> setQueueItems(
+    List<FinampQueueItem> queueItems, {
     bool preload = true,
     int? initialIndex,
     Duration? initialPosition,
     ShuffleOrder? shuffleOrder,
   }) async {
-    _setNextInitialIndex(initialIndex ?? 0);
     try {
+      List<AudioSource> audioSources = [];
+
+      for (final queueItem in queueItems) {
+        audioSources.add(await _queueItemToAudioSource(queueItem));
+      }
       return await _player.setAudioSources(
         audioSources,
         preload: preload,
@@ -443,15 +443,35 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
     return null;
   }
 
-  Future<void> moveAudioSource(int currentIndex, int newIndex) {
+  Future<void> appendFinampQueueItem(FinampQueueItem queueItem) async {
+    return _player.addAudioSource(await _queueItemToAudioSource(queueItem));
+  }
+
+  Future<void> appendFinampQueueItems(List<FinampQueueItem> queueItems) async {
+    return _player.addAudioSources(await Future.wait(queueItems.map(_queueItemToAudioSource)));
+  }
+
+  Future<void> insertFinampQueueItemAt(int index, FinampQueueItem queueItem) async {
+    return _player.insertAudioSource(index, await _queueItemToAudioSource(queueItem));
+  }
+
+  Future<void> insertFinampQueueItems(int index, List<FinampQueueItem> queueItems) async {
+    return _player.insertAudioSources(index, await Future.wait(queueItems.map(_queueItemToAudioSource)));
+  }
+
+  Future<void> moveFinampQueueItem(int currentIndex, int newIndex) {
     return _player.moveAudioSource(currentIndex, newIndex);
   }
 
-  Future<void> removeAudioSourceRange(int start, int end) {
+  Future<void> removeFinampQueueItemAt(int index) {
+    return _player.removeAudioSourceAt(index);
+  }
+
+  Future<void> removeFinampQueueItemRange(int start, int end) {
     return _player.removeAudioSourceRange(start, end);
   }
 
-  Future<void> clearAudioSources() {
+  Future<void> clearFinampQueueItems() {
     return _player.clearAudioSources();
   }
 
@@ -624,7 +644,7 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
       // item, so only pause.
       await pause(disableFade: true);
       // Skipping to zero with empty queue re-triggers queue complete event
-      if (_player.effectiveIndices?.isNotEmpty ?? false) {
+      if (_player.effectiveIndices.isNotEmpty) {
         await skipToIndex(0);
       }
     } catch (e) {
@@ -690,27 +710,27 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
 
     try {
       int queueIndex = _player.shuffleModeEnabled
-          ? _queueAudioSource.shuffleIndices.indexOf((_player.currentIndex ?? 0)) + offset
+          ? shuffleIndices.indexOf((_player.currentIndex ?? 0)) + offset
           : (_player.currentIndex ?? 0) + offset;
-      if (queueIndex >= (_player.effectiveIndices?.length ?? 1)) {
+      if (queueIndex >= _player.effectiveIndices.length) {
         if (_player.loopMode == LoopMode.off) {
           //!!! seek to end of track to for the player to handle the end of queue
           // this is hacky, but seems to be the only way to get the proper events that the playback history service needs
           //TODO Finamp should probably use its own event system that is able to convey the necessary information
           return await _player.seek(_player.duration);
         }
-        queueIndex %= (_player.effectiveIndices?.length ?? 1);
+        queueIndex %= (_player.effectiveIndices.length);
       }
       if (queueIndex < 0) {
         if (_player.loopMode == LoopMode.off) {
           queueIndex = 0;
         } else {
-          queueIndex %= (_player.effectiveIndices?.length ?? 1);
+          queueIndex %= (_player.effectiveIndices.length);
         }
       }
       await _player.seek(
         Duration.zero,
-        index: _player.shuffleModeEnabled ? _queueAudioSource.shuffleIndices[queueIndex] : queueIndex,
+        index: _player.shuffleModeEnabled ? shuffleIndices[queueIndex] : queueIndex,
       );
     } catch (e) {
       _audioServiceBackgroundTaskLogger.severe(e);
@@ -724,7 +744,7 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
     try {
       await _player.seek(
         Duration.zero,
-        index: _player.shuffleModeEnabled ? _queueAudioSource.shuffleIndices[index] : index,
+        index: _player.shuffleModeEnabled ? shuffleIndices[index] : index,
       );
     } catch (e) {
       _audioServiceBackgroundTaskLogger.severe(e);
@@ -930,50 +950,13 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
   @override
   Future<dynamic> customAction(String name, [Map<String, dynamic>? extras]) async {
     try {
-      final ref = GetIt.instance<ProviderContainer>();
       final action = CustomPlaybackActions.values.firstWhere((element) => element.name == name);
       switch (action) {
         case CustomPlaybackActions.shuffle:
           final queueService = GetIt.instance<QueueService>();
           return queueService.togglePlaybackOrder();
         case CustomPlaybackActions.toggleFavorite:
-          jellyfin_models.BaseItemDto? currentItem;
-
-          if (mediaItem.valueOrNull?.extras?["itemJson"] != null) {
-            currentItem = jellyfin_models.BaseItemDto.fromJson(
-              mediaItem.valueOrNull?.extras!["itemJson"] as Map<String, dynamic>,
-            );
-          } else {
-            return;
-          }
-
-          bool isFavorite = currentItem.userData?.isFavorite ?? false;
-          if (GlobalSnackbar.materialAppScaffoldKey.currentContext != null) {
-            // get current favorite status from the provider
-            isFavorite = ref.read(isFavoriteProvider(currentItem));
-            // update favorite status with the value returned by the provider
-            isFavorite = ref.read(isFavoriteProvider(currentItem).notifier).updateFavorite(!isFavorite);
-          } else {
-            // fallback if we can't find the context
-            final jellyfinApiHelper = GetIt.instance<JellyfinApiHelper>();
-            if (isFavorite) {
-              await jellyfinApiHelper.removeFavorite(currentItem.id);
-            } else {
-              await jellyfinApiHelper.addFavorite(currentItem.id);
-            }
-            isFavorite = !isFavorite;
-            final newUserData = currentItem.userData;
-            if (newUserData != null) {
-              newUserData.isFavorite = isFavorite;
-            }
-            currentItem.userData = newUserData;
-            mediaItem.add(
-              mediaItem.valueOrNull?.copyWith(
-                extras: {...mediaItem.valueOrNull?.extras ?? {}, "itemJson": currentItem.toJson()},
-              ),
-            );
-          }
-          return refreshPlaybackStateAndMediaNotification();
+          return toggleFavoriteStatusOfCurrentTrack();
       }
     } catch (e) {
       _audioServiceBackgroundTaskLogger.severe("Custom action '$name' not found.", e);
@@ -981,6 +964,47 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
 
     // only called if no custom action was found
     return await super.customAction(name, extras);
+  }
+
+  Future<void> toggleFavoriteStatusOfCurrentTrack() async {
+    final ref = GetIt.instance<ProviderContainer>();
+    jellyfin_models.BaseItemDto? currentItem;
+
+    if (mediaItem.valueOrNull?.extras?["itemJson"] != null) {
+      currentItem = jellyfin_models.BaseItemDto.fromJson(
+        mediaItem.valueOrNull?.extras!["itemJson"] as Map<String, dynamic>,
+      );
+    } else {
+      return;
+    }
+
+    bool isFavorite = currentItem.userData?.isFavorite ?? false;
+    if (GlobalSnackbar.materialAppScaffoldKey.currentContext != null) {
+      // get current favorite status from the provider
+      isFavorite = ref.read(isFavoriteProvider(currentItem));
+      // update favorite status with the value returned by the provider
+      isFavorite = ref.read(isFavoriteProvider(currentItem).notifier).updateFavorite(!isFavorite);
+    } else {
+      // fallback if we can't find the context
+      final jellyfinApiHelper = GetIt.instance<JellyfinApiHelper>();
+      if (isFavorite) {
+        await jellyfinApiHelper.removeFavorite(currentItem.id);
+      } else {
+        await jellyfinApiHelper.addFavorite(currentItem.id);
+      }
+      isFavorite = !isFavorite;
+      final newUserData = currentItem.userData;
+      if (newUserData != null) {
+        newUserData.isFavorite = isFavorite;
+      }
+      currentItem.userData = newUserData;
+      mediaItem.add(
+        mediaItem.valueOrNull?.copyWith(
+          extras: {...mediaItem.valueOrNull?.extras ?? {}, "itemJson": currentItem.toJson()},
+        ),
+      );
+    }
+    return refreshPlaybackStateAndMediaNotification();
   }
 
   Future<void> refreshPlaybackStateAndMediaNotification() async {
@@ -993,10 +1017,6 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
   @override
   Future<void> skipToQueueItem(int index) async {
     return skipToIndex(index);
-  }
-
-  void _setNextInitialIndex(int index) {
-    nextInitialIndex = index;
   }
 
   void _applyVolumeNormalization(MediaItem? currentTrack) {
@@ -1134,15 +1154,15 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
       updatePosition: _player.position,
       bufferedPosition: _player.bufferedPosition,
       speed: _player.speed,
-      queueIndex: _player.shuffleModeEnabled && (shuffleIndices?.isNotEmpty ?? false) && event.currentIndex != null
-          ? shuffleIndices!.indexOf(event.currentIndex!)
+      queueIndex: _player.shuffleModeEnabled && shuffleIndices.isNotEmpty && event.currentIndex != null
+          ? shuffleIndices.indexOf(event.currentIndex!)
           : event.currentIndex,
       shuffleMode: _player.shuffleModeEnabled ? AudioServiceShuffleMode.all : AudioServiceShuffleMode.none,
       repeatMode: _audioServiceRepeatMode(_player.loopMode),
     );
   }
 
-  List<IndexedAudioSource>? get effectiveSequence => _player.sequenceState?.effectiveSequence;
+  List<IndexedAudioSource> get effectiveSequence => _player.sequenceState.effectiveSequence;
   double get volume => _player.volume;
   bool get paused => !_player.playing;
   Duration get playbackPosition => _player.position;
@@ -1160,6 +1180,207 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
       }
     });
   }
+
+  /// Syncs the list of MediaItems (_queue) with the internal queue of the player.
+  /// Called by onAddQueueItem and onUpdateQueue.
+  Future<AudioSource> _queueItemToAudioSource(FinampQueueItem queueItem) async {
+    if (queueItem.item.extras!["downloadedTrackPath"] == null) {
+      // If downloadedTrack wasn't passed, we assume that the item is not
+      // downloaded.
+
+      // If offline, we throw an error so that we don't accidentally stream from
+      // the internet. See the big comment in _trackUri() to see why this was
+      // passed in extras.
+      if (queueItem.item.extras!["isOffline"] as bool) {
+        return Future.error("Offline mode enabled but downloaded track not found.");
+      } else {
+        final trackUri = await _trackUri(queueItem.item);
+        return AudioSource.uri(trackUri, tag: queueItem);
+        // if (queueItem.item.extras!["shouldTranscode"] == true) {
+        //   return HlsAudioSource(trackUri, tag: queueItem);
+        // } else {
+        //   return AudioSource.uri(trackUri, tag: queueItem);
+        // }
+      }
+    } else {
+      // We have to deserialise this because Dart is stupid and can't handle
+      // sending classes through isolates.
+      final downloadedTrackPath = queueItem.item.extras!["downloadedTrackPath"] as String;
+
+      // Path verification and stuff is done in AudioServiceHelper, so this path
+      // should be valid.
+      final downloadUri = Uri.file(downloadedTrackPath);
+      return AudioSource.uri(downloadUri, tag: queueItem);
+    }
+  }
+
+  Future<Uri> _trackUri(MediaItem mediaItem) async {
+    final finampUserHelper = GetIt.instance<FinampUserHelper>();
+    // When creating the MediaItem (usually in AudioServiceHelper), we specify
+    // whether or not to transcode. We used to pull from FinampSettings here,
+    // but since audio_service runs in an isolate (or at least, it does until
+    // 0.18), the value would be wrong if changed while a track was playing since
+    // Hive is bad at multi-isolate stuff.
+
+    final parsedBaseUrl = Uri.parse(finampUserHelper.currentUser!.baseURL);
+
+    List<String> builtPath = List.from(parsedBaseUrl.pathSegments);
+
+    Map<String, String> queryParameters = Map.from(parsedBaseUrl.queryParameters);
+
+    // We include the user token as a query parameter because just_audio used to
+    // have issues with headers in HLS, and this solution still works fine
+    queryParameters["ApiKey"] = finampUserHelper.currentUser!.accessToken;
+    // // indicate which play session this stream belongs to, this will be referenced when reporting playback progress
+    // queryParameters["PlaySessionId"] = _order.id; //!!! this currently breaks transcoding for some reason
+
+    if (mediaItem.extras!["shouldTranscode"] as bool) {
+      builtPath.addAll(["Audio", mediaItem.extras!["itemJson"]["Id"] as String, "main.m3u8"]);
+
+      queryParameters.addAll({
+        "audioCodec": FinampSettingsHelper.finampSettings.transcodingStreamingFormat.codec,
+        // Ideally we'd switch between 44.1/48kHz depending on the source is,
+        // realistically it doesn't matter too much
+        // default to 44100, only use 48000 for opus because opus doesn't support 44100
+        "playSessionId": mediaItem.extras!["playSessionId"] as String? ?? "",
+        "audioSampleRate": FinampSettingsHelper.finampSettings.transcodingStreamingFormat.codec == 'opus'
+            ? '48000'
+            : '44100',
+        "maxAudioBitDepth": "16",
+        "audioBitRate": FinampSettingsHelper.finampSettings.transcodeBitrate.toString(),
+        "segmentContainer": FinampSettingsHelper.finampSettings.transcodingStreamingFormat.container,
+      });
+    } else {
+      builtPath.addAll(["Items", mediaItem.extras!["itemJson"]["Id"] as String, "File"]);
+    }
+
+    return Uri(
+      host: parsedBaseUrl.host,
+      port: parsedBaseUrl.port,
+      scheme: parsedBaseUrl.scheme,
+      userInfo: parsedBaseUrl.userInfo,
+      pathSegments: builtPath,
+      queryParameters: queryParameters,
+    );
+  }
+
+  @override
+  @Deprecated("Don't use this method, we're using methods based on FinampQueueItem")
+  Future<void> addQueueItem(MediaItem mediaItem) async {}
+  @override
+  @Deprecated("Don't use this method, we're using methods based on FinampQueueItem")
+  Future<void> addQueueItems(List<MediaItem> mediaItems) async {}
+  @override
+  @Deprecated("Don't use this method, we're using methods based on FinampQueueItem")
+  Future<void> insertQueueItem(int index, MediaItem mediaItem) async {}
+  @override
+  @Deprecated("Don't use this method, we're using methods based on FinampQueueItem")
+  Future<void> updateQueue(List<MediaItem> queue) async {}
+  @override
+  @Deprecated("Don't use this method, we're using methods based on FinampQueueItem")
+  Future<void> updateMediaItem(MediaItem mediaItem) async {}
+  @override
+  @Deprecated(
+    "Don't use this method, we're using methods based on FinampQueueItem. This implementation is just for best-effort platform compatibility.",
+  )
+  Future<void> removeQueueItem(MediaItem mediaItem) async {
+    final index = queue.valueOrNull?.indexOf(mediaItem);
+    if (index != null) {
+      return removeFinampQueueItemAt(index);
+    }
+  }
+
+  @override
+  @Deprecated(
+    "Don't use this method, we're using methods based on FinampQueueItem. This implementation is just for best-effort platform compatibility.",
+  )
+  Future<void> removeQueueItemAt(int index) async {
+    return removeFinampQueueItemAt(index);
+  }
+
+  @override
+  @Deprecated(
+    "Don't use this method, we're using methods based on FinampQueueItem. This implementation is just for best-effort platform compatibility.",
+  )
+  Future<void> setRating(Rating rating, [Map<String, dynamic>? extras]) async {
+    jellyfin_models.BaseItemDto? currentItem;
+
+    if (mediaItem.valueOrNull?.extras?["itemJson"] != null) {
+      currentItem = jellyfin_models.BaseItemDto.fromJson(
+        mediaItem.valueOrNull?.extras!["itemJson"] as Map<String, dynamic>,
+      );
+    } else {
+      return;
+    }
+    bool isFavorite = currentItem.userData?.isFavorite ?? false;
+    switch (rating.getRatingStyle()) {
+      case RatingStyle.heart:
+        if (rating.hasHeart() && !isFavorite) {
+          // add favorite
+          await toggleFavoriteStatusOfCurrentTrack();
+        } else if (!rating.hasHeart() && isFavorite) {
+          // remove favorite
+          await toggleFavoriteStatusOfCurrentTrack();
+        }
+        break;
+      case RatingStyle.thumbUpDown:
+        if (rating.isThumbUp() && !isFavorite) {
+          // add favorite
+          await toggleFavoriteStatusOfCurrentTrack();
+        } else if (!rating.isThumbUp() && isFavorite) {
+          // remove favorite
+          await toggleFavoriteStatusOfCurrentTrack();
+        }
+        break;
+      case RatingStyle.percentage:
+        final percentage = rating.getPercentRating();
+        if (percentage > 0.5 && !isFavorite) {
+          // add favorite
+          await toggleFavoriteStatusOfCurrentTrack();
+        } else if (percentage < 0.5 && isFavorite) {
+          // remove favorite
+          await toggleFavoriteStatusOfCurrentTrack();
+        }
+        break;
+      case RatingStyle.range3stars:
+        final stars = rating.getStarRating();
+        if (stars >= 1.5 && !isFavorite) {
+          // add favorite
+          await toggleFavoriteStatusOfCurrentTrack();
+        } else if (stars <= 0.5 && isFavorite) {
+          // remove favorite
+          await toggleFavoriteStatusOfCurrentTrack();
+        }
+        break;
+      case RatingStyle.range4stars:
+        final stars = rating.getStarRating();
+        if (stars >= 2.0 && !isFavorite) {
+          // add favorite
+          await toggleFavoriteStatusOfCurrentTrack();
+        } else if (stars <= 1.0 && isFavorite) {
+          // remove favorite
+          await toggleFavoriteStatusOfCurrentTrack();
+        }
+        break;
+      case RatingStyle.range5stars:
+        final stars = rating.getStarRating();
+        if (stars >= 3 && !isFavorite) {
+          // add favorite
+          await toggleFavoriteStatusOfCurrentTrack();
+        } else if (stars <= 2.0 && isFavorite) {
+          // remove favorite
+          await toggleFavoriteStatusOfCurrentTrack();
+        }
+        break;
+      default:
+      // do nothing
+    }
+  }
+
+  @override
+  @Deprecated("Don't use this method yet, it has no implementation")
+  Future<void> setCaptioningEnabled(bool enabled) async {}
+
 }
 
 double? getGainForCurrentPlayback(MediaItem currentTrack, jellyfin_models.BaseItemDto? item) {

--- a/lib/services/music_player_background_task.dart
+++ b/lib/services/music_player_background_task.dart
@@ -245,6 +245,7 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler with SeekHandler, Queue
       _audioServiceBackgroundTaskLogger.info("Initializing media-kit for Windows/Linux");
       JustAudioMediaKit.title = "Finamp";
       JustAudioMediaKit.prefetchPlaylist = true; // cache upcoming tracks, enable gapless playback
+      JustAudioMediaKit.bufferSize = FinampSettingsHelper.finampSettings.bufferSizeMegabytes * 1024 * 1024;
       JustAudioMediaKit.ensureInitialized(linux: true, windows: true, macOS: false, iOS: false, android: false);
     }
 
@@ -753,10 +754,6 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler with SeekHandler, Queue
 
   @override
   Future<void> setShuffleMode(AudioServiceShuffleMode shuffleMode) async {
-    if (!Platform.isAndroid && !Platform.isIOS && shuffleMode != AudioServiceShuffleMode.none) {
-      GlobalSnackbar.message((scaffold) => AppLocalizations.of(scaffold)!.desktopShuffleWarning);
-      shuffleMode = AudioServiceShuffleMode.none;
-    }
     try {
       switch (shuffleMode) {
         case AudioServiceShuffleMode.all:

--- a/lib/services/music_player_background_task.dart
+++ b/lib/services/music_player_background_task.dart
@@ -386,20 +386,6 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler with SeekHandler, Queue
       }
     });
 
-    // PlaybackEvent doesn't include shuffle/loops so we listen for changes here
-    _player.shuffleModeEnabledStream.listen((_) {
-      final event = _transformEvent(_player.playbackEvent);
-      playbackState.add(event);
-      _audioServiceBackgroundTaskLogger.info(
-        "Shuffle mode changed to ${event.shuffleMode} (${_player.shuffleModeEnabled}).",
-      );
-    });
-    _player.loopModeStream.listen((_) {
-      final event = _transformEvent(_player.playbackEvent);
-      playbackState.add(event);
-      _audioServiceBackgroundTaskLogger.info("Loop mode changed to ${event.repeatMode} (${_player.loopMode}).");
-    });
-
     fadeState = BehaviorSubject.seeded(FadeState(fadeVolume: 1.0));
   }
 
@@ -790,6 +776,7 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler with SeekHandler, Queue
             "Unsupported AudioServiceRepeatMode! Received ${shuffleMode.toString()}, requires all or none.",
           );
       }
+      _audioServiceBackgroundTaskLogger.info("Set shuffle mode to $shuffleMode");
     } catch (e) {
       _audioServiceBackgroundTaskLogger.severe(e);
       return Future.error(e);
@@ -814,6 +801,7 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler with SeekHandler, Queue
             "Unsupported AudioServiceRepeatMode! Received ${repeatMode.toString()}, requires all, none, or one.",
           );
       }
+      _audioServiceBackgroundTaskLogger.info("Set repeat mode to $repeatMode");
     } catch (e) {
       _audioServiceBackgroundTaskLogger.severe(e);
       return Future.error(e);

--- a/lib/services/music_player_background_task.dart
+++ b/lib/services/music_player_background_task.dart
@@ -714,10 +714,7 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler with SeekHandler, Queue
           queueIndex %= (_player.effectiveIndices.length);
         }
       }
-      await _player.seek(
-        Duration.zero,
-        index: _player.shuffleModeEnabled ? shuffleIndices[queueIndex] : queueIndex,
-      );
+      await _player.seek(Duration.zero, index: _player.shuffleModeEnabled ? shuffleIndices[queueIndex] : queueIndex);
     } catch (e) {
       _audioServiceBackgroundTaskLogger.severe(e);
       return Future.error(e);
@@ -728,10 +725,7 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler with SeekHandler, Queue
     _audioServiceBackgroundTaskLogger.fine("skipping to index: $index");
 
     try {
-      await _player.seek(
-        Duration.zero,
-        index: _player.shuffleModeEnabled ? shuffleIndices[index] : index,
-      );
+      await _player.seek(Duration.zero, index: _player.shuffleModeEnabled ? shuffleIndices[index] : index);
     } catch (e) {
       _audioServiceBackgroundTaskLogger.severe(e);
       return Future.error(e);
@@ -1150,6 +1144,9 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler with SeekHandler, Queue
     );
   }
 
+  int? get queueIndex => _player.shuffleModeEnabled && shuffleIndices.isNotEmpty && _player.currentIndex != null
+      ? shuffleIndices.indexOf(_player.currentIndex!)
+      : _player.currentIndex;
   List<IndexedAudioSource> get effectiveSequence => _player.sequenceState.effectiveSequence;
   double get volume => _player.volume;
   bool get paused => !_player.playing;
@@ -1368,7 +1365,6 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler with SeekHandler, Queue
   @override
   @Deprecated("Don't use this method yet, it has no implementation")
   Future<void> setCaptioningEnabled(bool enabled) async {}
-
 }
 
 double? getGainForCurrentPlayback(MediaItem currentTrack, jellyfin_models.BaseItemDto? item) {

--- a/lib/services/queue_service.dart
+++ b/lib/services/queue_service.dart
@@ -156,8 +156,9 @@ class QueueService {
   void _buildQueueFromNativePlayerQueue({bool logUpdate = true}) {
     final playbackHistoryService = GetIt.instance<PlaybackHistoryService>();
 
-    List<FinampQueueItem> allTracks =
-        _audioHandler.effectiveSequence.map((e) => e.tag as FinampQueueItem).toList();
+    _queueAudioSourceIndex = _audioHandler.queueIndex ?? _queueAudioSourceIndex;
+
+    List<FinampQueueItem> allTracks = _audioHandler.effectiveSequence.map((e) => e.tag as FinampQueueItem).toList();
 
     _queuePreviousTracks.clear();
     _queueNextUp.clear();
@@ -611,7 +612,6 @@ class QueueService {
       } else if (!Platform.isAndroid && !Platform.isIOS) {
         unawaited(_audioHandler.pause(disableFade: true));
       }
-
     } catch (e) {
       _queueServiceLogger.severe("Error while initializing queue: $e");
     }
@@ -1157,7 +1157,6 @@ class QueueService {
       duration: item.runTimeTicksDuration(),
     );
   }
-
 }
 
 class NextUpShuffleOrder extends ShuffleOrder {

--- a/lib/services/queue_service.dart
+++ b/lib/services/queue_service.dart
@@ -26,7 +26,6 @@ import 'package:uuid/uuid.dart';
 import '../components/PlayerScreen/queue_source_helper.dart';
 import 'downloads_service.dart';
 import 'finamp_settings_helper.dart';
-import 'finamp_user_helper.dart';
 import 'jellyfin_api_helper.dart';
 import 'music_player_background_task.dart';
 
@@ -40,7 +39,6 @@ class QueueService {
 
   final _jellyfinApiHelper = GetIt.instance<JellyfinApiHelper>();
   final _audioHandler = GetIt.instance<MusicPlayerBackgroundTask>();
-  final _finampUserHelper = GetIt.instance<FinampUserHelper>();
   final _downloadsService = GetIt.instance<DownloadsService>();
   final _queueServiceLogger = Logger("QueueService");
   final _queuesBox = Hive.box<FinampStorableQueueInfo>("Queues");
@@ -512,14 +510,6 @@ class QueueService {
       }
 
       order ??= FinampPlaybackOrder.linear;
-
-      // Native shuffle is not currently implemented on mediakit backend.  Perform manually.
-      if ((Platform.isLinux || Platform.isWindows) && order == FinampPlaybackOrder.shuffled) {
-        List<jellyfin_models.BaseItemDto> clonedItems = List.from(itemList);
-        clonedItems.shuffle();
-        itemList = clonedItems;
-        order = FinampPlaybackOrder.linear;
-      }
 
       if (initialIndex == null) {
         if (order == FinampPlaybackOrder.shuffled) {
@@ -1012,11 +1002,6 @@ class QueueService {
   FinampLoopMode get loopMode => _loopMode;
 
   Future<void> setPlaybackOrder(FinampPlaybackOrder order) async {
-    // Native shuffle is not currently implemented on mediakit backend.
-    if ((Platform.isLinux || Platform.isWindows) && order != FinampPlaybackOrder.linear) {
-      GlobalSnackbar.message((scaffold) => AppLocalizations.of(scaffold)!.desktopShuffleWarning);
-      order = FinampPlaybackOrder.linear;
-    }
     _playbackOrder = order;
     _queueServiceLogger.fine("Playback order set to $order");
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -927,7 +927,7 @@ packages:
     description:
       path: "."
       ref: "feat/queue-shuffle"
-      resolved-ref: d0aac6c33a7b0f4eb9d2f35784891229c8f44976
+      resolved-ref: "2369f51989cb7fd8e6713f20844a0d4fe6f1bc0a"
       url: "https://github.com/Komodo5197/just_audio_media_kit.git"
     source: git
     version: "2.1.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -916,11 +916,12 @@ packages:
   just_audio:
     dependency: "direct main"
     description:
-      name: just_audio
-      sha256: "9694e4734f515f2a052493d1d7e0d6de219ee0427c7c29492e246ff32a219908"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.10.5"
+      path: just_audio
+      ref: "6dfdd07d19f6f037d3f4ff04c397639e4632c687"
+      resolved-ref: "6dfdd07d19f6f037d3f4ff04c397639e4632c687"
+      url: "https://github.com/LennartEnns/just_audio_fork.git"
+    source: git
+    version: "0.10.6"
   just_audio_media_kit:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -925,10 +925,11 @@ packages:
   just_audio_media_kit:
     dependency: "direct main"
     description:
-      name: just_audio_media_kit
-      sha256: f3cf04c3a50339709e87e90b4e841eef4364ab4be2bdbac0c54cc48679f84d23
-      url: "https://pub.dev"
-    source: hosted
+      path: "."
+      ref: faa61aef52426daa5aa081cb3f0f8a8467796c17
+      resolved-ref: faa61aef52426daa5aa081cb3f0f8a8467796c17
+      url: "https://github.com/Komodo5197/just_audio_media_kit.git"
+    source: git
     version: "2.1.0"
   just_audio_platform_interface:
     dependency: transitive
@@ -1022,10 +1023,10 @@ packages:
     dependency: transitive
     description:
       name: media_kit
-      sha256: "48c10c3785df5d88f0eef970743f8c99b2e5da2b34b9d8f9876e598f62d9e776"
+      sha256: "52a8e989babc431db0aa242f32a4a08e55f60662477ea09759a105d7cd6410da"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   media_kit_libs_linux:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -926,8 +926,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: faa61aef52426daa5aa081cb3f0f8a8467796c17
-      resolved-ref: faa61aef52426daa5aa081cb3f0f8a8467796c17
+      ref: "feat/queue-shuffle"
+      resolved-ref: d0aac6c33a7b0f4eb9d2f35784891229c8f44976
       url: "https://github.com/Komodo5197/just_audio_media_kit.git"
     source: git
     version: "2.1.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -125,10 +125,10 @@ packages:
     dependency: "direct main"
     description:
       name: audio_session
-      sha256: "2b7fff16a552486d078bfc09a8cde19f426dc6d6329262b684182597bec5b1ac"
+      sha256: "8f96a7fecbb718cb093070f868b4cdcb8a9b1053dce342ff8ab2fde10eb9afb7"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.25"
+    version: "0.2.2"
   auto_size_text:
     dependency: "direct main"
     description:
@@ -917,10 +917,10 @@ packages:
     dependency: "direct main"
     description:
       name: just_audio
-      sha256: f978d5b4ccea08f267dae0232ec5405c1b05d3f3cd63f82097ea46c015d5c09e
+      sha256: "9694e4734f515f2a052493d1d7e0d6de219ee0427c7c29492e246ff32a219908"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.46"
+    version: "0.10.5"
   just_audio_media_kit:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,7 +50,7 @@ dependencies:
   audio_service: ^0.18.17
   audio_service_mpris: ^0.2.0
   audio_service_platform_interface: ^0.1.1
-  audio_session: ^0.1.25
+  audio_session: ^0.2.2
   rxdart: ^0.28.0
   simple_gesture_detector: ^0.2.1
   path_provider: ^2.0.14

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,9 +30,9 @@ dependencies:
   json_annotation: ^4.8.1
   chopper: ^8.0.0
   get_it: ^8.2.0
-  just_audio: ^0.9.43
-  just_audio_media_kit: ^2.0.6
-  media_kit_libs_linux: ^1.1.3
+  just_audio: ^0.10.5
+  just_audio_media_kit: ^2.1.0
+  media_kit_libs_linux: ^1.2.1
 
   # Transcoding does not work on windows with current media-kit release.  This fork uses the most recent
   # build of MPV from https://github.com/zhongfly/mpv-winbuild, which works correctly while transcoding.
@@ -47,9 +47,9 @@ dependencies:
       ref: 7ece49cc16a459aaa0718ed23458802533daef37
       path: packages/smtc_windows/
 
-  audio_service: ^0.18.17
+  audio_service: ^0.18.18
   audio_service_mpris: ^0.2.0
-  audio_service_platform_interface: ^0.1.1
+  audio_service_platform_interface: ^0.1.3
   audio_session: ^0.2.2
   rxdart: ^0.28.0
   simple_gesture_detector: ^0.2.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,7 +30,12 @@ dependencies:
   json_annotation: ^4.8.1
   chopper: ^8.0.0
   get_it: ^8.2.0
-  just_audio: ^0.10.5
+  # just_audio: ^0.10.5
+  just_audio:
+    git:
+      url: https://github.com/LennartEnns/just_audio_fork.git
+      ref: 6dfdd07d19f6f037d3f4ff04c397639e4632c687
+      path: just_audio
   just_audio_media_kit: ^2.1.0
   media_kit_libs_linux: ^1.2.1
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,7 +39,7 @@ dependencies:
   just_audio_media_kit:
     git:
       url: https://github.com/Komodo5197/just_audio_media_kit.git
-      ref: faa61aef52426daa5aa081cb3f0f8a8467796c17
+      ref: feat/queue-shuffle
 
   media_kit_libs_linux: ^1.2.1
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,6 +32,7 @@ dependencies:
   get_it: ^8.2.0
   # just_audio: ^0.10.5
   just_audio:
+  # TODO switch back to official just_audio once https://github.com/ryanheise/just_audio/pull/1555 is merged
     git:
       url: https://github.com/LennartEnns/just_audio_fork.git
       ref: 6dfdd07d19f6f037d3f4ff04c397639e4632c687

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,7 +36,11 @@ dependencies:
       url: https://github.com/LennartEnns/just_audio_fork.git
       ref: 6dfdd07d19f6f037d3f4ff04c397639e4632c687
       path: just_audio
-  just_audio_media_kit: ^2.1.0
+  just_audio_media_kit:
+    git:
+      url: https://github.com/Komodo5197/just_audio_media_kit.git
+      ref: faa61aef52426daa5aa081cb3f0f8a8467796c17
+
   media_kit_libs_linux: ^1.2.1
 
   # Transcoding does not work on windows with current media-kit release.  This fork uses the most recent


### PR DESCRIPTION
https://github.com/ryanheise/just_audio/tree/minor/just_audio#migrating-to-010x

Only minor refactoring was needed so far. There are some batch operations that aren't available with the new API, so adding multiple tracks to an existing queue might be less efficient now, but that requires thorough testing.  
Testing on iOS would also be appreciated.

Known bugs/PRs that we might want to wait for:

- https://github.com/ryanheise/just_audio/pull/1555
  - I've switched to this fork for now. It might take a while before the PR is merged, but I see no issue with building the next version based on this instead of the pub.dev version as a temporary fix, instead of waiting for it to get merged
- `_player.playbackEventStream` doesn't emit an event anymore when the shuffle mode is changed, which means the current player index isn't updated properly and the wrong track is shown until the next `playbackEvent` is triggered (e.g. via seeking, pausing)
  - This could be related to the wrong shuffle order being used, but is unaffected by the open PR
  - I've worked around this now by manually fetching the current player index before rebuilding the queue