### PR TITLE
Add setting to reset "previousTracksExpaned" each time a queue is opened

### DIFF
--- a/.github/workflows/pr-healthchecks.yml
+++ b/.github/workflows/pr-healthchecks.yml
@@ -35,3 +35,35 @@ jobs:
           # Format locally generated localization files to prevent false positives
           dart format lib/l10n/ 
           dart format --output=none --set-exit-if-changed lib/
+  check-codegen:
+    name: Ensure correct code generation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake ninja-build libgtk-3-dev
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+      - name: Verify Flutter setup
+        run: flutter doctor
+      - name: Get dependencies
+        run: flutter pub get
+      - name: Verify code generation
+        run: |
+          dart run build_runner build --delete-conflicting-outputs
+          git add . # new files are not tracked by git
+          if git diff --cached --name-only | grep -q '\.g\.dart$'; then
+            echo "Code generation is different, diff follows"
+            git diff --cached | cat
+            exit 2
+          fi

--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1765435813,
-        "narHash": "sha256-C6tT7K1Lx6VsYw1BY5S3OavtapUvEnDQtmQB5DSgbCc=",
+        "lastModified": 1773471952,
+        "narHash": "sha256-kIRggXyT8RzijtfvyRIzj+zIDWM2fnCp8t0X4BkkTVc=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "6399553b7a300c77e7f07342904eb696a5b6bf9d",
+        "rev": "a1b770adbc3f6c27485d03b90462ec414d4e1ce5",
         "type": "github"
       },
       "original": {
@@ -41,11 +41,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1765779637,
-        "narHash": "sha256-KJ2wa/BLSrTqDjbfyNx70ov/HdgNBCBBSQP3BIzKnv4=",
+        "lastModified": 1773282481,
+        "narHash": "sha256-b/GV2ysM8mKHhinse2wz+uP37epUrSE+sAKXy/xvBY4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1306659b587dc277866c7b69eb97e5f07864d8c4",
+        "rev": "fe416aaedd397cacb33a610b33d60ff2b431b127",
         "type": "github"
       },
       "original": {
@@ -65,11 +65,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1765400135,
-        "narHash": "sha256-D3+4hfNwUhG0fdCpDhOASLwEQ1jKuHi4mV72up4kLQM=",
+        "lastModified": 1773326183,
+        "narHash": "sha256-tj3piRd9RnnP36HwHmQD4O4XZeowsH/rvMeyp9Pmot0=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "fface27171988b3d605ef45cf986c25533116f7e",
+        "rev": "6254616e97f358e67b70dfc0463687f5f7911c1a",
         "type": "github"
       },
       "original": {

--- a/lib/components/InteractionSettingsScreen/previous_tracks_persistence_mode_dropdown_list_tile.dart
+++ b/lib/components/InteractionSettingsScreen/previous_tracks_persistence_mode_dropdown_list_tile.dart
@@ -1,0 +1,50 @@
+import 'package:finamp/components/SettingsScreen/finamp_settings_dropdown.dart';
+import 'package:finamp/l10n/app_localizations.dart';
+import 'package:finamp/models/finamp_models.dart';
+import 'package:finamp/services/finamp_settings_helper.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+extension LocalizedName on PreviousTracksPersistenceMode {
+  String toLocalizedString(BuildContext context) => _humanReadableLocalizedName(this, context);
+
+  String _humanReadableLocalizedName(PreviousTracksPersistenceMode themeMode, BuildContext context) {
+    switch (themeMode) {
+      case PreviousTracksPersistenceMode.persistent:
+        return AppLocalizations.of(context)!.previousTracksPersistenceModePersistent;
+      case PreviousTracksPersistenceMode.initiallyCollapsed:
+        return AppLocalizations.of(context)!.previousTracksPersistenceModeCollapsed;
+      case PreviousTracksPersistenceMode.initiallyExpanded:
+        return AppLocalizations.of(context)!.previousTracksPersistenceModeExpanded;
+    }
+  }
+}
+
+class PreviousTracksPersistenceModeSelector extends ConsumerWidget {
+  const PreviousTracksPersistenceModeSelector({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final previousTracksPersistenceMode = ref.watch(finampSettingsProvider.previousTracksPersistenceMode);
+    return ListTile(
+      title: Text(AppLocalizations.of(context)!.previousTracksPersistenceModeSelectorTitle),
+      subtitle: Column(
+        spacing: 4.0,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(AppLocalizations.of(context)!.previousTracksPersistenceModeSelectorSubtitle),
+          FinampSettingsDropdown<PreviousTracksPersistenceMode>(
+            dropdownItems: PreviousTracksPersistenceMode.values
+                .map(
+                  (e) =>
+                      DropdownMenuEntry<PreviousTracksPersistenceMode>(value: e, label: e.toLocalizedString(context)),
+                )
+                .toList(),
+            selectedValue: previousTracksPersistenceMode,
+            onSelected: FinampSetters.setPreviousTracksPersistenceMode.ifNonNull,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/components/PlayerScreen/queue_list.dart
+++ b/lib/components/PlayerScreen/queue_list.dart
@@ -115,6 +115,17 @@ class _QueueListState extends ConsumerState<QueueList> {
     _contents = <Widget>[];
 
     widget.scrollController.addListener(_updateJumpToTop);
+
+    switch (FinampSettingsHelper.finampSettings.previousTracksPersistenceMode) {
+      case PreviousTracksPersistenceMode.persistent:
+        break;
+      case PreviousTracksPersistenceMode.initiallyCollapsed:
+        FinampSetters.setPreviousTracksExpaned(false);
+        break;
+      case PreviousTracksPersistenceMode.initiallyExpanded:
+        FinampSetters.setPreviousTracksExpaned(true);
+        break;
+    }
   }
 
   void _updateJumpToTop() {

--- a/lib/hive_registrar.g.dart
+++ b/lib/hive_registrar.g.dart
@@ -74,6 +74,7 @@ extension HiveRegistrar on HiveInterface {
     registerAdapter(PlaylistInfoAdapter());
     registerAdapter(PlaylistUserAdapter());
     registerAdapter(PlaylistUsersAdapter());
+    registerAdapter(PreviousTracksPersistenceModeAdapter());
     registerAdapter(ProfileConditionAdapter());
     registerAdapter(QueueItemAdapter());
     registerAdapter(QueueItemQueueTypeAdapter());
@@ -175,6 +176,7 @@ extension IsolatedHiveRegistrar on IsolatedHiveInterface {
     registerAdapter(PlaylistInfoAdapter());
     registerAdapter(PlaylistUserAdapter());
     registerAdapter(PlaylistUsersAdapter());
+    registerAdapter(PreviousTracksPersistenceModeAdapter());
     registerAdapter(ProfileConditionAdapter());
     registerAdapter(QueueItemAdapter());
     registerAdapter(QueueItemQueueTypeAdapter());

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3271,5 +3271,25 @@
         "example": "Ctrl + ←/→"
       }
     }
+  },
+  "previousTracksPersistenceModeSelectorTitle": "Initial state of \"Previous tracks\" header in queue list",
+  "@previousTracksPersistenceModeSelectorTitle": {
+    "description": "Title for setting that allows to override state of previous tracks header in queue list"
+  },
+  "previousTracksPersistenceModeSelectorSubtitle": "Applied each time queue is opened on player screen",
+  "@previousTracksPersistenceModeSelectorSubtitle": {
+    "description": "Subtitle for setting that allows to override state of previous tracks header in queue list"
+  },
+  "previousTracksPersistenceModePersistent": "Last used",
+  "@previousTracksPersistenceModePersistent": {
+    "description": "Does nothing to previous tracks header in queue list, using its saved value"
+  },
+  "previousTracksPersistenceModeCollapsed": "Initially collapsed",
+  "@previousTracksPersistenceModePersistent": {
+    "description": "Overrides saved value to collapse previous tracks header on queue list open"
+  },
+  "previousTracksPersistenceModeExpanded": "Initially expanded",
+  "@previousTracksPersistenceModePersistent": {
+    "description": "Overrides saved value to expand previous tracks header on queue list open"
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3272,24 +3272,24 @@
       }
     }
   },
-  "previousTracksPersistenceModeSelectorTitle": "Initial state of \"Previous tracks\" header in queue list",
+  "previousTracksPersistenceModeSelectorTitle": "Previous tracks visibility in queue panel",
   "@previousTracksPersistenceModeSelectorTitle": {
     "description": "Title for setting that allows to override state of previous tracks header in queue list"
   },
-  "previousTracksPersistenceModeSelectorSubtitle": "Applied each time queue is opened on player screen",
+  "previousTracksPersistenceModeSelectorSubtitle": "If you open the queue panel, the previous tracks section should be...",
   "@previousTracksPersistenceModeSelectorSubtitle": {
     "description": "Subtitle for setting that allows to override state of previous tracks header in queue list"
   },
-  "previousTracksPersistenceModePersistent": "Last used",
+  "previousTracksPersistenceModePersistent": "Like before (remember expanded/collapsed)",
   "@previousTracksPersistenceModePersistent": {
     "description": "Does nothing to previous tracks header in queue list, using its saved value"
   },
-  "previousTracksPersistenceModeCollapsed": "Initially collapsed",
-  "@previousTracksPersistenceModePersistent": {
+  "previousTracksPersistenceModeCollapsed": "Collapsed (hidden)",
+  "@previousTracksPersistenceModeCollapsed": {
     "description": "Overrides saved value to collapse previous tracks header on queue list open"
   },
-  "previousTracksPersistenceModeExpanded": "Initially expanded",
-  "@previousTracksPersistenceModePersistent": {
+  "previousTracksPersistenceModeExpanded": "Expanded (visible)",
+  "@previousTracksPersistenceModeExpanded": {
     "description": "Overrides saved value to expand previous tracks header on queue list open"
   }
 }

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -248,6 +248,7 @@ class DefaultSettings {
   static const radioEnabled = false;
   static const duckOnAudioInterruption = true;
   static const forceAudioOffloadingOnAndroid = false;
+  static const previousTracksPersistenceMode = PreviousTracksPersistenceMode.persistent;
 }
 
 @HiveType(typeId: 28)
@@ -390,6 +391,7 @@ class FinampSettings {
     this.useMonochromeIcon = DefaultSettings.useMonochromeIcon,
     this.duckOnAudioInterruption = DefaultSettings.duckOnAudioInterruption,
     this.forceAudioOffloadingOnAndroid = DefaultSettings.forceAudioOffloadingOnAndroid,
+    this.previousTracksPersistenceMode = DefaultSettings.previousTracksPersistenceMode,
   });
 
   @HiveField(0, defaultValue: DefaultSettings.isOffline)
@@ -841,6 +843,9 @@ class FinampSettings {
 
   @HiveField(144, defaultValue: DefaultSettings.multichannelHandlingSetting)
   MultichannelHandlingSetting multichannelHandlingSetting;
+
+  @HiveField(145, defaultValue: DefaultSettings.previousTracksPersistenceMode)
+  PreviousTracksPersistenceMode previousTracksPersistenceMode = DefaultSettings.previousTracksPersistenceMode;
 
   static Future<FinampSettings> create() async {
     final downloadLocation = await DownloadLocation.create(
@@ -3982,4 +3987,20 @@ enum MultichannelHandlingSetting {
   @HiveField(3)
   dynamicBitrate,
   **/
+}
+
+@HiveType(typeId: 112)
+/// Describes initial state of "previous tracks" header on queue open
+enum PreviousTracksPersistenceMode {
+  /// Use last stored state
+  @HiveField(0)
+  persistent,
+
+  /// Override state to be collapsed on open
+  @HiveField(1)
+  initiallyCollapsed,
+
+  /// Override state to be expanded on open
+  @HiveField(2)
+  initiallyExpanded,
 }

--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -447,6 +447,9 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
         forceAudioOffloadingOnAndroid: fields[143] == null
             ? false
             : fields[143] as bool,
+        previousTracksPersistenceMode: fields[145] == null
+            ? PreviousTracksPersistenceMode.persistent
+            : fields[145] as PreviousTracksPersistenceMode,
       )
       ..disableGesture = fields[19] == null ? false : fields[19] as bool
       ..showFastScroller = fields[25] == null ? true : fields[25] as bool
@@ -465,7 +468,7 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
   @override
   void write(BinaryWriter writer, FinampSettings obj) {
     writer
-      ..writeByte(138)
+      ..writeByte(139)
       ..writeByte(0)
       ..write(obj.isOffline)
       ..writeByte(1)
@@ -741,7 +744,9 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       ..writeByte(143)
       ..write(obj.forceAudioOffloadingOnAndroid)
       ..writeByte(144)
-      ..write(obj.multichannelHandlingSetting);
+      ..write(obj.multichannelHandlingSetting)
+      ..writeByte(145)
+      ..write(obj.previousTracksPersistenceMode);
   }
 
   @override
@@ -3146,6 +3151,48 @@ class MultichannelHandlingSettingAdapter
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is MultichannelHandlingSettingAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}
+
+class PreviousTracksPersistenceModeAdapter
+    extends TypeAdapter<PreviousTracksPersistenceMode> {
+  @override
+  final typeId = 112;
+
+  @override
+  PreviousTracksPersistenceMode read(BinaryReader reader) {
+    switch (reader.readByte()) {
+      case 0:
+        return PreviousTracksPersistenceMode.persistent;
+      case 1:
+        return PreviousTracksPersistenceMode.initiallyCollapsed;
+      case 2:
+        return PreviousTracksPersistenceMode.initiallyExpanded;
+      default:
+        return PreviousTracksPersistenceMode.persistent;
+    }
+  }
+
+  @override
+  void write(BinaryWriter writer, PreviousTracksPersistenceMode obj) {
+    switch (obj) {
+      case PreviousTracksPersistenceMode.persistent:
+        writer.writeByte(0);
+      case PreviousTracksPersistenceMode.initiallyCollapsed:
+        writer.writeByte(1);
+      case PreviousTracksPersistenceMode.initiallyExpanded:
+        writer.writeByte(2);
+    }
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is PreviousTracksPersistenceModeAdapter &&
           runtimeType == other.runtimeType &&
           typeId == other.typeId;
 }

--- a/lib/screens/interaction_settings_screen.dart
+++ b/lib/screens/interaction_settings_screen.dart
@@ -3,6 +3,7 @@ import 'package:finamp/components/InteractionSettingsScreen/auto_expand_player_s
 import 'package:finamp/components/InteractionSettingsScreen/item_swipe_action_dropdown_list_tile.dart';
 import 'package:finamp/components/InteractionSettingsScreen/keep_screen_on_dropdown_list_tile.dart';
 import 'package:finamp/components/InteractionSettingsScreen/keep_screen_on_while_charging_selector.dart';
+import 'package:finamp/components/InteractionSettingsScreen/previous_tracks_persistence_mode_dropdown_list_tile.dart';
 import 'package:finamp/l10n/app_localizations.dart';
 import 'package:finamp/screens/layout_settings_screen.dart';
 import 'package:finamp/services/finamp_settings_helper.dart';
@@ -45,6 +46,7 @@ class _InteractionSettingsScreenState extends State<InteractionSettingsScreen> {
           PreferAddingToFavoritesOverPlaylistsToggle(),
           PreferNextUpPrependingToggle(),
           RememberLastUsedPlaybackActionRowPageToggle(),
+          PreviousTracksPersistenceModeSelector(),
         ],
       ),
     );

--- a/lib/services/finamp_settings_helper.dart
+++ b/lib/services/finamp_settings_helper.dart
@@ -229,6 +229,7 @@ class FinampSettingsHelper {
     FinampSetters.setPreferAddingToFavoritesOverPlaylists(DefaultSettings.preferAddingToFavoritesOverPlaylists);
     FinampSetters.setPreferNextUpPrepending(DefaultSettings.preferNextUpPrepending);
     FinampSetters.setRememberLastUsedPlaybackActionRowPage(DefaultSettings.rememberLastUsedPlaybackActionRowPage);
+    FinampSetters.setPreviousTracksPersistenceMode(DefaultSettings.previousTracksPersistenceMode);
 
     Hive.box<FinampSettings>("FinampSettings").put("FinampSettings", finampSettingsTemp);
   }

--- a/lib/services/finamp_settings_helper.g.dart
+++ b/lib/services/finamp_settings_helper.g.dart
@@ -1259,6 +1259,17 @@ extension FinampSetters on FinampSettingsHelper {
     ).put("FinampSettings", finampSettingsTemp);
   }
 
+  static void setPreviousTracksPersistenceMode(
+    PreviousTracksPersistenceMode newPreviousTracksPersistenceMode,
+  ) {
+    FinampSettings finampSettingsTemp = FinampSettingsHelper.finampSettings;
+    finampSettingsTemp.previousTracksPersistenceMode =
+        newPreviousTracksPersistenceMode;
+    Hive.box<FinampSettings>(
+      "FinampSettings",
+    ).put("FinampSettings", finampSettingsTemp);
+  }
+
   static void setBufferDuration(Duration newBufferDuration) {
     FinampSettings finampSettingsTemp = FinampSettingsHelper.finampSettings;
     finampSettingsTemp.bufferDuration = newBufferDuration;
@@ -1693,6 +1704,10 @@ extension FinampSettingsProviderSelectors on StreamProvider<FinampSettings> {
   ProviderListenable<MultichannelHandlingSetting>
   get multichannelHandlingSetting => finampSettingsProvider.select(
     (value) => value.requireValue.multichannelHandlingSetting,
+  );
+  ProviderListenable<PreviousTracksPersistenceMode>
+  get previousTracksPersistenceMode => finampSettingsProvider.select(
+    (value) => value.requireValue.previousTracksPersistenceMode,
   );
   ProviderListenable<DownloadProfile> get downloadTranscodingProfile =>
       finampSettingsProvider.select(


### PR DESCRIPTION
<!-- Just a reminder that text in these brackets is not visible in the rendered output.
You also do **not** need to use this template. You can remove and modify anything however you like!
Its just a suggestion :)
-->

## Changes

- Update nix flake and CONTRIBUTING.md to allow contributing from NixOS at least with workarounds
- Add setting to reset "previousTracksExpaned" each time a queue is opened (this behavior is disabled by default but the setting is inversed). 
- Add a workflow check for codegen verification

<details>
<summary>Screenshot</summary>
<img width="781" height="75" alt="image" src="https://github.com/user-attachments/assets/3ff7252f-d93d-4bd7-a838-6e4a4cc92e73" />

</details>

## Todo before merging

- [x] Add a workflow check which checks that code generation was done properly; or
- [ ] check that change from `..writeByte(137)` to `..writeByte(138)` is okay.

<!-- Did you add UI text? 
No? Just check or remove the box
Yes? Make sure you replace hardcoded strings with translations -->
- [x] Translations
<!-- Did you add settings to the settings screen?
No? Just check or remove the box 
Yes? Make sure they are resettable using the button on the respective page! (see finamp_settings_helper.dart)-->
- [x] Reset Settings
<!-- Did you run into problems?
No? Just check or remove the box
Yes? Look at the CONTRIBUTING.md, maybe you can add something to help others! -->
- [x] Extended CONTRIBUTING.md

## Related Issues
<!-- List relevant issues to this PR using a format like this
- closes #xyz 
- fixes #abc
- follow up to #pr-name
-->

Not related to any issues