### PR TITLE
Fix duplicate listen events on iOS

### DIFF
--- a/lib/services/playback_history_service.dart
+++ b/lib/services/playback_history_service.dart
@@ -131,7 +131,7 @@ class PlaybackHistoryService {
             prevItem?.id == currentItem.id &&
                 // current position is close to the beginning of the track
                 currentState.position.inMilliseconds <= 1000 * 10) {
-              if ((prevState.position.inMilliseconds) >= ((prevItem?.item.duration?.inMilliseconds ?? 0) - 1000 * 10)) {
+              if (((prevState.position.inMilliseconds) >= ((prevItem?.item.duration?.inMilliseconds ?? 0) - 1000 * 10)) && (_queueService.loopMode == FinampLoopMode.one)) {
                 // looping a single track
                 // last position was close to the end of the track
                 updateCurrentTrack(currentItem, forceNewTrack: true); // add to playback history


### PR DESCRIPTION
## Changes
This PR adds a loop-mode check to `playback_history_service.dart`, as described by https://github.com/jmshrv/finamp/issues/1172#issuecomment-3434831790. As described in the issue, the client would report multiple listens for the same song, even when not in loop mode - however, this issue seemed to only appear on iOS devices.

## Related Issues
- closes #1172 
- possibly related to #688 
