### PR TITLE
Handle android.intent.action.MUSIC_PLAYER in AndroidManifest

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -51,9 +51,12 @@
       </intent-filter>
 
       <intent-filter>
-        <action android:name="android.intent.action.MAIN"/>
-        <category android:name="android.intent.category.APP_MUSIC"/>
-        <category android:name="android.intent.category.LAUNCHER"/>
+        <action android:name="android.intent.action.MAIN" />
+        <action android:name="android.intent.action.MUSIC_PLAYER" />
+
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.LAUNCHER" />
+        <category android:name="android.intent.category.APP_MUSIC" />
       </intent-filter>
       <intent-filter>
         <action android:name="android.media.action.MEDIA_PLAY_FROM_SEARCH" />


### PR DESCRIPTION
This allows starting Finamp from the “Play music” quick settings action on Samsung One UI devices. Currently, this doesn't start any playback, however.