### PR TITLE
Add setting for Handling Multichannel tracks

### DIFF
--- a/lib/hive_registrar.g.dart
+++ b/lib/hive_registrar.g.dart
@@ -63,6 +63,7 @@ extension HiveRegistrar on HiveInterface {
     registerAdapter(MediaSourceInfoAdapter());
     registerAdapter(MediaStreamAdapter());
     registerAdapter(MediaUrlAdapter());
+    registerAdapter(MultichannelHandlingSettingAdapter());
     registerAdapter(NameIdPairAdapter());
     registerAdapter(NameLongIdPairAdapter());
     registerAdapter(OfflineListenAdapter());
@@ -163,6 +164,7 @@ extension IsolatedHiveRegistrar on IsolatedHiveInterface {
     registerAdapter(MediaSourceInfoAdapter());
     registerAdapter(MediaStreamAdapter());
     registerAdapter(MediaUrlAdapter());
+    registerAdapter(MultichannelHandlingSettingAdapter());
     registerAdapter(NameIdPairAdapter());
     registerAdapter(NameLongIdPairAdapter());
     registerAdapter(OfflineListenAdapter());

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1888,22 +1888,22 @@
   "@downloadBitrateSubtitle": {
     "description": "subtitle for Download Bitrate settings slider"
   },
-  "multichannelHandlingTitle": "Multichannel Transcode Handling",
+  "multichannelHandlingTitle": "Multi-Channel Transcode Handling",
   "@multichannelHandlingTitle": {
-    "description": "Title for Multichannel Handling dropdown"
+    "description": "Title for multi-channel handling dropdown"
   },
-  "multichannelHandlingSubtitle": "How to deal with Multichannel tracks (> 2 channels) during transcoding. Applies to both Streams and Downloads.",
+  "multichannelHandlingSubtitle": "How to deal with multi-channel tracks (> 2 channels) when transcoding. Applies to both streaming and downloads.",
   "@multichannelHandlingSubtitle": {
-    "description": "subtitle for Multichannel Handling dropdown"
+    "description": "Subtitle for multi-channel handling dropdown"
   },
-  "multichannelHandlingOption": "{option, select, stereoDownmixLossy{Downmix Lossy to Stereo} stereoDownmix{Downmix All to Stereo} fixedBitrate{Fixed Bitrate Transcode} other{{option}} }",
+  "multichannelHandlingOption": "{option, select, stereoDownmixLossy{Only Downmix Lossy to Stereo} stereoDownmixAll{Downmix All to Stereo} fixedBitrate{Never Downmix} other{{option}} }",
   "@multichannelHandlingOption": {
     "placeholders": {
       "option": {
         "type": "String"
       }
     },
-    "description": "Options in Multichannel Handling dropdown"
+    "description": "Options in multi-channel handling dropdown"
   },
   "transcodeHint": "Transcode?",
   "@transcodeHint": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1888,6 +1888,23 @@
   "@downloadBitrateSubtitle": {
     "description": "subtitle for Download Bitrate settings slider"
   },
+  "multichannelHandlingTitle": "Multichannel Transcode Handling",
+  "@multichannelHandlingTitle": {
+    "description": "Title for Multichannel Handling dropdown"
+  },
+  "multichannelHandlingSubtitle": "How to deal with Multichannel tracks (> 2 channels) during transcoding. Applies to both Streams and Downloads.",
+  "@multichannelHandlingSubtitle": {
+    "description": "subtitle for Multichannel Handling dropdown"
+  },
+  "multichannelHandlingOption": "{option, select, stereoDownmixLossy{Downmix Lossy to Stereo} stereoDownmix{Downmix All to Stereo} fixedBitrate{Fixed Bitrate Transcode} other{{option}} }",
+  "@multichannelHandlingOption": {
+    "placeholders": {
+      "option": {
+        "type": "String"
+      }
+    },
+    "description": "Options in Multichannel Handling dropdown"
+  },
   "transcodeHint": "Transcode?",
   "@transcodeHint": {
     "description": "Initial text in downloads dropdown when 'Enable Transcoded Downloads' is set to ask."

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -140,6 +140,7 @@ class DefaultSettings {
   static const syncPlaybackSpeedAndPitch = false;
   static const autoLoadLastQueueOnStartup = true;
   static const shouldTranscodeDownloads = TranscodeDownloadsSetting.ask;
+  static const multichannelHandlingSetting = MultichannelHandlingSetting.stereoDownmixLossy;
   static const shouldRedownloadTranscodes = false;
   static const resyncOnStartup = true;
   static const fixedGridTileSize = 150;
@@ -302,6 +303,7 @@ class FinampSettings {
     this.downloadTranscodingCodec,
     this.downloadTranscodeBitrate,
     this.shouldTranscodeDownloads = DefaultSettings.shouldTranscodeDownloads,
+    this.multichannelHandlingSetting = DefaultSettings.multichannelHandlingSetting,
     this.shouldRedownloadTranscodes = DefaultSettings.shouldRedownloadTranscodes,
     this.itemSwipeActionLeftToRight = DefaultSettings.itemSwipeActionLeftToRight,
     this.itemSwipeActionRightToLeft = DefaultSettings.itemSwipeActionRightToLeft,
@@ -836,6 +838,9 @@ class FinampSettings {
 
   @HiveField(143, defaultValue: DefaultSettings.forceAudioOffloadingOnAndroid)
   bool forceAudioOffloadingOnAndroid = DefaultSettings.forceAudioOffloadingOnAndroid;
+
+  @HiveField(144, defaultValue: DefaultSettings.multichannelHandlingSetting)
+  MultichannelHandlingSetting multichannelHandlingSetting;
 
   static Future<FinampSettings> create() async {
     final downloadLocation = await DownloadLocation.create(
@@ -3962,4 +3967,19 @@ class FinampStorableQueueInfo extends FinampStorableQueueInfoLegacy {
   String toString() {
     return "previous:${previousTracks.length} current:$currentTrack seek:$currentTrackSeek next:${nextUp.length} queue:${queue.length} order:${packedShuffleOrder == null ? "linear" : "shuffled"} sources $sourceList";
   }
+}
+
+@HiveType(typeId: 111)
+enum MultichannelHandlingSetting {
+  @HiveField(0)
+  stereoDownmixLossy,
+  @HiveField(1)
+  stereoDownmixAll,
+  @HiveField(2)
+  fixedBitrate,
+  /**
+    reserved for potential automatic bitrate calculation
+  @HiveField(3)
+  dynamicBitrate,
+  **/
 }

--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -197,6 +197,9 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
         shouldTranscodeDownloads: fields[44] == null
             ? TranscodeDownloadsSetting.ask
             : fields[44] as TranscodeDownloadsSetting,
+        multichannelHandlingSetting: fields[144] == null
+            ? MultichannelHandlingSetting.stereoDownmixLossy
+            : fields[144] as MultichannelHandlingSetting,
         shouldRedownloadTranscodes: fields[46] == null
             ? false
             : fields[46] as bool,
@@ -462,7 +465,7 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
   @override
   void write(BinaryWriter writer, FinampSettings obj) {
     writer
-      ..writeByte(137)
+      ..writeByte(138)
       ..writeByte(0)
       ..write(obj.isOffline)
       ..writeByte(1)
@@ -736,7 +739,9 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       ..writeByte(142)
       ..write(obj.duckOnAudioInterruption)
       ..writeByte(143)
-      ..write(obj.forceAudioOffloadingOnAndroid);
+      ..write(obj.forceAudioOffloadingOnAndroid)
+      ..writeByte(144)
+      ..write(obj.multichannelHandlingSetting);
   }
 
   @override
@@ -3099,6 +3104,48 @@ class RadioModeAdapter extends TypeAdapter<RadioMode> {
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is RadioModeAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}
+
+class MultichannelHandlingSettingAdapter
+    extends TypeAdapter<MultichannelHandlingSetting> {
+  @override
+  final typeId = 111;
+
+  @override
+  MultichannelHandlingSetting read(BinaryReader reader) {
+    switch (reader.readByte()) {
+      case 0:
+        return MultichannelHandlingSetting.stereoDownmixLossy;
+      case 1:
+        return MultichannelHandlingSetting.stereoDownmixAll;
+      case 2:
+        return MultichannelHandlingSetting.fixedBitrate;
+      default:
+        return MultichannelHandlingSetting.stereoDownmixLossy;
+    }
+  }
+
+  @override
+  void write(BinaryWriter writer, MultichannelHandlingSetting obj) {
+    switch (obj) {
+      case MultichannelHandlingSetting.stereoDownmixLossy:
+        writer.writeByte(0);
+      case MultichannelHandlingSetting.stereoDownmixAll:
+        writer.writeByte(1);
+      case MultichannelHandlingSetting.fixedBitrate:
+        writer.writeByte(2);
+    }
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is MultichannelHandlingSettingAdapter &&
           runtimeType == other.runtimeType &&
           typeId == other.typeId;
 }

--- a/lib/screens/transcoding_settings_screen.dart
+++ b/lib/screens/transcoding_settings_screen.dart
@@ -39,6 +39,8 @@ class _TranscodingSettingsScreenState extends State<TranscodingSettingsScreen> {
           const DownloadTranscodeEnableDropdownListTile(),
           const DownloadTranscodeCodecDropdownListTile(),
           const DownloadBitrateSelector(),
+          Divider(),
+          const MultichannelHandlingSelector(),
         ],
       ),
     );
@@ -148,6 +150,29 @@ class StreamingTranscodingFormatDropdownListTile extends ConsumerWidget {
             onSelected: FinampSetters.setTranscodingStreamingFormat.ifNonNull,
           ),
         ],
+      ),
+    );
+  }
+}
+
+class MultichannelHandlingSelector extends ConsumerWidget {
+  const MultichannelHandlingSelector({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return ListTile(
+      title: Text(AppLocalizations.of(context)!.multichannelHandlingTitle),
+      subtitle: FinampSettingsDropdown<MultichannelHandlingSetting>(
+        dropdownItems: MultichannelHandlingSetting.values
+            .map(
+              (e) => DropdownMenuEntry<MultichannelHandlingSetting>(
+                value: e,
+                label: AppLocalizations.of(context)!.multichannelHandlingOption(e.name),
+              ),
+            )
+            .toList(),
+        selectedValue: ref.watch(finampSettingsProvider.multichannelHandlingSetting),
+        onSelected: FinampSetters.setMultichannelHandlingSetting.ifNonNull,
       ),
     );
   }

--- a/lib/screens/transcoding_settings_screen.dart
+++ b/lib/screens/transcoding_settings_screen.dart
@@ -162,17 +162,24 @@ class MultichannelHandlingSelector extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     return ListTile(
       title: Text(AppLocalizations.of(context)!.multichannelHandlingTitle),
-      subtitle: FinampSettingsDropdown<MultichannelHandlingSetting>(
-        dropdownItems: MultichannelHandlingSetting.values
-            .map(
-              (e) => DropdownMenuEntry<MultichannelHandlingSetting>(
-                value: e,
-                label: AppLocalizations.of(context)!.multichannelHandlingOption(e.name),
-              ),
-            )
-            .toList(),
-        selectedValue: ref.watch(finampSettingsProvider.multichannelHandlingSetting),
-        onSelected: FinampSetters.setMultichannelHandlingSetting.ifNonNull,
+      subtitle: Column(
+        spacing: 4.0,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(AppLocalizations.of(context)!.multichannelHandlingSubtitle),
+          FinampSettingsDropdown<MultichannelHandlingSetting>(
+            dropdownItems: MultichannelHandlingSetting.values
+                .map(
+                  (e) => DropdownMenuEntry<MultichannelHandlingSetting>(
+                    value: e,
+                    label: AppLocalizations.of(context)!.multichannelHandlingOption(e.name),
+                  ),
+                )
+                .toList(),
+            selectedValue: ref.watch(finampSettingsProvider.multichannelHandlingSetting),
+            onSelected: FinampSetters.setMultichannelHandlingSetting.ifNonNull,
+          ),
+        ],
       ),
     );
   }

--- a/lib/services/audio_service_smtc.dart
+++ b/lib/services/audio_service_smtc.dart
@@ -1,5 +1,5 @@
 import 'package:audio_service_platform_interface/audio_service_platform_interface.dart';
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/cupertino.dart' hide RepeatMode;
 import 'package:smtc_windows/smtc_windows.dart';
 
 class AudioServiceSMTC extends AudioServicePlatform {

--- a/lib/services/finamp_settings_helper.dart
+++ b/lib/services/finamp_settings_helper.dart
@@ -152,6 +152,7 @@ class FinampSettingsHelper {
     finampSettingsTemp.downloadTranscodingCodec =
         FinampTranscodingCodec.opus; // starts uninitilized, idk what value this should be
     finampSettingsTemp.downloadTranscodeBitrate = 128000; // starts uninitilized, idk what value this should be
+    finampSettingsTemp.multichannelHandlingSetting = DefaultSettings.multichannelHandlingSetting;
 
     Hive.box<FinampSettings>("FinampSettings").put("FinampSettings", finampSettingsTemp);
   }

--- a/lib/services/finamp_settings_helper.g.dart
+++ b/lib/services/finamp_settings_helper.g.dart
@@ -1248,6 +1248,17 @@ extension FinampSetters on FinampSettingsHelper {
     ).put("FinampSettings", finampSettingsTemp);
   }
 
+  static void setMultichannelHandlingSetting(
+    MultichannelHandlingSetting newMultichannelHandlingSetting,
+  ) {
+    FinampSettings finampSettingsTemp = FinampSettingsHelper.finampSettings;
+    finampSettingsTemp.multichannelHandlingSetting =
+        newMultichannelHandlingSetting;
+    Hive.box<FinampSettings>(
+      "FinampSettings",
+    ).put("FinampSettings", finampSettingsTemp);
+  }
+
   static void setBufferDuration(Duration newBufferDuration) {
     FinampSettings finampSettingsTemp = FinampSettingsHelper.finampSettings;
     finampSettingsTemp.bufferDuration = newBufferDuration;
@@ -1679,6 +1690,10 @@ extension FinampSettingsProviderSelectors on StreamProvider<FinampSettings> {
       finampSettingsProvider.select(
         (value) => value.requireValue.forceAudioOffloadingOnAndroid,
       );
+  ProviderListenable<MultichannelHandlingSetting>
+  get multichannelHandlingSetting => finampSettingsProvider.select(
+    (value) => value.requireValue.multichannelHandlingSetting,
+  );
   ProviderListenable<DownloadProfile> get downloadTranscodingProfile =>
       finampSettingsProvider.select(
         (value) => value.requireValue.downloadTranscodingProfile,

--- a/lib/services/jellyfin_api_helper.dart
+++ b/lib/services/jellyfin_api_helper.dart
@@ -1148,6 +1148,14 @@ class JellyfinApiHelper {
         "audioBitRate": transcodingProfile.stereoBitrate.toString(),
       });
 
+      if (FinampSettingsHelper.finampSettings.multichannelHandlingSetting ==
+              MultichannelHandlingSetting.stereoDownmixAll ||
+          (FinampSettingsHelper.finampSettings.multichannelHandlingSetting ==
+                  MultichannelHandlingSetting.stereoDownmixLossy &&
+              FinampSettingsHelper.finampSettings.transcodingStreamingFormat.codec != "flac")) {
+        queryParameters.addAll({"maxAudioChannels": "2"});
+      }
+
       uri = uri.replace(
         pathSegments: uri.pathSegments.followedBy(["Audio", item.id.raw, "Universal"]),
         queryParameters: queryParameters,

--- a/lib/services/music_player_background_task.dart
+++ b/lib/services/music_player_background_task.dart
@@ -1374,6 +1374,14 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler with SeekHandler, Queue
         "audioBitRate": FinampSettingsHelper.finampSettings.transcodeBitrate.toString(),
         "segmentContainer": FinampSettingsHelper.finampSettings.transcodingStreamingFormat.container,
       });
+
+      if (FinampSettingsHelper.finampSettings.multichannelHandlingSetting ==
+              MultichannelHandlingSetting.stereoDownmixAll ||
+          (FinampSettingsHelper.finampSettings.multichannelHandlingSetting ==
+                  MultichannelHandlingSetting.stereoDownmixLossy &&
+              FinampSettingsHelper.finampSettings.transcodingStreamingFormat.codec != "flac")) {
+        queryParameters.addAll({"maxAudioChannels": "2"});
+      }
     } else {
       builtPath.addAll(["Items", mediaItem.extras!["itemJson"]["Id"] as String, "File"]);
     }


### PR DESCRIPTION
## Changes
Since we're not adapting the bitrate to the number of channels, and have no setting to do so, transcodes will easily bitrate starve for Multichannel Audio (e.g. 5.1).

This adds a setting for the user to choose how they want to handle these Multichannel tracks:
- Downmix to Stereo
- Downmix only lossy transcodes to Stereo (Default)
- Keep all channels, respecting the Bitrate set for all encodes

This implementation leaves an option for future additions, such as a dynamic Bitrate allotment based on channel count or similar.

## Related Issues
- closes #1496
