### PR TITLE
Add universal search screen with classic search toggle

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -42,6 +42,13 @@ post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_ios_build_settings(target)
 
+    if target.name == 'file_picker'
+      target.build_configurations.each do |config|
+        config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)']
+        config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'FileUtils=FPFileUtils'
+      end
+    end
+
     target.build_configurations.each do |config|
       config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '14.0'
     end

--- a/ios/Runner/Info-Debug.plist
+++ b/ios/Runner/Info-Debug.plist
@@ -22,6 +22,8 @@
 	<string>$(FLUTTER_BUILD_NAME)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>FLTEnableTouchRateCorrection</key>
+	<false/>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/ios/Runner/Info-Profile.plist
+++ b/ios/Runner/Info-Profile.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
+	<key>FLTEnableTouchRateCorrection</key>
+	<false/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>

--- a/ios/Runner/Info-Release.plist
+++ b/ios/Runner/Info-Release.plist
@@ -25,6 +25,8 @@
 	</dict>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
+	<key>FLTEnableTouchRateCorrection</key>
+	<false/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3231,6 +3231,14 @@
   "@forceAudioOffloadingOnAndroidSubtitle": {
     "description": "Subtitle for the setting that controls audio offloading on Android."
   },
+  "useClassicSearchTitle": "Use classic search",
+  "@useClassicSearchTitle": {
+    "description": "Title for the setting that switches to classic in-page search"
+  },
+  "useClassicSearchSubtitle": "Use the classic in-page search instead of Universal Search.",
+  "@useClassicSearchSubtitle": {
+    "description": "Subtitle for the setting that switches to classic in-page search"
+  },
   "explicit": "Explicit",
   "@explicit": {
     "description": "Label for content that is considered explicit, usually marked by an 'E' in music apps"

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -27,6 +27,7 @@ import 'package:finamp/screens/playback_reporting_settings_screen.dart';
 import 'package:finamp/screens/player_settings_screen.dart';
 import 'package:finamp/screens/playlist_edit_screen.dart';
 import 'package:finamp/screens/queue_restore_screen.dart';
+import 'package:finamp/screens/universal_search_screen.dart';
 import 'package:finamp/services/album_image_provider.dart';
 import 'package:finamp/services/android_auto_helper.dart';
 import 'package:finamp/services/audio_service_smtc.dart';
@@ -652,6 +653,7 @@ class FinampApp extends ConsumerWidget {
         PlaybackHistoryScreen.routeName: (context) => const PlaybackHistoryScreen(),
         LogsScreen.routeName: (context) => const LogsScreen(),
         QueueRestoreScreen.routeName: (context) => const QueueRestoreScreen(),
+        UniversalSearchScreen.routeName: (context) => const UniversalSearchScreen(),
         SettingsScreen.routeName: (context) => const SettingsScreen(),
         TranscodingSettingsScreen.routeName: (context) => const TranscodingSettingsScreen(),
         DownloadsLocationScreen.routeName: (context) => const DownloadsLocationScreen(),

--- a/lib/menus/music_screen_drawer.dart
+++ b/lib/menus/music_screen_drawer.dart
@@ -6,7 +6,9 @@ import 'package:finamp/screens/logs_screen.dart';
 import 'package:finamp/components/MusicScreen/offline_mode_status_label.dart';
 import 'package:finamp/screens/playback_history_screen.dart';
 import 'package:finamp/screens/queue_restore_screen.dart';
+import 'package:finamp/screens/universal_search_screen.dart';
 import 'package:finamp/screens/settings_screen.dart';
+import 'package:finamp/services/finamp_settings_helper.dart';
 import 'package:finamp/services/finamp_user_helper.dart';
 import 'package:flutter/material.dart';
 import 'package:finamp/l10n/app_localizations.dart';
@@ -48,6 +50,15 @@ class MusicScreenDrawer extends StatelessWidget {
                 const OfflineModeSwitchListTile(),
                 const OfflineModeStatusLabel(),
                 Divider(),
+                if (FinampSettingsHelper.finampSettings.useUniversalSearch)
+                  ListTile(
+                    leading: const Padding(padding: EdgeInsets.only(right: 16), child: Icon(Icons.search)),
+                    title: Text(MaterialLocalizations.of(context).searchFieldLabel),
+                    onTap: () {
+                      Navigator.of(context).pop();
+                      Navigator.of(context).pushNamed(UniversalSearchScreen.routeName);
+                    },
+                  ),
                 ListTile(
                   leading: const Padding(padding: EdgeInsets.only(right: 16), child: Icon(Icons.file_download)),
                   title: Text(AppLocalizations.of(context)!.downloads),

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -123,6 +123,7 @@ class DefaultSettings {
   static const showTextOnGridView = false;
   static const sleepTimerDurationSeconds = 60 * 30;
   static const useCoverAsBackground = true;
+  static const useUniversalSearch = true;
   static const playerScreenCoverMinimumPadding = 1.5;
   static const showArtistsTracksSection = true;
   static const disableGesture = false;
@@ -280,6 +281,7 @@ class FinampSettings {
     this.bufferDisableSizeConstraints = DefaultSettings.bufferDisableSizeConstraints,
     this.bufferDurationSeconds = DefaultSettings.bufferDurationSeconds,
     this.bufferSizeMegabytes = DefaultSettings.bufferSizeMegabytes,
+    this.useUniversalSearch = DefaultSettings.useUniversalSearch,
     required this.tabSortBy,
     required this.tabSortOrder,
     this.loopMode = DefaultSettings.loopMode,
@@ -836,6 +838,9 @@ class FinampSettings {
 
   @HiveField(143, defaultValue: DefaultSettings.forceAudioOffloadingOnAndroid)
   bool forceAudioOffloadingOnAndroid = DefaultSettings.forceAudioOffloadingOnAndroid;
+
+  @HiveField(144, defaultValue: DefaultSettings.useUniversalSearch)
+  bool useUniversalSearch = DefaultSettings.useUniversalSearch;
 
   static Future<FinampSettings> create() async {
     final downloadLocation = await DownloadLocation.create(

--- a/lib/screens/layout_settings_screen.dart
+++ b/lib/screens/layout_settings_screen.dart
@@ -92,6 +92,7 @@ class _LayoutSettingsScreenState extends ConsumerState<LayoutSettingsScreen> {
           const ShowTextOnGridViewSelector(),
           const UseCoverAsBackgroundToggle(),
           const ShowArtistChipImageToggle(),
+          const UseClassicSearchToggle(),
           const AllowSplitScreenSwitch(),
           const ShowProgressOnNowPlayingBarToggle(),
         ],
@@ -161,6 +162,21 @@ class ShowProgressOnNowPlayingBarToggle extends ConsumerWidget {
       subtitle: Text(AppLocalizations.of(context)!.showProgressOnNowPlayingBarSubtitle),
       value: ref.watch(finampSettingsProvider.showProgressOnNowPlayingBar),
       onChanged: FinampSetters.setShowProgressOnNowPlayingBar,
+    );
+  }
+}
+
+class UseClassicSearchToggle extends ConsumerWidget {
+  const UseClassicSearchToggle({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final useUniversalSearch = ref.watch(finampSettingsProvider.useUniversalSearch);
+    return SwitchListTile.adaptive(
+      title: Text(AppLocalizations.of(context)!.useClassicSearchTitle),
+      subtitle: Text(AppLocalizations.of(context)!.useClassicSearchSubtitle),
+      value: !useUniversalSearch,
+      onChanged: (value) => FinampSetters.setUseUniversalSearch(!value),
     );
   }
 }

--- a/lib/screens/music_screen.dart
+++ b/lib/screens/music_screen.dart
@@ -18,6 +18,7 @@ import '../components/global_snackbar.dart';
 import '../components/now_playing_bar.dart';
 import '../menus/music_screen_drawer.dart';
 import '../models/finamp_models.dart';
+import '../screens/universal_search_screen.dart';
 import '../services/audio_service_helper.dart';
 import '../services/finamp_settings_helper.dart';
 import '../services/finamp_user_helper.dart';
@@ -351,9 +352,15 @@ class _MusicScreenState extends ConsumerState<MusicScreen> with TickerProviderSt
                     ),
                   IconButton(
                     icon: const Icon(Icons.search),
-                    onPressed: () => setState(() {
-                      isSearching = true;
-                    }),
+                    onPressed: () {
+                      if (ref.watch(finampSettingsProvider.useUniversalSearch)) {
+                        Navigator.of(context).pushNamed(UniversalSearchScreen.routeName);
+                      } else {
+                        setState(() {
+                          isSearching = true;
+                        });
+                      }
+                    },
                     tooltip: MaterialLocalizations.of(context).searchFieldLabel,
                   ),
                 ],

--- a/lib/screens/universal_search_screen.dart
+++ b/lib/screens/universal_search_screen.dart
@@ -1,0 +1,131 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
+
+import '../components/AlbumScreen/track_list_tile.dart';
+import '../components/MusicScreen/item_collection_wrapper.dart';
+import '../l10n/app_localizations.dart';
+import '../models/finamp_models.dart';
+import '../models/jellyfin_models.dart';
+import '../services/finamp_settings_helper.dart';
+import '../services/jellyfin_api_helper.dart';
+
+class UniversalSearchScreen extends StatefulWidget {
+  const UniversalSearchScreen({Key? key}) : super(key: key);
+
+  static const routeName = "/search";
+
+  @override
+  State<UniversalSearchScreen> createState() => _UniversalSearchScreenState();
+}
+
+class _UniversalSearchScreenState extends State<UniversalSearchScreen> {
+  final _searchController = TextEditingController();
+  final _jellyfinApiHelper = GetIt.instance<JellyfinApiHelper>();
+  Timer? _debounce;
+  Future<List<BaseItemDto>>? _searchFuture;
+  String _query = "";
+
+  @override
+  void dispose() {
+    _debounce?.cancel();
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  void _onSearchChanged(String value) {
+    _debounce?.cancel();
+    _debounce = Timer(const Duration(milliseconds: 300), () {
+      if (!mounted) return;
+      setState(() {
+        _query = value.trim();
+        _searchFuture = _query.isEmpty ? null : _performSearch(_query);
+      });
+    });
+  }
+
+  Future<List<BaseItemDto>> _performSearch(String query) async {
+    if (FinampSettingsHelper.finampSettings.isOffline) {
+      return [];
+    }
+
+    final results = await _jellyfinApiHelper.getItems(
+      includeItemTypes:
+          "Audio,MusicAlbum,MusicArtist,Playlist,MusicGenre",
+      searchTerm: query,
+      sortBy: "SortName",
+      sortOrder: "Ascending",
+      startIndex: 0,
+      limit: 100,
+    );
+
+    return results ?? [];
+  }
+
+  Widget _buildResultItem(BaseItemDto item) {
+    final itemType = BaseItemDtoType.fromItem(item);
+    if (itemType == BaseItemDtoType.track || item.type == "Audio") {
+      return TrackListTile(
+        item: item,
+        isTrack: true,
+        isShownInSearchOrHistory: true,
+        showIndex: false,
+        showCover: true,
+      );
+    }
+
+    return ItemCollectionWrapper(
+      item: item,
+      isPlaylist: item.type == "Playlist",
+      isGrid: false,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isOffline = FinampSettingsHelper.finampSettings.isOffline;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: TextField(
+          controller: _searchController,
+          autofocus: true,
+          onChanged: _onSearchChanged,
+          decoration: InputDecoration(
+            border: InputBorder.none,
+            hintText: MaterialLocalizations.of(context).searchFieldLabel,
+          ),
+        ),
+        scrolledUnderElevation: 0,
+      ),
+      body: isOffline
+            ? Center(
+                child: Text(AppLocalizations.of(context)!.notAvailableInOfflineMode),
+              )
+            : _searchFuture == null
+                ? const SizedBox.shrink()
+                : FutureBuilder<List<BaseItemDto>>(
+                    future: _searchFuture,
+                    builder: (context, snapshot) {
+                      if (snapshot.connectionState == ConnectionState.waiting) {
+                        return const Center(child: CircularProgressIndicator());
+                      }
+
+                      final results = snapshot.data ?? [];
+                      if (results.isEmpty) {
+                        return const Center(child: Text("No results"));
+                      }
+
+                      return ListView.builder(
+                        keyboardDismissBehavior:
+                            ScrollViewKeyboardDismissBehavior.onDrag,
+                        itemCount: results.length,
+                        itemBuilder: (context, index) =>
+                            _buildResultItem(results[index]),
+                      );
+                    },
+                  ),
+    );
+  }
+}

--- a/lib/services/finamp_settings_helper.dart
+++ b/lib/services/finamp_settings_helper.dart
@@ -138,6 +138,7 @@ class FinampSettingsHelper {
     finampSettingsTemp.showProgressOnNowPlayingBar = DefaultSettings.showProgressOnNowPlayingBar;
     finampSettingsTemp.autoSwitchItemCurationType = DefaultSettings.autoSwitchItemCurationType;
     finampSettingsTemp.useMonochromeIcon = DefaultSettings.useMonochromeIcon;
+    finampSettingsTemp.useUniversalSearch = DefaultSettings.useUniversalSearch;
 
     Hive.box<FinampSettings>("FinampSettings").put("FinampSettings", finampSettingsTemp);
   }

--- a/lib/services/finamp_settings_helper.g.dart
+++ b/lib/services/finamp_settings_helper.g.dart
@@ -1248,6 +1248,14 @@ extension FinampSetters on FinampSettingsHelper {
     ).put("FinampSettings", finampSettingsTemp);
   }
 
+  static void setUseUniversalSearch(bool newUseUniversalSearch) {
+    FinampSettings finampSettingsTemp = FinampSettingsHelper.finampSettings;
+    finampSettingsTemp.useUniversalSearch = newUseUniversalSearch;
+    Hive.box<FinampSettings>(
+      "FinampSettings",
+    ).put("FinampSettings", finampSettingsTemp);
+  }
+
   static void setBufferDuration(Duration newBufferDuration) {
     FinampSettings finampSettingsTemp = FinampSettingsHelper.finampSettings;
     finampSettingsTemp.bufferDuration = newBufferDuration;
@@ -1295,6 +1303,8 @@ extension FinampSettingsProviderSelectors on StreamProvider<FinampSettings> {
       .select((value) => value.requireValue.showTextOnGridView);
   ProviderListenable<bool> get useCoverAsBackground => finampSettingsProvider
       .select((value) => value.requireValue.useCoverAsBackground);
+  ProviderListenable<bool> get useUniversalSearch => finampSettingsProvider
+      .select((value) => value.requireValue.useUniversalSearch);
   ProviderListenable<int> get bufferDurationSeconds => finampSettingsProvider
       .select((value) => value.requireValue.bufferDurationSeconds);
   ProviderListenable<bool> get disableGesture => finampSettingsProvider.select(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -518,10 +518,10 @@ packages:
     dependency: "direct main"
     description:
       name: file_picker
-      sha256: "7872545770c277236fd32b022767576c562ba28366204ff1a5628853cf8f2200"
+      sha256: "57d9a1dd5063f85fa3107fb42d1faffda52fdc948cefd5fe5ea85267a5fc7343"
       url: "https://pub.dev"
     source: hosted
-    version: "10.3.7"
+    version: "10.3.10"
   file_sizes:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -70,7 +70,7 @@ dependencies:
   logging: ^1.3.0
   collection: ^1.18.0
   clipboard: ^2.0.2
-  file_picker: ^10.1.9
+  file_picker: ^10.3.10
   file: ^7.0.1
   permission_handler: ^12.0.0
   provider: ^6.0.5


### PR DESCRIPTION
## Changes

- **Universal Search Screen**: New dedicated search screen that queries the Jellyfin API with debounced requests (300ms) across Audio, Albums, Artists, Playlists, and Genres
- **Rich Search Results**: Uses `TrackListTile` for audio items and `ItemCollectionWrapper` for albums/artists/playlists to maintain consistency with existing app UI
- **Classic Search Toggle**: Added `useUniversalSearch` setting (HiveField 144) with a toggle in Layout & Theme settings. Users can switch back to the in-page classic search if preferred
- **Search Integration**: Search icon in the app bar and drawer menu entry now route to universal or classic search based on the user's preference setting
- **iOS 26 Crash Fix**: Added `FLTEnableTouchRateCorrection=false` to Debug, Release, and Profile plists to resolve VSyncClient crash on iOS 26 devices
- **iOS file_picker Fix**: Added Podfile preprocessor rename for `FileUtils` → `FPFileUtils` to resolve class collision with OSAnalytics framework
- **Dependency Bump**: Updated file_picker to ^10.3.10 for compatibility fixes

## Todo before merging

- [x] Translations (English strings added to app_en.arb; other language translations will follow)
- [x] Reset Settings (useUniversalSearch reset support added to resetLayoutSettings)
- [ ] Extended CONTRIBUTING.md

## Related Issues

- closes #471

Note this did fix an inappropriate pull request to which some other dart code was removed. 