### PR TITLE
Fix playback history reporting

### DIFF
--- a/lib/services/playback_history_service.dart
+++ b/lib/services/playback_history_service.dart
@@ -548,7 +548,12 @@ class PlaybackHistoryService {
     bool includeNowPlayingQueue = false,
     bool force = false,
   }) {
-    final currentTrack = _currentTrack?.item ?? _queueService.getCurrentTrack();
+    final queueTrack = _queueService.getCurrentTrack();
+    if (queueTrack != null && queueTrack.id != _currentTrack?.item.id) {
+      // Keep reporting in sync when queue changes outpace playback-state events.
+      updateCurrentTrack(queueTrack, forceNewTrack: true);
+    }
+    final currentTrack = _currentTrack?.item ?? queueTrack;
     if (currentTrack == null) {
       return null;
     }

--- a/lib/services/playback_history_service.dart
+++ b/lib/services/playback_history_service.dart
@@ -34,7 +34,6 @@ class PlaybackHistoryService {
   PlaybackState? _previousPlaybackState;
   DateTime _lastPositionUpdate = DateTime.now();
 
-  bool _wasOfflineBefore = false;
   FinampQueueItem?
   _lastReportedTrackStarted; // used to check if playback has already reported as "started" at some point for the current track
   FinampQueueItem? _lastReportedTrackStopped; // used to prevent reporting a track as stopped multiple times
@@ -67,7 +66,6 @@ class PlaybackHistoryService {
       if (!isOffline) {
         _updatePlaybackInfo();
       }
-      _wasOfflineBefore = FinampSettingsHelper.finampSettings.isOffline;
     });
 
     bool throttleRemoteSessionReporting = false;
@@ -520,7 +518,7 @@ class PlaybackHistoryService {
   }) {
     try {
       return jellyfin_models.PlaybackProgressInfo(
-        itemId: item.baseItem?.id ?? jellyfin_models.BaseItemId(""),
+        itemId: item.baseItem.id,
         playSessionId: item.item.extras?["playSessionId"] as String? ?? "",
         sessionId: _queueService.getQueue().id,
         isPaused: isPaused,
@@ -564,7 +562,7 @@ class PlaybackHistoryService {
 
     try {
       return jellyfin_models.PlaybackProgressInfo(
-        itemId: currentTrack.baseItem?.id ?? jellyfin_models.BaseItemId(""),
+        itemId: currentTrack.baseItem.id,
         playSessionId: currentTrack.item.extras?["playSessionId"] as String? ?? "",
         sessionId: _queueService.getQueue().id,
         canSeek: true,
@@ -592,7 +590,7 @@ class PlaybackHistoryService {
         (FinampSettingsHelper.finampSettings.enablePlayon || FinampSettingsHelper.finampSettings.reportQueueToServer)) {
       final queue = _queueService
           .peekQueue(next: _maxQueueLengthToReport)
-          .map((e) => jellyfin_models.QueueItem(id: e.baseItem?.id.raw ?? "", playlistItemId: e.type.name))
+          .map((e) => jellyfin_models.QueueItem(id: e.baseItem.id.raw, playlistItemId: e.type.name))
           .toList();
       return queue;
     } else {


### PR DESCRIPTION
Sometimes, after switching tracks, Finamp would send a `/Sessions/Playing/Progress` update for the previous track.

`generateGenericPlaybackProgressInfo()` could use an outdated `_currentTrack` when the queue changed faster than playback-state events. This patch syncs `_currentTrack` with `QueueService.getCurrentTrack()` before building the progress payload, so reports use the correct `ItemId`.