### PR TITLE
add amoled theme

### DIFF
--- a/lib/color_schemes.g.dart
+++ b/lib/color_schemes.g.dart
@@ -90,14 +90,20 @@ const darkColorScheme = ColorScheme(
 /// If [color] is provided -> returns a generated color scheme
 /// otherwise falls back to default color schemes
 /// [lightColorScheme] or [darkColorScheme]
-ColorScheme getColorScheme(Color? color, Brightness brightness) {
+ColorScheme getColorScheme(Color? color, Brightness brightness, bool amoledTheme) {
+  ColorScheme scheme = brightness == Brightness.dark ? darkColorScheme : lightColorScheme;
+
   if (color != null) {
-    return ColorScheme.fromSeed(
+    scheme = ColorScheme.fromSeed(
       seedColor: color,
       brightness: brightness,
       dynamicSchemeVariant: DynamicSchemeVariant.fidelity,
     );
   }
 
-  return brightness == Brightness.dark ? darkColorScheme : lightColorScheme;
+  if (amoledTheme && brightness == Brightness.dark) {
+    scheme = scheme.copyWith(background: Color(0xFF000000), surface: Color(0xFF000000));
+  }
+
+  return scheme;
 }

--- a/lib/components/LayoutSettingsScreen/accent_color_selector.dart
+++ b/lib/components/LayoutSettingsScreen/accent_color_selector.dart
@@ -78,6 +78,7 @@ class AccentColorPopup extends ConsumerStatefulWidget {
 
 class _AccentColorPopupState extends ConsumerState<AccentColorPopup> {
   Color? previewColor = FinampSettingsHelper.finampSettings.accentColor;
+  bool amoledTheme = FinampSettingsHelper.finampSettings.amoledTheme;
   late final controller = TextEditingController(text: previewColor?.toHex());
 
   void updatePreview(String value) => setState(() {
@@ -91,7 +92,9 @@ class _AccentColorPopupState extends ConsumerState<AccentColorPopup> {
 
   @override
   Widget build(BuildContext context) {
-    final previewTheme = Theme.of(context).withColorScheme(getColorScheme(previewColor, ref.watch(brightnessProvider)));
+    final previewTheme = Theme.of(
+      context,
+    ).withColorScheme(getColorScheme(previewColor, ref.watch(brightnessProvider), amoledTheme));
 
     return Theme(
       data: previewTheme,

--- a/lib/components/LayoutSettingsScreen/amoled_theme.dart
+++ b/lib/components/LayoutSettingsScreen/amoled_theme.dart
@@ -1,0 +1,18 @@
+import 'package:finamp/l10n/app_localizations.dart';
+import 'package:finamp/services/finamp_settings_helper.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class AmoledTheme extends ConsumerWidget {
+  const AmoledTheme({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return SwitchListTile.adaptive(
+      title: Text(AppLocalizations.of(context)!.amoledTheme),
+      subtitle: Text(AppLocalizations.of(context)!.amoledThemeSubtitle),
+      value: ref.watch(finampSettingsProvider.amoledTheme),
+      onChanged: (value) => FinampSetters.setAmoledTheme(value),
+    );
+  }
+}

--- a/lib/components/themed_bottom_sheet.dart
+++ b/lib/components/themed_bottom_sheet.dart
@@ -124,7 +124,11 @@ class _ThemedBottomSheetState extends ConsumerState<ThemedBottomSheet> {
             var (height, slivers) = widget.buildSlivers!(context);
             child = buildInternal(height, slivers);
           }
-          return ColoredBox(color: Theme.of(context).scaffoldBackgroundColor, child: child);
+          final colorScheme = ColorScheme.of(context);
+          return ColoredBox(
+            color: ElevationOverlay.applySurfaceTint(colorScheme.surface, colorScheme.surfaceTint, 1),
+            child: child,
+          );
         },
       ),
     );

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -2618,6 +2618,11 @@
     "@systemAccentColorHasPriorityInfo": {
         "description": "Text under the AccentColorTitle which is only visible when the system color is enabled since the system color will be prioritized over custom accent color"
     },
+    "amoledTheme": "AMOLED Theme benutzen",
+    "@amoledTheme": {
+        "description": "Schalter, welches dunkelgrau mit schwarz beim dunklen Farbschema ersetzt"
+    },
+    "amoledThemeSubtitle": "Ersetzt das dunkle Farbschema mit einem puren schwarzen Thema.",
     "useMonochromeIcon": "Monochromes Logo benutzen",
     "@useMonochromeIcon": {
         "description": "Toggles the Finamp icon between classic and it being monochromic. This does not change the outside-app-icon"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -740,6 +740,11 @@
   "@systemAccentColorHasPriorityInfo": {
     "description": "Text under the AccentColorTitle which is only visible when the system color is enabled since the system color will be prioritized over custom accent color"
   },
+  "amoledTheme": "Use AMOLED Theme",
+  "@amoledTheme": {
+    "description": "Toggles the dark color scheme between dark gray and pure black."
+  },
+  "amoledThemeSubtitle": "Replaces the dark color scheme with a pure black theme.",
   "useMonochromeIcon": "Use Monochrome Logo",
   "@useMonochromeIcon": {
     "description": "Toggles the Finamp icon between classic and it being monochromic. This does not change the outside-app-icon"

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -627,6 +627,7 @@ class FinampApp extends ConsumerWidget {
       useSystemTheme ? finampSettingsProvider.systemAccentColor : finampSettingsProvider.accentColor,
     );
     final themeMode = ref.watch(finampSettingsProvider.themeMode);
+    final amoledTheme = ref.watch(finampSettingsProvider.amoledTheme);
     final locale = ref.watch(finampSettingsProvider.locale);
     final transitionBuilder = MediaQuery.disableAnimationsOf(context)
         ? PageTransitionsTheme(
@@ -683,7 +684,7 @@ class FinampApp extends ConsumerWidget {
       },
       theme: ThemeData(
         brightness: Brightness.light,
-        colorScheme: getColorScheme(accentColor, Brightness.light),
+        colorScheme: getColorScheme(accentColor, Brightness.light, amoledTheme),
         appBarTheme: const AppBarThemeData(
           systemOverlayStyle: SystemUiOverlayStyle(
             statusBarBrightness: Brightness.light,
@@ -706,7 +707,7 @@ class FinampApp extends ConsumerWidget {
       ),
       darkTheme: ThemeData(
         brightness: Brightness.dark,
-        colorScheme: getColorScheme(accentColor, Brightness.dark),
+        colorScheme: getColorScheme(accentColor, Brightness.dark, amoledTheme),
         snackBarTheme: const SnackBarThemeData(
           //TODO get rid of floating action buttons and re-enable the floating behavior and insetPadding
           // behavior: SnackBarBehavior.floating,

--- a/lib/menus/music_screen_drawer.dart
+++ b/lib/menus/music_screen_drawer.dart
@@ -20,8 +20,10 @@ class MusicScreenDrawer extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final finampUserHelper = GetIt.instance<FinampUserHelper>();
+    final colorScheme = ColorScheme.of(context);
     return Drawer(
-      surfaceTintColor: Colors.white,
+      surfaceTintColor: colorScheme.surfaceTint,
+      backgroundColor: colorScheme.surface,
       child: ListTileTheme(
         // Shrink trailing padding from 24 to 8
         contentPadding: const EdgeInsetsDirectional.only(start: 16.0, end: 8.0),

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -104,6 +104,7 @@ class DefaultSettings {
   // FinampSettings's constructor and Hive's defaultValue.
   static const isOffline = false;
   static const themeMode = ThemeMode.system;
+  static const amoledTheme = false;
   static const Locale? locale = null;
   static const Color? accentColor = null;
   static const shouldTranscode = false;
@@ -383,6 +384,7 @@ class FinampSettings {
     this.lastUsedPlaybackActionRowPageForQueueMenu = DefaultSettings.lastUsedPlaybackActionRowPageForQueueMenu,
     this.accentColor = DefaultSettings.accentColor,
     this.themeMode = DefaultSettings.themeMode,
+    this.amoledTheme = DefaultSettings.amoledTheme,
     this.locale = DefaultSettings.locale,
     // !!! Don't touch this default value, it's supposed to be hard coded to run the migration only once
     this.hasCompletedThemeModeLocaleMigration = true,
@@ -846,6 +848,9 @@ class FinampSettings {
 
   @HiveField(145, defaultValue: DefaultSettings.previousTracksPersistenceMode)
   PreviousTracksPersistenceMode previousTracksPersistenceMode = DefaultSettings.previousTracksPersistenceMode;
+
+  @HiveField(146, defaultValue: DefaultSettings.amoledTheme)
+  bool amoledTheme = DefaultSettings.amoledTheme;
 
   static Future<FinampSettings> create() async {
     final downloadLocation = await DownloadLocation.create(

--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -450,6 +450,9 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
         previousTracksPersistenceMode: fields[145] == null
             ? PreviousTracksPersistenceMode.persistent
             : fields[145] as PreviousTracksPersistenceMode,
+        amoledTheme: fields[146] == null
+            ? false
+            : fields[146] as bool,
       )
       ..disableGesture = fields[19] == null ? false : fields[19] as bool
       ..showFastScroller = fields[25] == null ? true : fields[25] as bool
@@ -468,7 +471,7 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
   @override
   void write(BinaryWriter writer, FinampSettings obj) {
     writer
-      ..writeByte(139)
+      ..writeByte(140)
       ..writeByte(0)
       ..write(obj.isOffline)
       ..writeByte(1)
@@ -746,7 +749,9 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       ..writeByte(144)
       ..write(obj.multichannelHandlingSetting)
       ..writeByte(145)
-      ..write(obj.previousTracksPersistenceMode);
+      ..write(obj.previousTracksPersistenceMode)
+      ..writeByte(146)
+      ..write(obj.amoledTheme);
   }
 
   @override

--- a/lib/screens/layout_settings_screen.dart
+++ b/lib/screens/layout_settings_screen.dart
@@ -19,6 +19,7 @@ import '../components/LayoutSettingsScreen/show_artist_chip_image_toggle.dart';
 import '../components/LayoutSettingsScreen/show_text_on_grid_view_selector.dart';
 import '../components/LayoutSettingsScreen/theme_selector.dart';
 import '../components/LayoutSettingsScreen/use_cover_as_background_toggle.dart';
+import '../components/LayoutSettingsScreen/amoled_theme.dart';
 import '../services/finamp_settings_helper.dart';
 import 'tabs_settings_screen.dart';
 
@@ -79,6 +80,7 @@ class _LayoutSettingsScreenState extends ConsumerState<LayoutSettingsScreen> {
           ),
           const Divider(),
           const ThemeSelector(),
+          const AmoledTheme(),
           const UseMonochromeIcon(),
           const AccentColorSelector(),
           const AutomaticAccentColorSelector(),

--- a/lib/services/finamp_settings_helper.dart
+++ b/lib/services/finamp_settings_helper.dart
@@ -123,6 +123,7 @@ class FinampSettingsHelper {
     FinampSettings finampSettingsTemp = finampSettings;
 
     FinampSetters.setThemeMode(DefaultSettings.themeMode);
+    FinampSetters.setAmoledTheme(DefaultSettings.amoledTheme);
     FinampSetters.setAccentColor(DefaultSettings.accentColor);
     FinampSetters.setSystemAccentColor(DefaultSettings.accentColor);
     FinampSetters.setUseSystemAccentColor(DefaultSettings.useSystemAccentColor);

--- a/lib/services/finamp_settings_helper.g.dart
+++ b/lib/services/finamp_settings_helper.g.dart
@@ -1159,6 +1159,14 @@ extension FinampSetters on FinampSettingsHelper {
     ).put("FinampSettings", finampSettingsTemp);
   }
 
+  static void setAmoledTheme(bool newAmoledTheme) {
+    FinampSettings finampSettingsTemp = FinampSettingsHelper.finampSettings;
+    finampSettingsTemp.amoledTheme = newAmoledTheme;
+    Hive.box<FinampSettings>(
+      "FinampSettings",
+    ).put("FinampSettings", finampSettingsTemp);
+  }
+
   static void setLocale(Locale? newLocale) {
     FinampSettings finampSettingsTemp = FinampSettingsHelper.finampSettings;
     finampSettingsTemp.locale = newLocale;
@@ -1674,6 +1682,8 @@ extension FinampSettingsProviderSelectors on StreamProvider<FinampSettings> {
       finampSettingsProvider.select((value) => value.requireValue.accentColor);
   ProviderListenable<ThemeMode> get themeMode =>
       finampSettingsProvider.select((value) => value.requireValue.themeMode);
+  ProviderListenable<bool> get amoledTheme =>
+      finampSettingsProvider.select((value) => value.requireValue.amoledTheme);
   ProviderListenable<Locale?> get locale =>
       finampSettingsProvider.select((value) => value.requireValue.locale);
   ProviderListenable<bool> get hasCompletedThemeModeLocaleMigration =>


### PR DESCRIPTION
<!-- Just a reminder that text in these brackets is not visible in the rendered output.
You also do **not** need to use this template. You can remove and modify anything however you like!
Its just a suggestion :)
-->

## Changes
<!-- Please describe what this Pull request adds or changes. Possibly with images -->

| Disabled | Enabled |
| -------- | ------- |
| <img width="1080" height="2340" alt="Screenshot_FinampDebug_Disabled" src="https://github.com/user-attachments/assets/c2799290-7e5c-4b36-aaac-43e139cebbf1" /> | <img width="1080" height="2340" alt="Screenshot_FinampDebug_Enabled" src="https://github.com/user-attachments/assets/f74cd379-4631-4f45-b850-bf396ee51c6e" /> |

Hey, I've added a toggle to enable an AMOLED (pure black) theme that replaces the dark schemes with a darker version:
The background and surface are set to `0xFF000000`.

This option might improve battery life and looks a lot better on AMOLED displays in my opinion.

I've tried to add this feature before, but wasn't able to build the app.
Thanks to the _newly_ provided flake.nix file the build process got a lot easier for NixOS.

## Todo before merging
<!-- Add custom todos if deemed necessary to give others an overview on how far this PR is progressing -->

<!-- Did you add UI text? 
No? Just check or remove the box
Yes? Make sure you replace hardcoded strings with translations -->
- [x] Translations
<!-- Did you add settings to the settings screen?
No? Just check or remove the box 
Yes? Make sure they are resettable using the button on the respective page! (see finamp_settings_helper.dart)-->
- [x] Reset Settings
<!-- Did you run into problems?
No? Just check or remove the box
Yes? Look at the CONTRIBUTING.md, maybe you can add something to help others! -->
- [x] Extended CONTRIBUTING.md

## Related Issues
<!-- List relevant issues to this PR using a format like this
- closes #xyz 
- fixes #abc
- follow up to #pr-name
-->
Resolves #1229
