### PR TITLE
[Redesign] Add android gain effect disable

### DIFF
--- a/android/app/src/main/kotlin/com/unicornsonlsd/finamp/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/unicornsonlsd/finamp/MainActivity.kt
@@ -1,5 +1,7 @@
 package com.unicornsonlsd.finamp
 
+import android.app.UiModeManager
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.provider.Settings
@@ -18,6 +20,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
 
+
 class MainActivity : AudioServiceActivity() {
     companion object {
         private const val DOWNLOADS_SERVICE_CHANNEL = "com.unicornsonlsd.finamp/downloads_service"
@@ -25,6 +28,9 @@ class MainActivity : AudioServiceActivity() {
 
         private const val OUTPUT_SWITCHER_CHANNEL = "com.unicornsonlsd.finamp/output_switcher"
         private const val OUTPUT_SWITCHER_CHANNEL_LOG_TAG = "OutputSwitcherChannel"
+
+        private const val SET_NATIVE_THEME_CHANNEL = "com.unicornsonlsd.finamp/set_native_theme"
+        private const val SET_NATIVE_THEME_CHANNEL_LOG_TAG = "setNativeThemeChannel"
     }
 
     private lateinit var mediaRouter: MediaRouter
@@ -53,6 +59,40 @@ class MainActivity : AudioServiceActivity() {
                 }
                 else -> {
                     Log.e(DOWNLOADS_SERVICE_CHANNEL_LOG_TAG, "Method not found: '${call.method}'")
+                    result.notImplemented()
+                }
+            }
+        }
+        MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            SET_NATIVE_THEME_CHANNEL,
+        ).setMethodCallHandler { call, result ->
+            when (call.method) {
+                "setNativeThemeMode" -> {
+                    val uiManager: UiModeManager =
+                        getApplicationContext().getSystemService(Context.UI_MODE_SERVICE) as UiModeManager
+                    val targetMode = call.argument<Int?>("targetMode")
+                    when (targetMode) {
+                        0 -> {
+                            uiManager.setApplicationNightMode( UiModeManager.MODE_NIGHT_AUTO)
+                            result.success(null)
+                        }
+                        1 -> {
+                            uiManager.setApplicationNightMode( UiModeManager.MODE_NIGHT_NO)
+                            result.success(null)
+                        }
+                        2 -> {
+                            uiManager.setApplicationNightMode( UiModeManager.MODE_NIGHT_YES)
+                            result.success(null)
+                        }
+                        else -> {
+                            Log.e(SET_NATIVE_THEME_CHANNEL_LOG_TAG, "Method not found: '${call.method}'")
+                            result.notImplemented()
+                        }
+                    }
+                }
+                else -> {
+                    Log.e(SET_NATIVE_THEME_CHANNEL_LOG_TAG, "Method not found: '${call.method}'")
                     result.notImplemented()
                 }
             }

--- a/assets/com.unicornsonlsd.finamp.metainfo.xml
+++ b/assets/com.unicornsonlsd.finamp.metainfo.xml
@@ -5,11 +5,15 @@
   <summary>Open source Jellyfin music player</summary>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>MPL-2.0</project_license>
-  <recommends>
-    <control>pointing</control>
+  <supports>
     <control>keyboard</control>
+    <control>pointing</control>
     <control>touch</control>
-  </recommends>
+  </supports>
+  <requires>
+    <display_length side="shortest" compare="ge">250</display_length>
+    <display_length side="longest" compare="ge">400</display_length>
+  </requires>
   <developer id="com.unicornsonlsd">
     <name>
       jmshrv

--- a/lib/components/PlayerScreen/progress_slider.dart
+++ b/lib/components/PlayerScreen/progress_slider.dart
@@ -2,9 +2,9 @@ import 'dart:io';
 
 import 'package:audio_service/audio_service.dart';
 import 'package:finamp/components/print_duration.dart';
+import 'package:finamp/l10n/app_localizations.dart';
 import 'package:finamp/services/progress_state_stream.dart';
 import 'package:flutter/material.dart';
-import 'package:finamp/l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:get_it/get_it.dart';
 
@@ -54,6 +54,7 @@ class _ProgressSliderState extends State<ProgressSlider> {
             child: SliderTheme(
               data: SliderThemeData(trackHeight: 3.5, trackShape: CustomTrackShape()),
               child: StreamBuilder<ProgressState>(
+                initialData: progressState,
                 stream: progressStateStream,
                 builder: (context, snapshot) {
                   if (snapshot.data?.mediaItem == null) {
@@ -64,12 +65,19 @@ class _ProgressSliderState extends State<ProgressSlider> {
                     return widget.showPlaceholder
                         ? Column(
                             children: [
-                              Slider(
-                                value: 0,
-                                max: 1,
-                                onChanged: null,
-                                autofocus: false,
-                                focusNode: FocusNode(skipTraversal: true, canRequestFocus: false),
+                              SizedBox(
+                                height: 24.0,
+                                child: Stack(
+                                  children: [
+                                    Slider(
+                                      value: 0,
+                                      max: 1,
+                                      onChanged: null,
+                                      autofocus: false,
+                                      focusNode: FocusNode(skipTraversal: true, canRequestFocus: false),
+                                    ),
+                                  ],
+                                ),
                               ),
                               if (widget.showDuration) const _ProgressSliderDuration(position: Duration()),
                             ],

--- a/lib/components/global_snackbar.dart
+++ b/lib/components/global_snackbar.dart
@@ -198,6 +198,35 @@ class GlobalSnackbar {
     }
   }
 
+  /// Show a localized message to the user using the global context
+  static void popup(
+    (String, String) Function(BuildContext scaffold) message, {
+    bool isConfirmation = false,
+    SnackBarAction Function(BuildContext scaffold)? action,
+  }) => _enqueue(() => _popup(message, isConfirmation, action));
+  static void _popup(
+    (String, String) Function(BuildContext scaffold) message,
+    bool isConfirmation,
+    SnackBarAction Function(BuildContext scaffold)? action,
+  ) {
+    BuildContext context = materialAppNavigatorKey.currentContext!;
+    var text = message(context);
+    _logger.info("Displaying message: $text");
+    showDialog<void>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(text.$1),
+        content: Text(text.$2),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: Text(MaterialLocalizations.of(context).closeButtonLabel),
+          ),
+        ],
+      ),
+    );
+  }
+
   static const snackbarOptionsRoute = "/snackbar-options";
   static Future<void> showSnackbarOptionsMenu() async {
     if (materialAppNavigatorKey.currentContext == null) return;

--- a/lib/components/global_snackbar.dart
+++ b/lib/components/global_snackbar.dart
@@ -35,13 +35,20 @@ class GlobalSnackbar {
   /// startup completes.  If this happens, we delay executing the function
   /// until the MaterialApp has been set up.
   static void _enqueue(Function func) {
-    if (materialAppScaffoldKey.currentState != null && (materialAppNavigatorKey.currentContext?.mounted ?? false)) {
+    if (materialAppScaffoldKey.currentState != null && (materialAppScaffoldKey.currentContext?.mounted ?? false)) {
       // Schedule snackbar creation for as soon as possible outside of build()
-      SchedulerBinding.instance.scheduleTask(() => func(), Priority.touch);
+      SchedulerBinding.instance.scheduleTask(() {
+        if (materialAppScaffoldKey.currentState == null || !(materialAppScaffoldKey.currentContext?.mounted ?? false)) {
+          _logger.warning("Global Snackbar context unmounted during async gap.");
+          _enqueue(func);
+        } else {
+          func();
+        }
+      }, Priority.touch);
     } else {
       _queue.add(func);
       _timer ??= Timer.periodic(const Duration(seconds: 1), (timer) {
-        if (materialAppScaffoldKey.currentState != null && (materialAppNavigatorKey.currentContext?.mounted ?? false)) {
+        if (materialAppScaffoldKey.currentState != null && (materialAppScaffoldKey.currentContext?.mounted ?? false)) {
           timer.cancel();
           _timer = null;
           for (var queuedFunc in _queue) {
@@ -73,7 +80,7 @@ class GlobalSnackbar {
   /// Show a snackbar to the user using the global context
   static void show(SnackBar Function(BuildContext scaffold) snackbar) => _enqueue(() => _show(snackbar));
   static void _show(SnackBar Function(BuildContext scaffold) snackbar) {
-    materialAppScaffoldKey.currentState!.showSnackBar(snackbar(materialAppNavigatorKey.currentContext!));
+    materialAppScaffoldKey.currentState!.showSnackBar(snackbar(materialAppScaffoldKey.currentContext!));
   }
 
   /// Show a localized message to the user using the global context
@@ -87,7 +94,7 @@ class GlobalSnackbar {
     bool isConfirmation,
     SnackBarAction Function(BuildContext scaffold)? action,
   ) {
-    BuildContext context = materialAppNavigatorKey.currentContext!;
+    BuildContext context = materialAppScaffoldKey.currentContext!;
     var text = message(context);
     _logger.info("Displaying message: $text");
     materialAppScaffoldKey.currentState!.showSnackBar(
@@ -125,7 +132,7 @@ class GlobalSnackbar {
     }
 
     _logger.warning("Displaying error: $event", event);
-    BuildContext context = materialAppNavigatorKey.currentContext!;
+    BuildContext context = materialAppScaffoldKey.currentContext!;
     String errorText;
     if (event is Response) {
       if (event.statusCode == 401) {
@@ -209,7 +216,7 @@ class GlobalSnackbar {
     bool isConfirmation,
     SnackBarAction Function(BuildContext scaffold)? action,
   ) {
-    BuildContext context = materialAppNavigatorKey.currentContext!;
+    BuildContext context = materialAppScaffoldKey.currentContext!;
     var text = message(context);
     _logger.info("Displaying message: $text");
     showDialog<void>(
@@ -229,7 +236,7 @@ class GlobalSnackbar {
 
   static const snackbarOptionsRoute = "/snackbar-options";
   static Future<void> showSnackbarOptionsMenu() async {
-    if (materialAppNavigatorKey.currentContext == null) return;
+    if (materialAppScaffoldKey.currentContext == null) return;
     FeedbackHelper.feedback(FeedbackType.selection);
 
     // Normal menu entries, excluding headers
@@ -262,7 +269,7 @@ class GlobalSnackbar {
     }
 
     await showThemedBottomSheet(
-      context: materialAppNavigatorKey.currentContext!,
+      context: materialAppScaffoldKey.currentContext!,
       routeName: snackbarOptionsRoute,
       minDraggableHeight: 0.15,
       buildSlivers: getMenuProperties,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3296,7 +3296,7 @@
   "@useAndroidGainEffectTitle": {
     "description": "Title for Android gain effect setting.  This setting is used to work around player errors on some devices."
   },
-  "useAndroidGainEffectSubtitle": "Use native gain effect to control volume.  This is more flexible but breaks the player on some devices.  You shouldn't need to change this manually.",
+  "useAndroidGainEffectSubtitle": "Use native gain effect to control volume.  This is more flexible but breaks the player on some devices.  You shouldn't need to change this manually.  Requires app restart to apply.",
   "@useAndroidGainEffectSubtitle": {
     "description": "Subtitle for Android gain effect setting.  This setting is used to work around player errors on some devices."
   },

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3291,5 +3291,21 @@
   "previousTracksPersistenceModeExpanded": "Expanded (visible)",
   "@previousTracksPersistenceModeExpanded": {
     "description": "Overrides saved value to expand previous tracks header on queue list open"
+  },
+  "useAndroidGainEffectTitle": "Use Gain Effect",
+  "@useAndroidGainEffectTitle": {
+    "description": "Title for Android gain effect setting.  This setting is used to work around player errors on some devices."
+  },
+  "useAndroidGainEffectSubtitle": "Use native gain effect to control volume.  This is more flexible but breaks the player on some devices.  You shouldn't need to change this manually.",
+  "@useAndroidGainEffectSubtitle": {
+    "description": "Subtitle for Android gain effect setting.  This setting is used to work around player errors on some devices."
+  },
+  "androidGainDisabled": "Enabling gain effect fallback due to error.  Please restart app.",
+  "@androidGainDisabled": {
+    "description": "Message presented when the android gain effect fallback is enabled after an error occurs."
+  },
+  "errorRestart": "Error - Restart Required",
+  "@errorRestart": {
+    "description": "Warning shown on an unrecoverable error."
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3300,12 +3300,8 @@
   "@useAndroidGainEffectSubtitle": {
     "description": "Subtitle for Android gain effect setting.  This setting is used to work around player errors on some devices."
   },
-  "androidGainDisabled": "Enabling gain effect fallback due to error.  Please restart app.",
+  "androidGainDisabled": "Switching to gain effect fallback due to initialization error.",
   "@androidGainDisabled": {
     "description": "Message presented when the android gain effect fallback is enabled after an error occurs."
-  },
-  "errorRestart": "Error - Restart Required",
-  "@errorRestart": {
-    "description": "Warning shown on an unrecoverable error."
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -368,6 +368,21 @@ Future<void> _setupOSIntegration() async {
       albumBuffer.asUint8List(albumImageBytes.offsetInBytes, albumImageBytes.lengthInBytes),
     );
   }
+
+  if (Platform.isAndroid) {
+    var themeModeChannel = MethodChannel("com.unicornsonlsd.finamp/set_native_theme");
+    GetIt.instance<ProviderContainer>().listen(finampSettingsProvider.themeMode, (_, mode) {
+      _mainLog.info("Setting android native theme to $mode");
+      themeModeChannel.invokeMethod("setNativeThemeMode", {
+        "targetMode": switch (mode) {
+          ThemeMode.system => 0,
+          ThemeMode.light => 1,
+          ThemeMode.dark => 2,
+        },
+      });
+      // Fire on startup to correct desyncs and apply migration
+    }, fireImmediately: true);
+  }
 }
 
 Future<void> _setupPlaybackServices() async {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -541,10 +541,10 @@ class _FinampState extends State<Finamp> with WindowListener {
     SchedulerBinding.instance.addPostFrameCallback((_) {
       _uriLinkSubscription = AppLinks().uriLinkStream.listen((uri) async {
         linkHandlingLogger.info("Received link: $uri");
-        var context = GlobalSnackbar.materialAppNavigatorKey.currentContext;
-        if (context != null) {
+        var state = GlobalSnackbar.materialAppNavigatorKey.currentState;
+        if (state != null) {
           if (uri.host == "internal") {
-            await Navigator.of(context).pushNamed(uri.path);
+            await state.pushNamed(uri.path);
           }
         } else {
           linkHandlingLogger.warning("No context available to handle link");

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,7 +4,6 @@ import 'dart:ui';
 
 import 'package:app_links/app_links.dart';
 import 'package:audio_service/audio_service.dart';
-import 'package:audio_session/audio_session.dart';
 import 'package:background_downloader/background_downloader.dart';
 import 'package:finamp/color_schemes.g.dart';
 import 'package:finamp/components/Buttons/cta_medium.dart';
@@ -36,7 +35,6 @@ import 'package:finamp/services/dbus_manager.dart';
 import 'package:finamp/services/discord_rpc.dart';
 import 'package:finamp/services/downloads_service.dart';
 import 'package:finamp/services/downloads_service_backend.dart';
-import 'package:finamp/services/feedback_helper.dart';
 import 'package:finamp/services/finamp_logs_helper.dart';
 import 'package:finamp/services/finamp_settings_helper.dart';
 import 'package:finamp/services/finamp_user_helper.dart';
@@ -164,6 +162,14 @@ void main() async {
 
     PlatformDispatcher.instance.onError = (error, stack) {
       flutterLogger.severe(error, error, stack);
+
+      if (error.toString().contains('audiofx\.LoudnessEnhancer\.setTargetGain')) {
+        FinampSetters.setUseAndroidGainEffect(false);
+        GlobalSnackbar.popup(
+          (context) => (AppLocalizations.of(context)!.errorRestart, AppLocalizations.of(context)!.androidGainDisabled),
+        );
+      }
+
       // We have not handled printing to console, flutter should still do that.
       return false;
     };

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -163,14 +163,6 @@ void main() async {
     PlatformDispatcher.instance.onError = (error, stack) {
       flutterLogger.severe(error, error, stack);
 
-      // If we recieve a PlatformException from the loudness enhancer effect, disable and prompt to restart
-      if (error.toString().contains('audiofx\.LoudnessEnhancer\.setTargetGain')) {
-        FinampSetters.setUseAndroidGainEffect(false);
-        GlobalSnackbar.popup(
-          (context) => (AppLocalizations.of(context)!.errorRestart, AppLocalizations.of(context)!.androidGainDisabled),
-        );
-      }
-
       // We have not handled printing to console, flutter should still do that.
       return false;
     };

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -163,6 +163,7 @@ void main() async {
     PlatformDispatcher.instance.onError = (error, stack) {
       flutterLogger.severe(error, error, stack);
 
+      // If we recieve a PlatformException from the loudness enhancer effect, disable and prompt to restart
       if (error.toString().contains('audiofx\.LoudnessEnhancer\.setTargetGain')) {
         FinampSetters.setUseAndroidGainEffect(false);
         GlobalSnackbar.popup(

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -249,6 +249,7 @@ class DefaultSettings {
   static const duckOnAudioInterruption = true;
   static const forceAudioOffloadingOnAndroid = false;
   static const previousTracksPersistenceMode = PreviousTracksPersistenceMode.persistent;
+  static const useAndroidGainEffect = true;
 }
 
 @HiveType(typeId: 28)
@@ -392,6 +393,7 @@ class FinampSettings {
     this.duckOnAudioInterruption = DefaultSettings.duckOnAudioInterruption,
     this.forceAudioOffloadingOnAndroid = DefaultSettings.forceAudioOffloadingOnAndroid,
     this.previousTracksPersistenceMode = DefaultSettings.previousTracksPersistenceMode,
+    this.useAndroidGainEffect = DefaultSettings.useAndroidGainEffect,
   });
 
   @HiveField(0, defaultValue: DefaultSettings.isOffline)
@@ -846,6 +848,9 @@ class FinampSettings {
 
   @HiveField(145, defaultValue: DefaultSettings.previousTracksPersistenceMode)
   PreviousTracksPersistenceMode previousTracksPersistenceMode = DefaultSettings.previousTracksPersistenceMode;
+
+  @HiveField(146, defaultValue: DefaultSettings.useAndroidGainEffect)
+  bool useAndroidGainEffect;
 
   static Future<FinampSettings> create() async {
     final downloadLocation = await DownloadLocation.create(

--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -450,6 +450,7 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
         previousTracksPersistenceMode: fields[145] == null
             ? PreviousTracksPersistenceMode.persistent
             : fields[145] as PreviousTracksPersistenceMode,
+        useAndroidGainEffect: fields[146] == null ? true : fields[146] as bool,
       )
       ..disableGesture = fields[19] == null ? false : fields[19] as bool
       ..showFastScroller = fields[25] == null ? true : fields[25] as bool
@@ -468,7 +469,7 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
   @override
   void write(BinaryWriter writer, FinampSettings obj) {
     writer
-      ..writeByte(139)
+      ..writeByte(140)
       ..writeByte(0)
       ..write(obj.isOffline)
       ..writeByte(1)
@@ -746,7 +747,9 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       ..writeByte(144)
       ..write(obj.multichannelHandlingSetting)
       ..writeByte(145)
-      ..write(obj.previousTracksPersistenceMode);
+      ..write(obj.previousTracksPersistenceMode)
+      ..writeByte(146)
+      ..write(obj.useAndroidGainEffect);
   }
 
   @override

--- a/lib/screens/player_screen.dart
+++ b/lib/screens/player_screen.dart
@@ -221,6 +221,7 @@ class _PlayerScreenContent extends ConsumerWidget {
                             width: controller.albumSize.width,
                             height: controller.albumSize.height,
                             child: Padding(
+                              // TODO Why does landscape get an additional 3% on top of minAlbumPadding?
                               padding: EdgeInsets.only(
                                 left: constraints.maxHeight * 0.03,
                                 top: constraints.maxHeight * 0.03,

--- a/lib/screens/volume_normalization_settings_screen.dart
+++ b/lib/screens/volume_normalization_settings_screen.dart
@@ -3,29 +3,24 @@ import 'dart:io';
 import 'package:finamp/l10n/app_localizations.dart';
 import 'package:finamp/services/finamp_settings_helper.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../components/VolumeNormalizationSettingsScreen/volume_normalization_ios_base_gain_editor.dart';
 import '../components/VolumeNormalizationSettingsScreen/volume_normalization_mode_selector.dart';
 import '../components/VolumeNormalizationSettingsScreen/volume_normalization_switch.dart';
 
-class VolumeNormalizationSettingsScreen extends StatefulWidget {
+class VolumeNormalizationSettingsScreen extends ConsumerWidget {
   const VolumeNormalizationSettingsScreen({super.key});
   static const routeName = "/settings/volume-normalization";
-  @override
-  State<VolumeNormalizationSettingsScreen> createState() => _VolumeNormalizationSettingsScreenState();
-}
 
-class _VolumeNormalizationSettingsScreenState extends State<VolumeNormalizationSettingsScreen> {
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
       appBar: AppBar(
         title: Text(AppLocalizations.of(context)!.volumeNormalizationSettingsTitle),
         actions: [
           FinampSettingsHelper.makeSettingsResetButtonWithDialog(context, () {
-            setState(() {
-              FinampSettingsHelper.resetNormalizationSettings();
-            });
+            FinampSettingsHelper.resetNormalizationSettings();
           }),
         ],
       ),
@@ -33,10 +28,26 @@ class _VolumeNormalizationSettingsScreenState extends State<VolumeNormalizationS
         padding: const EdgeInsets.only(bottom: 200.0),
         children: [
           const VolumeNormalizationSwitch(),
-          if (!Platform.isAndroid) const VolumeNormalizationIOSBaseGainEditor(),
+          if (Platform.isAndroid) const UseAndroidGainEffectSwitch(),
+          if (!Platform.isAndroid || !ref.watch(finampSettingsProvider.useAndroidGainEffect))
+            const VolumeNormalizationIOSBaseGainEditor(),
           const VolumeNormalizationModeSelector(),
         ],
       ),
+    );
+  }
+}
+
+class UseAndroidGainEffectSwitch extends ConsumerWidget {
+  const UseAndroidGainEffectSwitch({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return SwitchListTile.adaptive(
+      title: Text(AppLocalizations.of(context)!.useAndroidGainEffectTitle),
+      subtitle: Text(AppLocalizations.of(context)!.useAndroidGainEffectSubtitle),
+      value: ref.watch(finampSettingsProvider.useAndroidGainEffect),
+      onChanged: FinampSetters.setUseAndroidGainEffect,
     );
   }
 }

--- a/lib/services/finamp_settings_helper.g.dart
+++ b/lib/services/finamp_settings_helper.g.dart
@@ -1270,6 +1270,14 @@ extension FinampSetters on FinampSettingsHelper {
     ).put("FinampSettings", finampSettingsTemp);
   }
 
+  static void setUseAndroidGainEffect(bool newUseAndroidGainEffect) {
+    FinampSettings finampSettingsTemp = FinampSettingsHelper.finampSettings;
+    finampSettingsTemp.useAndroidGainEffect = newUseAndroidGainEffect;
+    Hive.box<FinampSettings>(
+      "FinampSettings",
+    ).put("FinampSettings", finampSettingsTemp);
+  }
+
   static void setBufferDuration(Duration newBufferDuration) {
     FinampSettings finampSettingsTemp = FinampSettingsHelper.finampSettings;
     finampSettingsTemp.bufferDuration = newBufferDuration;
@@ -1709,6 +1717,8 @@ extension FinampSettingsProviderSelectors on StreamProvider<FinampSettings> {
   get previousTracksPersistenceMode => finampSettingsProvider.select(
     (value) => value.requireValue.previousTracksPersistenceMode,
   );
+  ProviderListenable<bool> get useAndroidGainEffect => finampSettingsProvider
+      .select((value) => value.requireValue.useAndroidGainEffect);
   ProviderListenable<DownloadProfile> get downloadTranscodingProfile =>
       finampSettingsProvider.select(
         (value) => value.requireValue.downloadTranscodingProfile,

--- a/lib/services/music_player_background_task.dart
+++ b/lib/services/music_player_background_task.dart
@@ -287,7 +287,7 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler with SeekHandler, Queue
     _androidAudioEffects = [];
     _iosAudioEffects = [];
 
-    if (Platform.isAndroid) {
+    if (Platform.isAndroid && FinampSettingsHelper.finampSettings.useAndroidGainEffect) {
       _loudnessEnhancerEffect = AndroidLoudnessEnhancer();
       _androidAudioEffects.add(_loudnessEnhancerEffect!);
     } else {
@@ -402,7 +402,7 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler with SeekHandler, Queue
     iosBaseVolumeGainFactor =
         pow(10.0, FinampSettingsHelper.finampSettings.volumeNormalizationIOSBaseGain / 20.0)
             as double; // https://sound.stackexchange.com/questions/38722/convert-db-value-to-linear-scale
-    if (!Platform.isAndroid) {
+    if (_loudnessEnhancerEffect == null) {
       _volumeNormalizationLogger.info("non-Android base volume gain factor: $iosBaseVolumeGainFactor");
     }
 
@@ -1127,8 +1127,8 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler with SeekHandler, Queue
         "normalization gain for '${baseItem.name}': $effectiveGainChange (track gain change: ${baseItem.normalizationGain})",
       );
       if (effectiveGainChange != null) {
-        if (Platform.isAndroid) {
-          _loudnessEnhancerEffect?.setTargetGain(effectiveGainChange);
+        if (_loudnessEnhancerEffect != null) {
+          _loudnessEnhancerEffect.setTargetGain(effectiveGainChange);
         } else {
           final newVolume =
               iosBaseVolumeGainFactor *
@@ -1140,9 +1140,9 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler with SeekHandler, Queue
           _volume.setReplayGainVolume(newVolume);
         }
       } else {
-        if (Platform.isAndroid) {
+        if (_loudnessEnhancerEffect != null) {
           // reset gain offset
-          _loudnessEnhancerEffect?.setTargetGain(0);
+          _loudnessEnhancerEffect.setTargetGain(0);
         }
         _volume.setReplayGainVolume(
           iosBaseVolumeGainFactor,

--- a/lib/services/music_player_background_task.dart
+++ b/lib/services/music_player_background_task.dart
@@ -396,8 +396,16 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler with SeekHandler, Queue
       audioPipeline: _audioPipeline,
     );
 
-    _loudnessEnhancerEffect?.setEnabled(FinampSettingsHelper.finampSettings.volumeNormalizationActive);
-    _loudnessEnhancerEffect?.setTargetGain(0.0);
+    try {
+      _loudnessEnhancerEffect?.setEnabled(FinampSettingsHelper.finampSettings.volumeNormalizationActive);
+      _loudnessEnhancerEffect?.setTargetGain(0.0);
+    } catch (_) {
+      // Assume we've hit https://github.com/UnicornsOnLSD/finamp/issues/1343 and disable loudness enhancer effect permanently
+      FinampSetters.setUseAndroidGainEffect(false);
+      _loudnessEnhancerEffect = null;
+      GlobalSnackbar.message((context) => AppLocalizations.of(context)!.androidGainDisabled);
+    }
+
     // calculate base volume gain for iOS as a linear factor, because just_audio doesn't yet support AudioEffect on iOS
     iosBaseVolumeGainFactor =
         pow(10.0, FinampSettingsHelper.finampSettings.volumeNormalizationIOSBaseGain / 20.0)

--- a/lib/services/progress_state_stream.dart
+++ b/lib/services/progress_state_stream.dart
@@ -23,3 +23,12 @@ Stream<ProgressState> get progressStateStream {
     (mediaItem, playbackState, position) => ProgressState(mediaItem, playbackState, position),
   );
 }
+
+ProgressState? get progressState {
+  final audioHandler = GetIt.instance<MusicPlayerBackgroundTask>();
+  return ProgressState(
+    audioHandler.mediaItem.value,
+    audioHandler.playbackState.value,
+    audioHandler.playbackState.value.position,
+  );
+}


### PR DESCRIPTION
Adds a setting to force android devices to use the basic volume control for replay gain instead of the loudness enhancer effect, and a fallback to enable automatically on error  This is a workaround for #1343.  This is currently untested due to the hardware dependency, but I felt like throwing a potential fix together because it seems someone new has hit this error on discord.