### PR TITLE
Add support for mTLS client certificates

### DIFF
--- a/android/app/src/main/kotlin/com/unicornsonlsd/finamp/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/unicornsonlsd/finamp/MainActivity.kt
@@ -3,12 +3,15 @@ package com.unicornsonlsd.finamp
 import android.app.UiModeManager
 import android.content.Intent
 import android.content.Intent.CATEGORY_APP_MUSIC
+import android.os.Build
 import android.os.Bundle
+import android.provider.MediaStore.INTENT_ACTION_MUSIC_PLAYER
 import android.provider.Settings
 import android.system.ErrnoException
 import android.system.Os
 import android.util.Log
 import androidx.annotation.WorkerThread
+import androidx.core.net.toUri
 import androidx.lifecycle.lifecycleScope
 import androidx.mediarouter.app.SystemOutputSwitcherDialogController
 import androidx.mediarouter.media.MediaRouter
@@ -18,17 +21,21 @@ import io.flutter.plugin.common.MethodChannel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.io.ByteArrayInputStream
 import java.io.File
-import android.os.Build
-import android.provider.MediaStore.INTENT_ACTION_MUSIC_PLAYER
-import androidx.core.net.toUri
+import java.security.KeyStore
+import javax.net.ssl.HttpsURLConnection
+import javax.net.ssl.KeyManagerFactory
+import javax.net.ssl.SSLContext
 
 
 class MainActivity : AudioServiceActivity() {
     companion object {
+        private const val CLIENT_CERT_CHANNEL = "com.unicornsonlsd.finamp/client_certificate"
+        private const val CLIENT_CERT_CHANNEL_LOG_TAG = "ClientCertChannel"
+
         private const val DOWNLOADS_SERVICE_CHANNEL = "com.unicornsonlsd.finamp/downloads_service"
         private const val DOWNLOADS_SERVICE_CHANNEL_LOG_TAG = "DownloadsServiceChannel"
-        private const val INTENT_CHANNEL_LOG_TAG = "intentChannel"
 
         private const val OUTPUT_SWITCHER_CHANNEL = "com.unicornsonlsd.finamp/output_switcher"
         private const val OUTPUT_SWITCHER_CHANNEL_LOG_TAG = "OutputSwitcherChannel"
@@ -51,15 +58,74 @@ class MainActivity : AudioServiceActivity() {
         super.onNewIntent(intent)
     }
 
-    private fun updateIntent(intent: Intent){
-        if((intent.action==INTENT_ACTION_MUSIC_PLAYER || intent.action==CATEGORY_APP_MUSIC)
-            &&intent.data==null){
+    private fun updateIntent(intent: Intent) {
+        if (
+            (intent.action == INTENT_ACTION_MUSIC_PLAYER || intent.action == CATEGORY_APP_MUSIC) &&
+            intent.data == null
+        ) {
             intent.data = "finamp://play/surprisemix".toUri()
         }
     }
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
+        MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            CLIENT_CERT_CHANNEL,
+        ).setMethodCallHandler { call, result ->
+            when (call.method) {
+                "installClientCertificate" -> {
+                    val bytes = call.argument<ByteArray>("bytes")
+                    val password = call.argument<String>("password")
+                    if (bytes == null || password == null) {
+                        result.error("INVALID_ARGS", "bytes and password are required", null)
+                        return@setMethodCallHandler
+                    }
+                    lifecycleScope.launch {
+                        withContext(Dispatchers.IO) {
+                            try {
+                                installClientCertificate(bytes, password)
+
+                                Log.i(
+                                    CLIENT_CERT_CHANNEL_LOG_TAG,
+                                    "Client certificate installed in Android SSL context"
+                                )
+                                result.success(null)
+                            } catch (e: Exception) {
+                                Log.e(
+                                    CLIENT_CERT_CHANNEL_LOG_TAG,
+                                    "Failed to install client certificate",
+                                    e
+                                )
+                                result.error("CERT_ERROR", e.message, null)
+                            }
+                        }
+                    }
+                }
+                "clearClientCertificate" -> {
+                    lifecycleScope.launch {
+                        withContext(Dispatchers.IO) {
+                            try {
+                                clearClientCertificate()
+
+                                Log.i(
+                                    CLIENT_CERT_CHANNEL_LOG_TAG,
+                                    "Client certificate cleared from Android SSL context"
+                                )
+                                result.success(null)
+                            } catch (e: Exception) {
+                                Log.e(CLIENT_CERT_CHANNEL_LOG_TAG, "Failed to clear client certificate", e)
+                                result.error("CERT_ERROR", e.message, null)
+                            }
+                        }
+                    }
+                }
+                else -> {
+                    Log.e(CLIENT_CERT_CHANNEL_LOG_TAG, "Method not found: '${call.method}'")
+                    result.notImplemented()
+                }
+            }
+        }
         MethodChannel(
             flutterEngine.dartExecutor.binaryMessenger,
             DOWNLOADS_SERVICE_CHANNEL,
@@ -99,15 +165,15 @@ class MainActivity : AudioServiceActivity() {
                     val targetMode = call.argument<Int?>("targetMode")
                     when (targetMode) {
                         0 -> {
-                            uiManager.setApplicationNightMode( UiModeManager.MODE_NIGHT_AUTO)
+                            uiManager.setApplicationNightMode(UiModeManager.MODE_NIGHT_AUTO)
                             result.success(null)
                         }
                         1 -> {
-                            uiManager.setApplicationNightMode( UiModeManager.MODE_NIGHT_NO)
+                            uiManager.setApplicationNightMode(UiModeManager.MODE_NIGHT_NO)
                             result.success(null)
                         }
                         2 -> {
-                            uiManager.setApplicationNightMode( UiModeManager.MODE_NIGHT_YES)
+                            uiManager.setApplicationNightMode(UiModeManager.MODE_NIGHT_YES)
                             result.success(null)
                         }
                         else -> {
@@ -187,6 +253,27 @@ class MainActivity : AudioServiceActivity() {
                 }
             }
         }
+    }
+
+    private fun installClientCertificate(bytes: ByteArray, password: String) {
+        val keyStore = KeyStore.getInstance("PKCS12")
+        keyStore.load(ByteArrayInputStream(bytes), password.toCharArray())
+
+        val keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm())
+        keyManagerFactory.init(keyStore, password.toCharArray())
+
+        val sslContext = SSLContext.getInstance("TLS")
+        sslContext.init(keyManagerFactory.keyManagers, null, null)
+
+        SSLContext.setDefault(sslContext)
+        HttpsURLConnection.setDefaultSSLSocketFactory(sslContext.socketFactory)
+    }
+
+    private fun clearClientCertificate() {
+        val defaultContext = SSLContext.getInstance("TLS")
+        defaultContext.init(null, null, null)
+        SSLContext.setDefault(defaultContext)
+        HttpsURLConnection.setDefaultSSLSocketFactory(defaultContext.socketFactory)
     }
 
     /**

--- a/android/app/src/main/kotlin/com/unicornsonlsd/finamp/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/unicornsonlsd/finamp/MainActivity.kt
@@ -16,10 +16,18 @@ import io.flutter.plugin.common.MethodChannel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.io.ByteArrayInputStream
 import java.io.File
+import java.security.KeyStore
+import javax.net.ssl.HttpsURLConnection
+import javax.net.ssl.KeyManagerFactory
+import javax.net.ssl.SSLContext
 
 class MainActivity : AudioServiceActivity() {
     companion object {
+        private const val CLIENT_CERT_CHANNEL = "com.unicornsonlsd.finamp/client_certificate"
+        private const val CLIENT_CERT_CHANNEL_LOG_TAG = "ClientCertChannel"
+
         private const val DOWNLOADS_SERVICE_CHANNEL = "com.unicornsonlsd.finamp/downloads_service"
         private const val DOWNLOADS_SERVICE_CHANNEL_LOG_TAG = "DownloadsServiceChannel"
 
@@ -37,6 +45,63 @@ class MainActivity : AudioServiceActivity() {
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
+        MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            CLIENT_CERT_CHANNEL,
+        ).setMethodCallHandler { call, result ->
+            when (call.method) {
+                "installClientCertificate" -> {
+                    val bytes = call.argument<ByteArray>("bytes")
+                    val password = call.argument<String>("password")
+                    if (bytes == null || password == null) {
+                        result.error("INVALID_ARGS", "bytes and password are required", null)
+                        return@setMethodCallHandler
+                    }
+                    lifecycleScope.launch {
+                        withContext(Dispatchers.IO) {
+                            try {
+                                installClientCertificate(bytes, password)
+
+                                Log.i(
+                                    CLIENT_CERT_CHANNEL_LOG_TAG,
+                                    "Client certificate installed in Android SSL context"
+                                )
+                                result.success(null)
+                            } catch (e: Exception) {
+                                Log.e(
+                                    CLIENT_CERT_CHANNEL_LOG_TAG,
+                                    "Failed to install client certificate",
+                                    e
+                                )
+                                result.error("CERT_ERROR", e.message, null)
+                            }
+                        }
+                    }
+                }
+                "clearClientCertificate" -> {
+                    lifecycleScope.launch {
+                        withContext(Dispatchers.IO) {
+                            try {
+                                clearClientCertificate()
+
+                                Log.i(
+                                    CLIENT_CERT_CHANNEL_LOG_TAG,
+                                    "Client certificate cleared from Android SSL context"
+                                )
+                                result.success(null)
+                            } catch (e: Exception) {
+                                Log.e(CLIENT_CERT_CHANNEL_LOG_TAG, "Failed to clear client certificate", e)
+                                result.error("CERT_ERROR", e.message, null)
+                            }
+                        }
+                    }
+                }
+                else -> {
+                    Log.e(CLIENT_CERT_CHANNEL_LOG_TAG, "Method not found: '${call.method}'")
+                    result.notImplemented()
+                }
+            }
+        }
         MethodChannel(
             flutterEngine.dartExecutor.binaryMessenger,
             DOWNLOADS_SERVICE_CHANNEL,
@@ -122,6 +187,27 @@ class MainActivity : AudioServiceActivity() {
                 }
             }
         }
+    }
+
+    private fun installClientCertificate(bytes: ByteArray, password: String) {
+        val keyStore = KeyStore.getInstance("PKCS12")
+        keyStore.load(ByteArrayInputStream(bytes), password.toCharArray())
+
+        val keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm())
+        keyManagerFactory.init(keyStore, password.toCharArray())
+
+        val sslContext = SSLContext.getInstance("TLS")
+        sslContext.init(keyManagerFactory.keyManagers, null, null)
+
+        SSLContext.setDefault(sslContext)
+        HttpsURLConnection.setDefaultSSLSocketFactory(sslContext.socketFactory)
+    }
+
+    private fun clearClientCertificate() {
+        val defaultContext = SSLContext.getInstance("TLS")
+        defaultContext.init(null, null, null)
+        SSLContext.setDefault(defaultContext)
+        HttpsURLConnection.setDefaultSSLSocketFactory(defaultContext.socketFactory)
     }
 
     /**

--- a/lib/components/LoginScreen/login_flow.dart
+++ b/lib/components/LoginScreen/login_flow.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:finamp/components/LoginScreen/login_server_selection_page.dart';
 import 'package:finamp/models/jellyfin_models.dart';
 import 'package:finamp/screens/view_selector.dart';
+import 'package:finamp/services/client_certificate_installer.dart';
 import 'package:finamp/services/jellyfin_api_helper.dart';
 import 'package:finamp/services/server_client_discovery_service.dart';
 import 'package:flutter/material.dart';
@@ -262,7 +263,9 @@ class ServerState {
       try {
         publicServerInfo = await jellyfinApiHelper.loadServerPublicInfo();
       } catch (error) {
-        if (error is ClientException && error.message.contains("TLSV1_ALERT_CERTIFICATE_REQUIRED")) {
+        if (ClientCertificateInstaller.isSupported &&
+            error is ClientException &&
+            error.message.contains("TLSV1_ALERT_CERTIFICATE_REQUIRED")) {
           clientCertificateRequired = true;
         } else {
           serverStateLogger.severe("Error loading server info: $error");

--- a/lib/components/LoginScreen/login_flow.dart
+++ b/lib/components/LoginScreen/login_flow.dart
@@ -8,6 +8,7 @@ import 'package:finamp/services/server_client_discovery_service.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:get_it/get_it.dart';
+import 'package:http/http.dart';
 import 'package:logging/logging.dart';
 
 import 'login_authentication_page.dart';
@@ -200,6 +201,7 @@ class ServerState {
   Timer? connectionTestDebounceTimer;
   String? baseUrlToTest;
   JellyfinServerClientDiscovery clientDiscoveryHandler;
+  bool clientCertificateRequired = false;
   VoidCallback? updateCallback;
 
   ServerState({
@@ -260,7 +262,11 @@ class ServerState {
       try {
         publicServerInfo = await jellyfinApiHelper.loadServerPublicInfo();
       } catch (error) {
-        serverStateLogger.severe("Error loading server info: $error");
+        if (error is ClientException && error.message.contains("TLSV1_ALERT_CERTIFICATE_REQUIRED")) {
+          clientCertificateRequired = true;
+        } else {
+          serverStateLogger.severe("Error loading server info: $error");
+        }
       }
       if (this.baseUrlToTest != baseUrl) {
         throw Exception("Server URL changed while testing");

--- a/lib/components/LoginScreen/login_flow.dart
+++ b/lib/components/LoginScreen/login_flow.dart
@@ -267,6 +267,8 @@ class ServerState {
             error is ClientException &&
             error.message.contains("TLSV1_ALERT_CERTIFICATE_REQUIRED")) {
           clientCertificateRequired = true;
+          // Found server requiring mTLS certificate, no need to try other protocols/ports.
+          return;
         } else {
           serverStateLogger.severe("Error loading server info: $error");
         }

--- a/lib/components/LoginScreen/login_server_selection_page.dart
+++ b/lib/components/LoginScreen/login_server_selection_page.dart
@@ -4,15 +4,17 @@ import 'package:finamp/components/finamp_icon.dart';
 import 'package:finamp/l10n/app_localizations.dart';
 import 'package:finamp/menus/client_certificate_authentication_menu.dart';
 import 'package:finamp/models/jellyfin_models.dart';
+import 'package:finamp/services/finamp_settings_helper.dart';
 import 'package:finamp/services/jellyfin_api_helper.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
 import 'package:get_it/get_it.dart';
 import 'package:logging/logging.dart';
 
 import 'login_flow.dart';
 
-class LoginServerSelectionPage extends StatefulWidget {
+class LoginServerSelectionPage extends ConsumerStatefulWidget {
   static const routeName = "login/server-selection";
 
   final ServerState serverState;
@@ -21,10 +23,10 @@ class LoginServerSelectionPage extends StatefulWidget {
   const LoginServerSelectionPage({super.key, required this.serverState, this.onServerSelected});
 
   @override
-  State<LoginServerSelectionPage> createState() => _LoginServerSelectionPageState();
+  ConsumerState<LoginServerSelectionPage> createState() => _LoginServerSelectionPageState();
 }
 
-class _LoginServerSelectionPageState extends State<LoginServerSelectionPage> {
+class _LoginServerSelectionPageState extends ConsumerState<LoginServerSelectionPage> {
   static final _loginServerSelectionPageLogger = Logger("LoginServerSelectionPage");
 
   final jellyfinApiHelper = GetIt.instance<JellyfinApiHelper>();
@@ -69,6 +71,9 @@ class _LoginServerSelectionPageState extends State<LoginServerSelectionPage> {
 
   @override
   Widget build(BuildContext context) {
+    final clientCertificate = ref.watch(finampSettingsProvider.clientCertificate);
+    final isClientCertificateInstalled = clientCertificate != null;
+
     return SingleChildScrollView(
       padding: const EdgeInsets.symmetric(horizontal: 32.0),
       child: Center(
@@ -99,8 +104,10 @@ class _LoginServerSelectionPageState extends State<LoginServerSelectionPage> {
             _buildServerUrlInput(context),
             ConstrainedBox(
               constraints: const BoxConstraints(minHeight: 95.0),
-              child: widget.serverState.manualServer != null
-                  ? Padding(
+              child: Column(
+                children: [
+                  if (widget.serverState.manualServer != null)
+                    Padding(
                       padding: const EdgeInsets.only(top: 12.0),
                       child: JellyfinServerSelectionWidget(
                         baseUrl: widget.serverState.baseUrl,
@@ -109,9 +116,19 @@ class _LoginServerSelectionPageState extends State<LoginServerSelectionPage> {
                           widget.onServerSelected?.call(widget.serverState.manualServer!, widget.serverState.baseUrl!);
                         },
                       ),
+                    ),
+                  if (isClientCertificateInstalled)
+                    Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 12.0),
+                      child: CTAMedium(
+                        text: AppLocalizations.of(context)!.clientCertificateInstalled,
+                        icon: TablerIcons.certificate,
+                        onPressed: () => showClientCertificateMenu(context: context),
+                        minWidth: 0,
+                      ),
                     )
-                  : widget.serverState.clientCertificateRequired
-                  ? Column(
+                  else if (widget.serverState.clientCertificateRequired)
+                    Column(
                       mainAxisAlignment: MainAxisAlignment.center,
                       crossAxisAlignment: CrossAxisAlignment.center,
                       children: [
@@ -134,9 +151,9 @@ class _LoginServerSelectionPageState extends State<LoginServerSelectionPage> {
                           ],
                         ),
                       ],
-                    )
-                  : widget.serverState.baseUrlToTest != null
-                  ? Padding(
+                    ),
+                  if (widget.serverState.baseUrlToTest != null && widget.serverState.manualServer == null)
+                    Padding(
                       padding: const EdgeInsets.only(top: 12.0),
                       child: Row(
                         mainAxisAlignment: MainAxisAlignment.center,
@@ -149,8 +166,9 @@ class _LoginServerSelectionPageState extends State<LoginServerSelectionPage> {
                           ),
                         ],
                       ),
-                    )
-                  : const SizedBox.shrink(),
+                    ),
+                ],
+              ),
             ),
             Padding(
               padding: const EdgeInsets.only(top: 20.0, bottom: 16.0),

--- a/lib/components/LoginScreen/login_server_selection_page.dart
+++ b/lib/components/LoginScreen/login_server_selection_page.dart
@@ -4,12 +4,15 @@ import 'package:finamp/components/finamp_icon.dart';
 import 'package:finamp/l10n/app_localizations.dart';
 import 'package:finamp/menus/client_certificate_authentication_menu.dart';
 import 'package:finamp/models/jellyfin_models.dart';
+import 'package:finamp/services/client_certificate_installer.dart';
 import 'package:finamp/services/finamp_settings_helper.dart';
 import 'package:finamp/services/jellyfin_api_helper.dart';
+import 'package:finamp/services/server_client_discovery_service.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
 import 'package:get_it/get_it.dart';
+import 'package:http/http.dart' show ClientException;
 import 'package:logging/logging.dart';
 
 import 'login_flow.dart';
@@ -42,12 +45,37 @@ class _LoginServerSelectionPageState extends ConsumerState<LoginServerSelectionP
       }
     };
 
+    _startDiscovery();
+  }
+
+  void _startDiscovery() {
     widget.serverState.clientDiscoveryHandler.discoverServers((ClientDiscoveryResponse response) async {
-      _loginServerSelectionPageLogger.finer("Found server: ${response.name} at ${response.address}");
+      _loginServerSelectionPageLogger.fine("Found server '${response.name}' at ${response.address}");
 
       final serverUrl = Uri.parse(response.address!);
-      PublicSystemInfoResult? serverInfo = await jellyfinApiHelper.loadCustomServerPublicInfo(serverUrl);
-      _loginServerSelectionPageLogger.finer("Server info: ${serverInfo?.toJson()}");
+      final PublicSystemInfoResult? serverInfo;
+      try {
+        serverInfo = await jellyfinApiHelper.loadCustomServerPublicInfo(serverUrl);
+      } catch (error) {
+        if (ClientCertificateInstaller.isSupported &&
+            error is ClientException &&
+            error.message.contains("TLSV1_ALERT_CERTIFICATE_REQUIRED")) {
+          _loginServerSelectionPageLogger.info(
+            "Discovered server '${response.name}' at ${response.address} requires an mTLS client certificate",
+          );
+          if (mounted && !widget.serverState.clientCertificateRequired) {
+            setState(() {
+              widget.serverState.clientCertificateRequired = true;
+            });
+          }
+        } else {
+          _loginServerSelectionPageLogger.severe(
+            "Failed to load public server info for discovered server '${response.name}' at ${response.address}: $error",
+          );
+        }
+        return;
+      }
+      _loginServerSelectionPageLogger.fine("Server info from ${response.address}: ${serverInfo?.toJson()}");
       if (serverInfo != null && mounted) {
         if (serverInfo.serverName == null) {
           serverInfo.serverName = response.name;
@@ -57,10 +85,19 @@ class _LoginServerSelectionPageState extends ConsumerState<LoginServerSelectionP
         }
         // no need to filter duplicates, we're using a map
         setState(() {
-          widget.serverState.discoveredServers[serverUrl] = serverInfo;
+          widget.serverState.discoveredServers[serverUrl] = serverInfo!;
         });
       }
     });
+  }
+
+  /// Discards the current discovery handler and starts over with a fresh socket.
+  /// The old socket can end up in a broken state after the app was backgrounded, e.g. while picking a certificate file,
+  /// and servers that responded before a certificate was installed need to be probed again either way.
+  void _restartDiscovery() {
+    widget.serverState.clientDiscoveryHandler.dispose();
+    widget.serverState.clientDiscoveryHandler = JellyfinServerClientDiscovery();
+    _startDiscovery();
   }
 
   @override
@@ -148,6 +185,7 @@ class _LoginServerSelectionPageState extends ConsumerState<LoginServerSelectionP
                               onPressed: () => showClientCertificateMenu(
                                 context: context,
                                 onImported: () {
+                                  _restartDiscovery();
                                   final baseUrl = widget.serverState.baseUrl;
                                   if (baseUrl != null) {
                                     widget.serverState.onBaseUrlChanged(baseUrl);

--- a/lib/components/LoginScreen/login_server_selection_page.dart
+++ b/lib/components/LoginScreen/login_server_selection_page.dart
@@ -145,7 +145,15 @@ class _LoginServerSelectionPageState extends ConsumerState<LoginServerSelectionP
                             CTAMedium(
                               text: AppLocalizations.of(context)!.importClientCertificate,
                               icon: TablerIcons.certificate,
-                              onPressed: () => showClientCertificateMenu(context: context),
+                              onPressed: () => showClientCertificateMenu(
+                                context: context,
+                                onImported: () {
+                                  final baseUrl = widget.serverState.baseUrl;
+                                  if (baseUrl != null) {
+                                    widget.serverState.onBaseUrlChanged(baseUrl);
+                                  }
+                                },
+                              ),
                               minWidth: 0,
                             ),
                           ],

--- a/lib/components/LoginScreen/login_server_selection_page.dart
+++ b/lib/components/LoginScreen/login_server_selection_page.dart
@@ -1,9 +1,11 @@
+import 'package:finamp/components/Buttons/cta_medium.dart';
 import 'package:finamp/components/Buttons/simple_button.dart';
 import 'package:finamp/components/finamp_icon.dart';
+import 'package:finamp/l10n/app_localizations.dart';
+import 'package:finamp/menus/client_certificate_authentication_menu.dart';
 import 'package:finamp/models/jellyfin_models.dart';
 import 'package:finamp/services/jellyfin_api_helper.dart';
 import 'package:flutter/material.dart';
-import 'package:finamp/l10n/app_localizations.dart';
 import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
 import 'package:get_it/get_it.dart';
 import 'package:logging/logging.dart';
@@ -97,7 +99,43 @@ class _LoginServerSelectionPageState extends State<LoginServerSelectionPage> {
             _buildServerUrlInput(context),
             ConstrainedBox(
               constraints: const BoxConstraints(minHeight: 95.0),
-              child: widget.serverState.baseUrlToTest != null && widget.serverState.manualServer == null
+              child: widget.serverState.manualServer != null
+                  ? Padding(
+                      padding: const EdgeInsets.only(top: 12.0),
+                      child: JellyfinServerSelectionWidget(
+                        baseUrl: widget.serverState.baseUrl,
+                        serverInfo: widget.serverState.manualServer,
+                        onPressed: () {
+                          widget.onServerSelected?.call(widget.serverState.manualServer!, widget.serverState.baseUrl!);
+                        },
+                      ),
+                    )
+                  : widget.serverState.clientCertificateRequired
+                  ? Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      children: [
+                        Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 12.0),
+                          child: Text(
+                            AppLocalizations.of(context)!.clientCertificateRequired,
+                            style: Theme.of(context).textTheme.bodyLarge,
+                          ),
+                        ),
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            CTAMedium(
+                              text: AppLocalizations.of(context)!.importClientCertificate,
+                              icon: TablerIcons.certificate,
+                              onPressed: () => showClientCertificateMenu(context: context),
+                              minWidth: 0,
+                            ),
+                          ],
+                        ),
+                      ],
+                    )
+                  : widget.serverState.baseUrlToTest != null
                   ? Padding(
                       padding: const EdgeInsets.only(top: 12.0),
                       child: Row(
@@ -112,22 +150,7 @@ class _LoginServerSelectionPageState extends State<LoginServerSelectionPage> {
                         ],
                       ),
                     )
-                  : Visibility(
-                      visible: widget.serverState.manualServer != null,
-                      child: Padding(
-                        padding: const EdgeInsets.only(top: 12.0),
-                        child: JellyfinServerSelectionWidget(
-                          baseUrl: widget.serverState.baseUrl,
-                          serverInfo: widget.serverState.manualServer,
-                          onPressed: () {
-                            widget.onServerSelected?.call(
-                              widget.serverState.manualServer!,
-                              widget.serverState.baseUrl!,
-                            );
-                          },
-                        ),
-                      ),
-                    ),
+                  : const SizedBox.shrink(),
             ),
             Padding(
               padding: const EdgeInsets.only(top: 20.0, bottom: 16.0),

--- a/lib/components/LoginScreen/login_server_selection_page.dart
+++ b/lib/components/LoginScreen/login_server_selection_page.dart
@@ -1,9 +1,11 @@
+import 'package:finamp/components/Buttons/cta_medium.dart';
 import 'package:finamp/components/Buttons/simple_button.dart';
 import 'package:finamp/components/finamp_icon.dart';
+import 'package:finamp/l10n/app_localizations.dart';
+import 'package:finamp/menus/client_certificate_authentication_menu.dart';
 import 'package:finamp/models/jellyfin_models.dart';
 import 'package:finamp/services/jellyfin_api_helper.dart';
 import 'package:flutter/material.dart';
-import 'package:finamp/l10n/app_localizations.dart';
 import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
 import 'package:get_it/get_it.dart';
 import 'package:logging/logging.dart';
@@ -98,7 +100,46 @@ class _LoginServerSelectionPageState extends State<LoginServerSelectionPage> {
               _buildServerUrlInput(context),
               ConstrainedBox(
                 constraints: const BoxConstraints(minHeight: 95.0),
-                child: widget.serverState.baseUrlToTest != null && widget.serverState.manualServer == null
+                child: widget.serverState.manualServer != null
+                    ? Padding(
+                        padding: const EdgeInsets.only(top: 12.0),
+                        child: JellyfinServerSelectionWidget(
+                          baseUrl: widget.serverState.baseUrl,
+                          serverInfo: widget.serverState.manualServer,
+                          onPressed: () {
+                            widget.onServerSelected?.call(
+                              widget.serverState.manualServer!,
+                              widget.serverState.baseUrl!,
+                            );
+                          },
+                        ),
+                      )
+                    : widget.serverState.clientCertificateRequired
+                    ? Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        crossAxisAlignment: CrossAxisAlignment.center,
+                        children: [
+                          Padding(
+                            padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 12.0),
+                            child: Text(
+                              AppLocalizations.of(context)!.clientCertificateRequired,
+                              style: Theme.of(context).textTheme.bodyLarge,
+                            ),
+                          ),
+                          Row(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: [
+                              CTAMedium(
+                                text: AppLocalizations.of(context)!.importClientCertificate,
+                                icon: TablerIcons.certificate,
+                                onPressed: () => showClientCertificateMenu(context: context),
+                                minWidth: 0,
+                              ),
+                            ],
+                          ),
+                        ],
+                      )
+                    : widget.serverState.baseUrlToTest != null
                     ? Padding(
                         padding: const EdgeInsets.only(top: 12.0),
                         child: Row(
@@ -113,22 +154,7 @@ class _LoginServerSelectionPageState extends State<LoginServerSelectionPage> {
                           ],
                         ),
                       )
-                    : Visibility(
-                        visible: widget.serverState.manualServer != null,
-                        child: Padding(
-                          padding: const EdgeInsets.only(top: 12.0),
-                          child: JellyfinServerSelectionWidget(
-                            baseUrl: widget.serverState.baseUrl,
-                            serverInfo: widget.serverState.manualServer,
-                            onPressed: () {
-                              widget.onServerSelected?.call(
-                                widget.serverState.manualServer!,
-                                widget.serverState.baseUrl!,
-                              );
-                            },
-                          ),
-                        ),
-                      ),
+                    : const SizedBox.shrink(),
               ),
               Padding(
                 padding: const EdgeInsets.only(top: 20.0, bottom: 16.0),

--- a/lib/components/themed_bottom_sheet.dart
+++ b/lib/components/themed_bottom_sheet.dart
@@ -29,6 +29,7 @@ Future<T?> showThemedBottomSheet<T>({
   WrapperBuilder? buildWrapper,
   double minDraggableHeight = 0.6,
   bool showDragHandle = true,
+  bool useRootNavigator = false,
 }) async {
   FeedbackHelper.feedback(FeedbackType.selection);
   bool useDefaultTheme = false;
@@ -47,6 +48,7 @@ Future<T?> showThemedBottomSheet<T>({
     constraints: BoxConstraints(
       maxWidth: (Platform.isIOS || Platform.isAndroid) ? 500 : min(500, MediaQuery.widthOf(context) * 0.9),
     ),
+    useRootNavigator: useRootNavigator,
     isDismissible: true,
     enableDrag: true,
     useSafeArea: true,

--- a/lib/hive_registrar.g.dart
+++ b/lib/hive_registrar.g.dart
@@ -17,6 +17,7 @@ extension HiveRegistrar on HiveInterface {
     registerAdapter(BaseItemDtoAdapter());
     registerAdapter(BaseItemPersonAdapter());
     registerAdapter(ClientCapabilitiesAdapter());
+    registerAdapter(ClientCertificateAdapter());
     registerAdapter(CodecProfileAdapter());
     registerAdapter(CollectionHomeSectionAdapter());
     registerAdapter(ContainerProfileAdapter());
@@ -130,6 +131,7 @@ extension IsolatedHiveRegistrar on IsolatedHiveInterface {
     registerAdapter(BaseItemDtoAdapter());
     registerAdapter(BaseItemPersonAdapter());
     registerAdapter(ClientCapabilitiesAdapter());
+    registerAdapter(ClientCertificateAdapter());
     registerAdapter(CodecProfileAdapter());
     registerAdapter(CollectionHomeSectionAdapter());
     registerAdapter(ContainerProfileAdapter());

--- a/lib/hive_registrar.g.dart
+++ b/lib/hive_registrar.g.dart
@@ -17,6 +17,7 @@ extension HiveRegistrar on HiveInterface {
     registerAdapter(BaseItemDtoAdapter());
     registerAdapter(BaseItemPersonAdapter());
     registerAdapter(ClientCapabilitiesAdapter());
+    registerAdapter(ClientCertificateAdapter());
     registerAdapter(CodecProfileAdapter());
     registerAdapter(ContainerProfileAdapter());
     registerAdapter(ContentViewTypeAdapter());
@@ -119,6 +120,7 @@ extension IsolatedHiveRegistrar on IsolatedHiveInterface {
     registerAdapter(BaseItemDtoAdapter());
     registerAdapter(BaseItemPersonAdapter());
     registerAdapter(ClientCapabilitiesAdapter());
+    registerAdapter(ClientCertificateAdapter());
     registerAdapter(CodecProfileAdapter());
     registerAdapter(ContainerProfileAdapter());
     registerAdapter(ContentViewTypeAdapter());

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3528,5 +3528,49 @@
                 "example": "syncingLocal"
             }
         }
+    },
+    "clientCertificate": "SSL Client Certificate",
+    "@clientCertificate": {
+        "description": "Title for the setting that allows managing SSL client certificates used for authentication"
+    },
+    "clientCertificateUnavailable": "No certificate available, client authentication disabled.",
+    "@clientCertificateUnavailable": {
+        "description": "Message shown when the user has no SSL client certificate available to use."
+    },
+    "clientCertificateInstalled": "Certificate installed.",
+    "@clientCertificateInstalled": {
+        "description": "Message shown when the user has successfully installed an SSL client certificate."
+    },
+    "clientCertificateDescription": "An SSL client certificate (.p12 or .pfx) is used to authenticate this device with your Jellyfin server. Only required if your server is configured for mutual TLS.",
+    "@clientCertificateDescription": {
+        "description": "Explanatory text in the client certificate settings menu describing what a client certificate is used for"
+    },
+    "importClientCertificate": "Import Certificate",
+    "@importClientCertificate": {
+        "description": "Label for the button to import a new SSL client certificate."
+    },
+    "removeClientCertificate": "Remove Certificate",
+    "@removeClientCertificate": {
+        "description": "Label for the button to remove the currently installed SSL client certificate."
+    },
+    "clientCertificatePasswordTitle": "Certificate Password",
+    "@clientCertificatePasswordTitle": {
+        "description": "Title of the dialog prompting the user to enter the password for the client certificate being imported."
+    },
+    "clientCertificatePasswordHint": "Password",
+    "@clientCertificatePasswordHint": {
+        "description": "Hint text for the password input field when importing a client certificate."
+    },
+    "clientCertificateDeleteConfirm": "Remove the installed certificate? Client authentication will be disabled.",
+    "@clientCertificateDeleteConfirm": {
+        "description": "Confirmation prompt shown before removing the installed client certificate."
+    },
+    "clientCertificateImportSuccess": "Certificate imported successfully.",
+    "@clientCertificateImportSuccess": {
+        "description": "Message shown after successfully importing a client certificate."
+    },
+    "clientCertificateImportError": "Failed to import certificate.",
+    "@clientCertificateImportError": {
+        "description": "Error message shown when importing a client certificate fails."
     }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3529,19 +3529,19 @@
             }
         }
     },
-    "clientCertificate": "SSL Client Certificate",
+    "clientCertificate": "mTLS (SSL) Client Certificate",
     "@clientCertificate": {
         "description": "Title for the setting that allows managing SSL client certificates used for authentication"
     },
-    "clientCertificateUnavailable": "No certificate available, client authentication disabled.",
+    "clientCertificateUnavailable": "No certificate set up, client authentication disabled",
     "@clientCertificateUnavailable": {
         "description": "Message shown when the user has no SSL client certificate available to use."
     },
-    "clientCertificateInstalled": "Certificate installed.",
+    "clientCertificateInstalled": "Certificate installed",
     "@clientCertificateInstalled": {
         "description": "Message shown when the user has successfully installed an SSL client certificate."
     },
-    "clientCertificateDescription": "An SSL client certificate (.p12 or .pfx) is used to authenticate this device with your Jellyfin server. Only required if your server is configured for mutual TLS.",
+    "clientCertificateDescription": "A TLS client certificate (.p12 or .pfx) is used to authenticate this device with your Jellyfin server. Only required if your server is configured for mutual TLS.",
     "@clientCertificateDescription": {
         "description": "Explanatory text in the client certificate settings menu describing what a client certificate is used for"
     },
@@ -3565,15 +3565,15 @@
     "@clientCertificateDeleteConfirm": {
         "description": "Confirmation prompt shown before removing the installed client certificate."
     },
-    "clientCertificateImportSuccess": "Certificate imported successfully.",
+    "clientCertificateImportSuccess": "Certificate imported successfully",
     "@clientCertificateImportSuccess": {
         "description": "Message shown after successfully importing a client certificate."
     },
-    "clientCertificateImportError": "Failed to import certificate.",
+    "clientCertificateImportError": "Failed to import certificate",
     "@clientCertificateImportError": {
         "description": "Error message shown when importing a client certificate fails."
     },
-    "clientCertificateRequired": "Client certificate required.",
+    "clientCertificateRequired": "Client certificate required",
     "@clientCertificateRequired": {
         "description": "Message shown on the server selection screen when the server requires a client certificate to be provided."
     }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3572,5 +3572,9 @@
     "clientCertificateImportError": "Failed to import certificate.",
     "@clientCertificateImportError": {
         "description": "Error message shown when importing a client certificate fails."
+    },
+    "clientCertificateRequired": "Client certificate required.",
+    "@clientCertificateRequired": {
+        "description": "Message shown on the server selection screen when the server requires a client certificate to be provided."
     }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3291,5 +3291,49 @@
   "previousTracksPersistenceModeExpanded": "Expanded (visible)",
   "@previousTracksPersistenceModeExpanded": {
     "description": "Overrides saved value to expand previous tracks header on queue list open"
+  },
+  "clientCertificate": "SSL Client Certificate",
+  "@clientCertificate": {
+    "description": "Title for the setting that allows managing SSL client certificates used for authentication"
+  },
+  "clientCertificateUnavailable": "No certificate available, client authentication disabled.",
+  "@clientCertificateUnavailable": {
+    "description": "Message shown when the user has no SSL client certificate available to use."
+  },
+  "clientCertificateInstalled": "Certificate installed.",
+  "@clientCertificateInstalled": {
+    "description": "Message shown when the user has successfully installed an SSL client certificate."
+  },
+  "clientCertificateDescription": "An SSL client certificate (.p12 or .pfx) is used to authenticate this device with your Jellyfin server. Only required if your server is configured for mutual TLS.",
+  "@clientCertificateDescription": {
+    "description": "Explanatory text in the client certificate settings menu describing what a client certificate is used for"
+  },
+  "importClientCertificate": "Import Certificate",
+  "@importClientCertificate": {
+    "description": "Label for the button to import a new SSL client certificate."
+  },
+  "removeClientCertificate": "Remove Certificate",
+  "@removeClientCertificate": {
+    "description": "Label for the button to remove the currently installed SSL client certificate."
+  },
+  "clientCertificatePasswordTitle": "Certificate Password",
+  "@clientCertificatePasswordTitle": {
+    "description": "Title of the dialog prompting the user to enter the password for the client certificate being imported."
+  },
+  "clientCertificatePasswordHint": "Password",
+  "@clientCertificatePasswordHint": {
+    "description": "Hint text for the password input field when importing a client certificate."
+  },
+  "clientCertificateDeleteConfirm": "Remove the installed certificate? Client authentication will be disabled.",
+  "@clientCertificateDeleteConfirm": {
+    "description": "Confirmation prompt shown before removing the installed client certificate."
+  },
+  "clientCertificateImportSuccess": "Certificate imported successfully.",
+  "@clientCertificateImportSuccess": {
+    "description": "Message shown after successfully importing a client certificate."
+  },
+  "clientCertificateImportError": "Failed to import certificate.",
+  "@clientCertificateImportError": {
+    "description": "Error message shown when importing a client certificate fails."
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3335,5 +3335,9 @@
   "clientCertificateImportError": "Failed to import certificate.",
   "@clientCertificateImportError": {
     "description": "Error message shown when importing a client certificate fails."
+  },
+  "clientCertificateRequired": "Client certificate required.",
+  "@clientCertificateRequired": {
+    "description": "Message shown on the server selection screen when the server requires a client certificate to be provided."
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -34,6 +34,7 @@ import 'package:finamp/services/album_image_provider.dart';
 import 'package:finamp/services/android_auto_helper.dart';
 import 'package:finamp/services/audio_service_smtc.dart';
 import 'package:finamp/services/carplay_helper.dart';
+import 'package:finamp/services/client_certificate_installer.dart';
 import 'package:finamp/services/data_source_service.dart';
 import 'package:finamp/services/dbus_manager.dart';
 import 'package:finamp/services/discord_rpc.dart';
@@ -143,6 +144,8 @@ Future<void> main({bool integrationTesting = false, bool loginTesting = false}) 
     _mainLog.info("Completed applicable migrations");
     await _trustAndroidUserCerts();
     _mainLog.info("Trusted Android user certs");
+    await ClientCertificateInstaller().defaultInstallClientCertificate();
+    _mainLog.info("Installed client certificate");
     await _setupFinampUserHelper();
     _mainLog.info("Setup user helper");
     await _setupJellyfinApiData();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -144,7 +144,7 @@ Future<void> main({bool integrationTesting = false, bool loginTesting = false}) 
     _mainLog.info("Completed applicable migrations");
     await _trustAndroidUserCerts();
     _mainLog.info("Trusted Android user certs");
-    await ClientCertificateInstaller().defaultInstallClientCertificate();
+    await ClientCertificateInstaller().installClientCertificate();
     _mainLog.info("Installed client certificate");
     await _setupFinampUserHelper();
     _mainLog.info("Setup user helper");

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -31,6 +31,7 @@ import 'package:finamp/screens/queue_restore_screen.dart';
 import 'package:finamp/services/album_image_provider.dart';
 import 'package:finamp/services/android_auto_helper.dart';
 import 'package:finamp/services/audio_service_smtc.dart';
+import 'package:finamp/services/client_certificate_installer.dart';
 import 'package:finamp/services/data_source_service.dart';
 import 'package:finamp/services/dbus_manager.dart';
 import 'package:finamp/services/discord_rpc.dart';
@@ -124,6 +125,8 @@ void main() async {
     _mainLog.info("Completed applicable migrations");
     await _trustAndroidUserCerts();
     _mainLog.info("Trusted Android user certs");
+    await ClientCertificateInstaller().defaultInstallClientCertificate();
+    _mainLog.info("Installed client certificate");
     await _setupFinampUserHelper();
     _mainLog.info("Setup user helper");
     await _setupJellyfinApiData();

--- a/lib/menus/client_certificate_authentication_menu.dart
+++ b/lib/menus/client_certificate_authentication_menu.dart
@@ -82,7 +82,7 @@ class _ClientCertificateMenuContentState extends ConsumerState<_ClientCertificat
     try {
       final bytes = await File(filePath).readAsBytes();
       FinampSetters.setClientCertificate(ClientCertificate(data: bytes, password: password));
-      await _clientCertificateInstaller.defaultInstallClientCertificate();
+      await _clientCertificateInstaller.installClientCertificate();
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(l10n.clientCertificateImportSuccess)));
         widget.onImported?.call();
@@ -112,7 +112,7 @@ class _ClientCertificateMenuContentState extends ConsumerState<_ClientCertificat
         confirmButtonText: l10n.removeClientCertificate,
         onConfirmed: () async {
           FinampSetters.setClientCertificate(null);
-          await _clientCertificateInstaller.defaultClearClientCertificate();
+          await _clientCertificateInstaller.clearClientCertificate();
         },
       ),
     );

--- a/lib/menus/client_certificate_authentication_menu.dart
+++ b/lib/menus/client_certificate_authentication_menu.dart
@@ -1,0 +1,191 @@
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:finamp/components/confirmation_prompt_dialog.dart';
+import 'package:finamp/components/themed_bottom_sheet.dart';
+import 'package:finamp/l10n/app_localizations.dart';
+import 'package:finamp/models/finamp_models.dart';
+import 'package:finamp/services/finamp_settings_helper.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_sticky_header/flutter_sticky_header.dart';
+import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
+
+const clientCertificateAuthenticationRouteName = "/client-certificate-authentication-menu";
+
+Future<void> showClientCertificateMenu({required BuildContext context}) async {
+  await showThemedBottomSheet(
+    context: context,
+    routeName: clientCertificateAuthenticationRouteName,
+    minDraggableHeight: 0.3,
+    buildSlivers: (context) {
+      var menu = [
+        SliverStickyHeader(
+          header: const _ClientCertificateMenuHeader(),
+          sliver: MenuMask(
+            height: const MenuMaskHeight(44.0),
+            child: SliverToBoxAdapter(child: _ClientCertificateMenuContent()),
+          ),
+        ),
+      ];
+      const stackHeight = 250.0;
+      return (stackHeight, menu);
+    },
+  );
+}
+
+class _ClientCertificateMenuHeader extends StatelessWidget {
+  const _ClientCertificateMenuHeader();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 6.0, bottom: 16.0),
+      child: Center(
+        child: Text(
+          AppLocalizations.of(context)!.clientCertificate,
+          style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w400),
+        ),
+      ),
+    );
+  }
+}
+
+class _ClientCertificateMenuContent extends ConsumerStatefulWidget {
+  @override
+  ConsumerState<_ClientCertificateMenuContent> createState() => _ClientCertificateMenuContentState();
+}
+
+class _ClientCertificateMenuContentState extends ConsumerState<_ClientCertificateMenuContent> {
+  bool _importing = false;
+
+  Future<void> _importCertificate() async {
+    final l10n = AppLocalizations.of(context)!;
+
+    final result = await FilePicker.pickFiles(type: FileType.custom, allowedExtensions: ['p12', 'pfx']);
+    if (result == null || result.files.single.path == null) return;
+
+    final filePath = result.files.single.path!;
+
+    if (!mounted) return;
+    final password = await _showPasswordDialog(context);
+    if (password == null) return;
+
+    setState(() => _importing = true);
+    try {
+      final bytes = await File(filePath).readAsBytes();
+      FinampSetters.setClientCertificate(ClientCertificate(data: bytes, password: password));
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(l10n.clientCertificateImportSuccess)));
+      }
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(l10n.clientCertificateImportError)));
+      }
+    } finally {
+      if (mounted) setState(() => _importing = false);
+    }
+  }
+
+  Future<String?> _showPasswordDialog(BuildContext context) async {
+    final l10n = AppLocalizations.of(context)!;
+    final controller = TextEditingController();
+    final result = await showDialog<String?>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(l10n.clientCertificatePasswordTitle),
+        content: TextField(
+          controller: controller,
+          obscureText: true,
+          autofocus: true,
+          keyboardType: TextInputType.visiblePassword,
+          decoration: InputDecoration(hintText: l10n.clientCertificatePasswordHint),
+          onSubmitted: (value) => Navigator.of(context).pop(value),
+        ),
+        actions: [
+          TextButton(onPressed: () => Navigator.of(context).pop(null), child: Text(l10n.genericCancel)),
+          TextButton(onPressed: () => Navigator.of(context).pop(controller.text), child: Text(l10n.confirm)),
+        ],
+      ),
+    );
+    controller.dispose();
+    return result;
+  }
+
+  Future<void> _removeCertificate() async {
+    final l10n = AppLocalizations.of(context)!;
+    await showDialog<void>(
+      context: context,
+      builder: (context) => ConfirmationPromptDialog(
+        promptText: l10n.clientCertificateDeleteConfirm,
+        confirmButtonText: l10n.removeClientCertificate,
+        onConfirmed: () => FinampSetters.setClientCertificate(null),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final certificate = ref.watch(finampSettingsProvider.clientCertificate);
+    final isInstalled = certificate != null;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 24.0, vertical: 8.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        spacing: 16.0,
+        children: [
+          // Status row
+          Row(
+            spacing: 12.0,
+            children: [
+              Icon(
+                isInstalled ? TablerIcons.certificate : TablerIcons.certificate_off,
+                color: isInstalled
+                    ? Theme.of(context).colorScheme.primary
+                    : Theme.of(context).colorScheme.onSurface.withAlpha(153),
+                size: 28.0,
+              ),
+              Expanded(
+                child: Text(
+                  isInstalled ? l10n.clientCertificateInstalled : l10n.clientCertificateUnavailable,
+                  style: Theme.of(context).textTheme.bodyMedium,
+                ),
+              ),
+            ],
+          ),
+          // Description
+          Text(
+            l10n.clientCertificateDescription,
+            style: Theme.of(
+              context,
+            ).textTheme.bodySmall?.copyWith(color: Theme.of(context).colorScheme.onSurface.withAlpha(179)),
+          ),
+          // Action buttons
+          Row(
+            spacing: 8.0,
+            children: [
+              Expanded(
+                child: FilledButton.tonal(
+                  onPressed: _importing ? null : _importCertificate,
+                  child: _importing
+                      ? const SizedBox(width: 18, height: 18, child: CircularProgressIndicator(strokeWidth: 2.5))
+                      : Text(l10n.importClientCertificate),
+                ),
+              ),
+              if (isInstalled)
+                Expanded(
+                  child: FilledButton.tonal(
+                    style: FilledButton.styleFrom(foregroundColor: Theme.of(context).colorScheme.error),
+                    onPressed: _removeCertificate,
+                    child: Text(l10n.removeClientCertificate),
+                  ),
+                ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/menus/client_certificate_authentication_menu.dart
+++ b/lib/menus/client_certificate_authentication_menu.dart
@@ -92,28 +92,9 @@ class _ClientCertificateMenuContentState extends ConsumerState<_ClientCertificat
   }
 
   Future<String?> _showPasswordDialog(BuildContext context) async {
-    final l10n = AppLocalizations.of(context)!;
-    final controller = TextEditingController();
-    final result = await showDialog<String?>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: Text(l10n.clientCertificatePasswordTitle),
-        content: TextField(
-          controller: controller,
-          obscureText: true,
-          autofocus: true,
-          keyboardType: TextInputType.visiblePassword,
-          decoration: InputDecoration(hintText: l10n.clientCertificatePasswordHint),
-          onSubmitted: (value) => Navigator.of(context).pop(value),
-        ),
-        actions: [
-          TextButton(onPressed: () => Navigator.of(context).pop(null), child: Text(l10n.genericCancel)),
-          TextButton(onPressed: () => Navigator.of(context).pop(controller.text), child: Text(l10n.confirm)),
-        ],
-      ),
-    );
-    controller.dispose();
-    return result;
+    // Use root navigator context to avoid cross-overlay InheritedWidget dependency issues.
+    final dialogContext = Navigator.of(context, rootNavigator: true).context;
+    return await showDialog<String?>(context: dialogContext, builder: (context) => const _PasswordDialog());
   }
 
   Future<void> _removeCertificate() async {
@@ -193,6 +174,43 @@ class _ClientCertificateMenuContentState extends ConsumerState<_ClientCertificat
           ),
         ],
       ),
+    );
+  }
+}
+
+class _PasswordDialog extends StatefulWidget {
+  const _PasswordDialog();
+
+  @override
+  State<_PasswordDialog> createState() => _PasswordDialogState();
+}
+
+class _PasswordDialogState extends State<_PasswordDialog> {
+  final _controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    return AlertDialog(
+      title: Text(l10n.clientCertificatePasswordTitle),
+      content: TextField(
+        controller: _controller,
+        obscureText: true,
+        autofocus: true,
+        keyboardType: TextInputType.visiblePassword,
+        decoration: InputDecoration(hintText: l10n.clientCertificatePasswordHint),
+        onSubmitted: (value) => Navigator.of(context).pop(value),
+      ),
+      actions: [
+        TextButton(onPressed: () => Navigator.of(context).pop(null), child: Text(l10n.genericCancel)),
+        TextButton(onPressed: () => Navigator.of(context).pop(_controller.text), child: Text(l10n.confirm)),
+      ],
     );
   }
 }

--- a/lib/menus/client_certificate_authentication_menu.dart
+++ b/lib/menus/client_certificate_authentication_menu.dart
@@ -5,6 +5,7 @@ import 'package:finamp/components/confirmation_prompt_dialog.dart';
 import 'package:finamp/components/themed_bottom_sheet.dart';
 import 'package:finamp/l10n/app_localizations.dart';
 import 'package:finamp/models/finamp_models.dart';
+import 'package:finamp/services/client_certificate_installer.dart';
 import 'package:finamp/services/finamp_settings_helper.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -57,6 +58,7 @@ class _ClientCertificateMenuContent extends ConsumerStatefulWidget {
 }
 
 class _ClientCertificateMenuContentState extends ConsumerState<_ClientCertificateMenuContent> {
+  final _clientCertificateInstaller = ClientCertificateInstaller();
   bool _importing = false;
 
   Future<void> _importCertificate() async {
@@ -75,6 +77,7 @@ class _ClientCertificateMenuContentState extends ConsumerState<_ClientCertificat
     try {
       final bytes = await File(filePath).readAsBytes();
       FinampSetters.setClientCertificate(ClientCertificate(data: bytes, password: password));
+      await _clientCertificateInstaller.defaultInstallClientCertificate();
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(l10n.clientCertificateImportSuccess)));
       }
@@ -119,7 +122,10 @@ class _ClientCertificateMenuContentState extends ConsumerState<_ClientCertificat
       builder: (context) => ConfirmationPromptDialog(
         promptText: l10n.clientCertificateDeleteConfirm,
         confirmButtonText: l10n.removeClientCertificate,
-        onConfirmed: () => FinampSetters.setClientCertificate(null),
+        onConfirmed: () async {
+          FinampSetters.setClientCertificate(null);
+          await _clientCertificateInstaller.defaultClearClientCertificate();
+        },
       ),
     );
   }

--- a/lib/menus/client_certificate_authentication_menu.dart
+++ b/lib/menus/client_certificate_authentication_menu.dart
@@ -14,7 +14,7 @@ import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
 
 const clientCertificateAuthenticationRouteName = "/client-certificate-authentication-menu";
 
-Future<void> showClientCertificateMenu({required BuildContext context}) async {
+Future<void> showClientCertificateMenu({required BuildContext context, VoidCallback? onImported}) async {
   await showThemedBottomSheet(
     context: context,
     routeName: clientCertificateAuthenticationRouteName,
@@ -26,7 +26,7 @@ Future<void> showClientCertificateMenu({required BuildContext context}) async {
           header: const _ClientCertificateMenuHeader(),
           sliver: MenuMask(
             height: const MenuMaskHeight(44.0),
-            child: SliverToBoxAdapter(child: _ClientCertificateMenuContent()),
+            child: SliverToBoxAdapter(child: _ClientCertificateMenuContent(onImported: onImported)),
           ),
         ),
       ];
@@ -54,6 +54,10 @@ class _ClientCertificateMenuHeader extends StatelessWidget {
 }
 
 class _ClientCertificateMenuContent extends ConsumerStatefulWidget {
+  const _ClientCertificateMenuContent({this.onImported});
+
+  final VoidCallback? onImported;
+
   @override
   ConsumerState<_ClientCertificateMenuContent> createState() => _ClientCertificateMenuContentState();
 }
@@ -81,6 +85,7 @@ class _ClientCertificateMenuContentState extends ConsumerState<_ClientCertificat
       await _clientCertificateInstaller.defaultInstallClientCertificate();
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(l10n.clientCertificateImportSuccess)));
+        widget.onImported?.call();
         Navigator.of(context).pop();
       }
     } catch (_) {

--- a/lib/menus/client_certificate_authentication_menu.dart
+++ b/lib/menus/client_certificate_authentication_menu.dart
@@ -81,6 +81,7 @@ class _ClientCertificateMenuContentState extends ConsumerState<_ClientCertificat
       await _clientCertificateInstaller.defaultInstallClientCertificate();
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(l10n.clientCertificateImportSuccess)));
+        Navigator.of(context).pop();
       }
     } catch (_) {
       if (mounted) {

--- a/lib/menus/client_certificate_authentication_menu.dart
+++ b/lib/menus/client_certificate_authentication_menu.dart
@@ -19,6 +19,7 @@ Future<void> showClientCertificateMenu({required BuildContext context}) async {
     context: context,
     routeName: clientCertificateAuthenticationRouteName,
     minDraggableHeight: 0.3,
+    useRootNavigator: true,
     buildSlivers: (context) {
       var menu = [
         SliverStickyHeader(

--- a/lib/menus/client_certificate_authentication_menu.dart
+++ b/lib/menus/client_certificate_authentication_menu.dart
@@ -1,0 +1,191 @@
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:finamp/components/confirmation_prompt_dialog.dart';
+import 'package:finamp/components/themed_bottom_sheet.dart';
+import 'package:finamp/l10n/app_localizations.dart';
+import 'package:finamp/models/finamp_models.dart';
+import 'package:finamp/services/finamp_settings_helper.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_sticky_header/flutter_sticky_header.dart';
+import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
+
+const clientCertificateAuthenticationRouteName = "/client-certificate-authentication-menu";
+
+Future<void> showClientCertificateMenu({required BuildContext context}) async {
+  await showThemedBottomSheet(
+    context: context,
+    routeName: clientCertificateAuthenticationRouteName,
+    minDraggableHeight: 0.3,
+    buildSlivers: (context) {
+      var menu = [
+        SliverStickyHeader(
+          header: const _ClientCertificateMenuHeader(),
+          sliver: MenuMask(
+            height: const MenuMaskHeight(44.0),
+            child: SliverToBoxAdapter(child: _ClientCertificateMenuContent()),
+          ),
+        ),
+      ];
+      const stackHeight = 250.0;
+      return (stackHeight, menu);
+    },
+  );
+}
+
+class _ClientCertificateMenuHeader extends StatelessWidget {
+  const _ClientCertificateMenuHeader();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 6.0, bottom: 16.0),
+      child: Center(
+        child: Text(
+          AppLocalizations.of(context)!.clientCertificate,
+          style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w400),
+        ),
+      ),
+    );
+  }
+}
+
+class _ClientCertificateMenuContent extends ConsumerStatefulWidget {
+  @override
+  ConsumerState<_ClientCertificateMenuContent> createState() => _ClientCertificateMenuContentState();
+}
+
+class _ClientCertificateMenuContentState extends ConsumerState<_ClientCertificateMenuContent> {
+  bool _importing = false;
+
+  Future<void> _importCertificate() async {
+    final l10n = AppLocalizations.of(context)!;
+
+    final result = await FilePicker.platform.pickFiles(type: FileType.custom, allowedExtensions: ['p12', 'pfx']);
+    if (result == null || result.files.single.path == null) return;
+
+    final filePath = result.files.single.path!;
+
+    if (!mounted) return;
+    final password = await _showPasswordDialog(context);
+    if (password == null) return;
+
+    setState(() => _importing = true);
+    try {
+      final bytes = await File(filePath).readAsBytes();
+      FinampSetters.setClientCertificate(ClientCertificate(data: bytes, password: password));
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(l10n.clientCertificateImportSuccess)));
+      }
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(l10n.clientCertificateImportError)));
+      }
+    } finally {
+      if (mounted) setState(() => _importing = false);
+    }
+  }
+
+  Future<String?> _showPasswordDialog(BuildContext context) async {
+    final l10n = AppLocalizations.of(context)!;
+    final controller = TextEditingController();
+    final result = await showDialog<String?>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(l10n.clientCertificatePasswordTitle),
+        content: TextField(
+          controller: controller,
+          obscureText: true,
+          autofocus: true,
+          keyboardType: TextInputType.visiblePassword,
+          decoration: InputDecoration(hintText: l10n.clientCertificatePasswordHint),
+          onSubmitted: (value) => Navigator.of(context).pop(value),
+        ),
+        actions: [
+          TextButton(onPressed: () => Navigator.of(context).pop(null), child: Text(l10n.genericCancel)),
+          TextButton(onPressed: () => Navigator.of(context).pop(controller.text), child: Text(l10n.confirm)),
+        ],
+      ),
+    );
+    controller.dispose();
+    return result;
+  }
+
+  Future<void> _removeCertificate() async {
+    final l10n = AppLocalizations.of(context)!;
+    await showDialog<void>(
+      context: context,
+      builder: (context) => ConfirmationPromptDialog(
+        promptText: l10n.clientCertificateDeleteConfirm,
+        confirmButtonText: l10n.removeClientCertificate,
+        onConfirmed: () => FinampSetters.setClientCertificate(null),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final certificate = ref.watch(finampSettingsProvider.clientCertificate);
+    final isInstalled = certificate != null;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 24.0, vertical: 8.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        spacing: 16.0,
+        children: [
+          // Status row
+          Row(
+            spacing: 12.0,
+            children: [
+              Icon(
+                isInstalled ? TablerIcons.certificate : TablerIcons.certificate_off,
+                color: isInstalled
+                    ? Theme.of(context).colorScheme.primary
+                    : Theme.of(context).colorScheme.onSurface.withAlpha(153),
+                size: 28.0,
+              ),
+              Expanded(
+                child: Text(
+                  isInstalled ? l10n.clientCertificateInstalled : l10n.clientCertificateUnavailable,
+                  style: Theme.of(context).textTheme.bodyMedium,
+                ),
+              ),
+            ],
+          ),
+          // Description
+          Text(
+            l10n.clientCertificateDescription,
+            style: Theme.of(
+              context,
+            ).textTheme.bodySmall?.copyWith(color: Theme.of(context).colorScheme.onSurface.withAlpha(179)),
+          ),
+          // Action buttons
+          Row(
+            spacing: 8.0,
+            children: [
+              Expanded(
+                child: FilledButton.tonal(
+                  onPressed: _importing ? null : _importCertificate,
+                  child: _importing
+                      ? const SizedBox(width: 18, height: 18, child: CircularProgressIndicator(strokeWidth: 2.5))
+                      : Text(l10n.importClientCertificate),
+                ),
+              ),
+              if (isInstalled)
+                Expanded(
+                  child: FilledButton.tonal(
+                    style: FilledButton.styleFrom(foregroundColor: Theme.of(context).colorScheme.error),
+                    onPressed: _removeCertificate,
+                    child: Text(l10n.removeClientCertificate),
+                  ),
+                ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -298,6 +298,7 @@ class DefaultSettings {
   static const homeScreenImageSizeDesktop = 120;
   static int get gridImageSize => isDesktop ? gridImageSizeDesktop : gridImageSizeMobile;
   static const useAndroidGainEffect = true;
+  static const ClientCertificate? clientCertificate = null;
 }
 
 @HiveType(typeId: 28)
@@ -919,6 +920,9 @@ class FinampSettings {
 
   @HiveField(150, defaultValue: DefaultSettings.homeScreenImageSizeMobile)
   int homeScreenImageSize;
+
+  @HiveField(151, defaultValue: DefaultSettings.clientCertificate)
+  ClientCertificate? clientCertificate = DefaultSettings.clientCertificate;
 
   static Future<FinampSettings> create() async {
     final downloadLocation = await DownloadLocation.create(
@@ -4624,4 +4628,15 @@ class QuickActionConfig {
   String toString() {
     return jsonEncode(toJson());
   }
+}
+
+@HiveType(typeId: 127)
+class ClientCertificate {
+  ClientCertificate({required this.data, required this.password});
+
+  @HiveField(0)
+  final Uint8List data;
+
+  @HiveField(1)
+  final String password;
 }

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -249,6 +249,7 @@ class DefaultSettings {
   static const duckOnAudioInterruption = true;
   static const forceAudioOffloadingOnAndroid = false;
   static const previousTracksPersistenceMode = PreviousTracksPersistenceMode.persistent;
+  static const ClientCertificate? clientCertificate = null;
 }
 
 @HiveType(typeId: 28)
@@ -846,6 +847,9 @@ class FinampSettings {
 
   @HiveField(145, defaultValue: DefaultSettings.previousTracksPersistenceMode)
   PreviousTracksPersistenceMode previousTracksPersistenceMode = DefaultSettings.previousTracksPersistenceMode;
+
+  @HiveField(146, defaultValue: DefaultSettings.clientCertificate)
+  ClientCertificate? clientCertificate = DefaultSettings.clientCertificate;
 
   static Future<FinampSettings> create() async {
     final downloadLocation = await DownloadLocation.create(
@@ -4003,4 +4007,15 @@ enum PreviousTracksPersistenceMode {
   /// Override state to be expanded on open
   @HiveField(2)
   initiallyExpanded,
+}
+
+@HiveType(typeId: 113)
+class ClientCertificate {
+  ClientCertificate({required this.data, required this.password});
+
+  @HiveField(0)
+  final Uint8List data;
+
+  @HiveField(1)
+  final String password;
 }

--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -464,13 +464,14 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       ..radioEnabled = fields[140] == null ? false : fields[140] as bool
       ..radioMode = fields[141] == null
           ? RadioMode.similar
-          : fields[141] as RadioMode;
+          : fields[141] as RadioMode
+      ..clientCertificate = fields[151] as ClientCertificate?;
   }
 
   @override
   void write(BinaryWriter writer, FinampSettings obj) {
     writer
-      ..writeByte(144)
+      ..writeByte(145)
       ..writeByte(0)
       ..write(obj.isOffline)
       ..writeByte(1)
@@ -758,7 +759,9 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       ..writeByte(149)
       ..write(obj.useAndroidGainEffect)
       ..writeByte(150)
-      ..write(obj.homeScreenImageSize);
+      ..write(obj.homeScreenImageSize)
+      ..writeByte(151)
+      ..write(obj.clientCertificate);
   }
 
   @override
@@ -1880,6 +1883,43 @@ class QuickActionConfigAdapter extends TypeAdapter<QuickActionConfig> {
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is QuickActionConfigAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}
+
+class ClientCertificateAdapter extends TypeAdapter<ClientCertificate> {
+  @override
+  final typeId = 127;
+
+  @override
+  ClientCertificate read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return ClientCertificate(
+      data: fields[0] as Uint8List,
+      password: fields[1] as String,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, ClientCertificate obj) {
+    writer
+      ..writeByte(2)
+      ..writeByte(0)
+      ..write(obj.data)
+      ..writeByte(1)
+      ..write(obj.password);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ClientCertificateAdapter &&
           runtimeType == other.runtimeType &&
           typeId == other.typeId;
 }

--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -462,13 +462,14 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       ..radioEnabled = fields[140] == null ? false : fields[140] as bool
       ..radioMode = fields[141] == null
           ? RadioMode.similar
-          : fields[141] as RadioMode;
+          : fields[141] as RadioMode
+      ..clientCertificate = fields[146] as ClientCertificate?;
   }
 
   @override
   void write(BinaryWriter writer, FinampSettings obj) {
     writer
-      ..writeByte(139)
+      ..writeByte(140)
       ..writeByte(0)
       ..write(obj.isOffline)
       ..writeByte(1)
@@ -746,7 +747,9 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       ..writeByte(144)
       ..write(obj.multichannelHandlingSetting)
       ..writeByte(145)
-      ..write(obj.previousTracksPersistenceMode);
+      ..write(obj.previousTracksPersistenceMode)
+      ..writeByte(146)
+      ..write(obj.clientCertificate);
   }
 
   @override
@@ -1570,6 +1573,43 @@ class FinampStorableQueueInfoAdapter
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is FinampStorableQueueInfoAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}
+
+class ClientCertificateAdapter extends TypeAdapter<ClientCertificate> {
+  @override
+  final typeId = 113;
+
+  @override
+  ClientCertificate read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return ClientCertificate(
+      data: fields[0] as Uint8List,
+      password: fields[1] as String,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, ClientCertificate obj) {
+    writer
+      ..writeByte(2)
+      ..writeByte(0)
+      ..write(obj.data)
+      ..writeByte(1)
+      ..write(obj.password);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ClientCertificateAdapter &&
           runtimeType == other.runtimeType &&
           typeId == other.typeId;
 }

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -2,6 +2,7 @@ import 'package:finamp/components/SettingsScreen/logout_list_tile.dart';
 import 'package:finamp/components/finamp_app_bar_back_button.dart';
 import 'package:finamp/components/finamp_icon.dart';
 import 'package:finamp/l10n/app_localizations.dart';
+import 'package:finamp/menus/client_certificate_authentication_menu.dart';
 import 'package:finamp/menus/quick_connect_authorization_menu.dart';
 import 'package:finamp/menus/server_sharing_menu.dart';
 import 'package:finamp/screens/accessibility_settings_screen.dart';
@@ -28,7 +29,9 @@ import 'package:url_launcher/url_launcher.dart';
 
 class SettingsScreen extends ConsumerStatefulWidget {
   const SettingsScreen({super.key});
+
   static const routeName = "/settings";
+
   @override
   ConsumerState<SettingsScreen> createState() => _SettingsScreenState();
 }
@@ -208,6 +211,16 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             leading: Icon(TablerIcons.lock_bolt),
             title: Text(AppLocalizations.of(context)!.quickConnectAuthorizationMenuButtonTitle),
             onTap: () => showQuickConnectAuthorizationMenu(context: context),
+          ),
+          ListTile(
+            leading: Icon(TablerIcons.certificate),
+            title: Text(AppLocalizations.of(context)!.clientCertificate),
+            subtitle: Text(
+              ref.watch(finampSettingsProvider.clientCertificate) != null
+                  ? AppLocalizations.of(context)!.clientCertificateInstalled
+                  : AppLocalizations.of(context)!.clientCertificateUnavailable,
+            ),
+            onTap: () => showClientCertificateMenu(context: context),
           ),
           const LogoutListTile(),
         ],

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -17,6 +17,7 @@ import 'package:finamp/screens/playback_reporting_settings_screen.dart';
 import 'package:finamp/screens/transcoding_settings_screen.dart';
 import 'package:finamp/screens/view_selector.dart';
 import 'package:finamp/screens/volume_normalization_settings_screen.dart';
+import 'package:finamp/services/client_certificate_installer.dart';
 import 'package:finamp/services/finamp_settings_helper.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
@@ -212,16 +213,17 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             title: Text(AppLocalizations.of(context)!.quickConnectAuthorizationMenuButtonTitle),
             onTap: () => showQuickConnectAuthorizationMenu(context: context),
           ),
-          ListTile(
-            leading: Icon(TablerIcons.certificate),
-            title: Text(AppLocalizations.of(context)!.clientCertificate),
-            subtitle: Text(
-              ref.watch(finampSettingsProvider.clientCertificate) != null
-                  ? AppLocalizations.of(context)!.clientCertificateInstalled
-                  : AppLocalizations.of(context)!.clientCertificateUnavailable,
+          if (ClientCertificateInstaller.isSupported)
+            ListTile(
+              leading: Icon(TablerIcons.certificate),
+              title: Text(AppLocalizations.of(context)!.clientCertificate),
+              subtitle: Text(
+                ref.watch(finampSettingsProvider.clientCertificate) != null
+                    ? AppLocalizations.of(context)!.clientCertificateInstalled
+                    : AppLocalizations.of(context)!.clientCertificateUnavailable,
+              ),
+              onTap: () => showClientCertificateMenu(context: context),
             ),
-            onTap: () => showClientCertificateMenu(context: context),
-          ),
           const LogoutListTile(),
         ],
       ),

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -6,6 +6,7 @@ import 'package:finamp/menus/server_sharing_menu.dart';
 import 'package:finamp/screens/accessibility_settings_screen.dart';
 import 'package:finamp/screens/interaction_settings_screen.dart';
 import 'package:finamp/screens/network_settings_screen.dart';
+import 'package:finamp/services/client_certificate_installer.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
@@ -205,16 +206,17 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             title: Text(AppLocalizations.of(context)!.quickConnectAuthorizationMenuButtonTitle),
             onTap: () => showQuickConnectAuthorizationMenu(context: context),
           ),
-          ListTile(
-            leading: Icon(TablerIcons.certificate),
-            title: Text(AppLocalizations.of(context)!.clientCertificate),
-            subtitle: Text(
-              ref.watch(finampSettingsProvider.clientCertificate) != null
-                  ? AppLocalizations.of(context)!.clientCertificateInstalled
-                  : AppLocalizations.of(context)!.clientCertificateUnavailable,
+          if (ClientCertificateInstaller.isSupported)
+            ListTile(
+              leading: Icon(TablerIcons.certificate),
+              title: Text(AppLocalizations.of(context)!.clientCertificate),
+              subtitle: Text(
+                ref.watch(finampSettingsProvider.clientCertificate) != null
+                    ? AppLocalizations.of(context)!.clientCertificateInstalled
+                    : AppLocalizations.of(context)!.clientCertificateUnavailable,
+              ),
+              onTap: () => showClientCertificateMenu(context: context),
             ),
-            onTap: () => showClientCertificateMenu(context: context),
-          ),
           const LogoutListTile(),
         ],
       ),

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,10 +1,11 @@
+import 'package:finamp/components/finamp_icon.dart';
 import 'package:finamp/l10n/app_localizations.dart';
+import 'package:finamp/menus/client_certificate_authentication_menu.dart';
 import 'package:finamp/menus/quick_connect_authorization_menu.dart';
 import 'package:finamp/menus/server_sharing_menu.dart';
 import 'package:finamp/screens/accessibility_settings_screen.dart';
 import 'package:finamp/screens/interaction_settings_screen.dart';
 import 'package:finamp/screens/network_settings_screen.dart';
-import 'package:finamp/components/finamp_icon.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
@@ -20,14 +21,16 @@ import 'audio_service_settings_screen.dart';
 import 'downloads_settings_screen.dart';
 import 'language_selection_screen.dart';
 import 'layout_settings_screen.dart';
+import 'playback_reporting_settings_screen.dart';
 import 'transcoding_settings_screen.dart';
 import 'view_selector.dart';
 import 'volume_normalization_settings_screen.dart';
-import 'playback_reporting_settings_screen.dart';
 
 class SettingsScreen extends ConsumerStatefulWidget {
   const SettingsScreen({super.key});
+
   static const routeName = "/settings";
+
   @override
   ConsumerState<SettingsScreen> createState() => _SettingsScreenState();
 }
@@ -201,6 +204,16 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             leading: Icon(TablerIcons.lock_bolt),
             title: Text(AppLocalizations.of(context)!.quickConnectAuthorizationMenuButtonTitle),
             onTap: () => showQuickConnectAuthorizationMenu(context: context),
+          ),
+          ListTile(
+            leading: Icon(TablerIcons.certificate),
+            title: Text(AppLocalizations.of(context)!.clientCertificate),
+            subtitle: Text(
+              ref.watch(finampSettingsProvider.clientCertificate) != null
+                  ? AppLocalizations.of(context)!.clientCertificateInstalled
+                  : AppLocalizations.of(context)!.clientCertificateUnavailable,
+            ),
+            onTap: () => showClientCertificateMenu(context: context),
           ),
           const LogoutListTile(),
         ],

--- a/lib/services/client_certificate_installer.dart
+++ b/lib/services/client_certificate_installer.dart
@@ -1,0 +1,37 @@
+import 'dart:io';
+
+import 'finamp_settings_helper.dart';
+
+class ClientCertificateInstaller {
+  /// Installs the configured [ClientCertificate] to the [SecurityContext.defaultContext], if available.
+  Future<void> defaultInstallClientCertificate() async {
+    await installClientCertificate(SecurityContext.defaultContext);
+  }
+
+  /// Installs the configured [ClientCertificate] into the given [context], if available.
+  Future<void> installClientCertificate(SecurityContext context) async {
+    var cert = FinampSettingsHelper.finampSettings.clientCertificate;
+    if (cert == null) {
+      return;
+    }
+
+    try {
+      context.usePrivateKeyBytes(cert.data, password: cert.password);
+      // "On iOS one call to usePrivateKey […] is used instead of two calls
+      // to useCertificateChain and usePrivateKey." (see [SecurityContext.usePrivateKey]).
+      if (!Platform.isIOS) {
+        context.useCertificateChainBytes(cert.data, password: cert.password);
+      }
+    } catch (e) {
+      _logger.warning('Failed to install client certificate in SecurityContext: $e');
+    }
+  }
+
+  Future<void> defaultClearClientCertificate() async {
+    await clearClientCertificate(SecurityContext.defaultContext);
+  }
+
+  Future<void> clearClientCertificate(SecurityContext context) async {
+    // TODO: clear certificate from context
+  }
+}

--- a/lib/services/client_certificate_installer.dart
+++ b/lib/services/client_certificate_installer.dart
@@ -2,9 +2,11 @@ import 'dart:io';
 
 import 'package:finamp/models/finamp_models.dart';
 import 'package:flutter/services.dart';
+import 'package:get_it/get_it.dart';
 import 'package:logging/logging.dart';
 
 import 'finamp_settings_helper.dart';
+import 'jellyfin_api_helper.dart';
 
 class ClientCertificateInstaller {
   static final isSupported = Platform.isAndroid;
@@ -25,6 +27,20 @@ class ClientCertificateInstaller {
     }
 
     installCertificateInSecurityContext(cert, SecurityContext.defaultContext);
+
+    // Install certificate to worker isolate with separate SecurityContext.
+    // During app startup, the API helper isn't registered yet, we can ignore that,
+    // since it'll pass the certificate to the isolate itself when spawning it.
+    if (GetIt.instance.isRegistered<JellyfinApiHelper>()) {
+      try {
+        await GetIt.instance<JellyfinApiHelper>().runInIsolate((_) async {
+          ClientCertificateInstaller().installCertificateInSecurityContext(cert, SecurityContext.defaultContext);
+          return true;
+        });
+      } catch (e) {
+        _logger.warning('Failed to install client certificate in worker isolate: $e');
+      }
+    }
 
     // On Android, ExoPlayer uses HttpURLConnection (not Dart's HttpClient),
     // so we also configure the JVM-global SSLContext via a method channel.

--- a/lib/services/client_certificate_installer.dart
+++ b/lib/services/client_certificate_installer.dart
@@ -60,7 +60,7 @@ class ClientCertificateInstaller {
       try {
         await _channel.invokeMethod('clearClientCertificate');
       } catch (e) {
-        _logger.warning('Failed to install client certificate in Android SSL context: $e');
+        _logger.warning('Failed to clear client certificate from Android SSL context: $e');
       }
     }
   }

--- a/lib/services/client_certificate_installer.dart
+++ b/lib/services/client_certificate_installer.dart
@@ -12,13 +12,10 @@ class ClientCertificateInstaller {
   static final _logger = Logger('ClientCertificateInstaller');
   static const _channel = MethodChannel('com.unicornsonlsd.finamp/client_certificate');
 
-  /// Installs the configured [ClientCertificate] to the [SecurityContext.defaultContext], if available.
-  Future<void> defaultInstallClientCertificate() async {
-    await installClientCertificate(SecurityContext.defaultContext);
-  }
-
-  /// Installs the configured [ClientCertificate] into the given [context], if available.
-  Future<void> installClientCertificate(SecurityContext context) async {
+  /// Installs the configured [ClientCertificate] in the whole app, if supported and available:
+  /// - into the [SecurityContext.defaultContext] used by Dart's HttpClient
+  /// - into the process-global Android SSL context
+  Future<void> installClientCertificate() async {
     if (!isSupported) {
       return;
     }
@@ -27,16 +24,7 @@ class ClientCertificateInstaller {
       return;
     }
 
-    try {
-      context.usePrivateKeyBytes(cert.data, password: cert.password);
-      // "On iOS one call to usePrivateKey […] is used instead of two calls
-      // to useCertificateChain and usePrivateKey." (see [SecurityContext.usePrivateKey]).
-      if (!Platform.isIOS) {
-        context.useCertificateChainBytes(cert.data, password: cert.password);
-      }
-    } catch (e) {
-      _logger.warning('Failed to install client certificate in SecurityContext: $e');
-    }
+    installCertificateInSecurityContext(cert, SecurityContext.defaultContext);
 
     // On Android, ExoPlayer uses HttpURLConnection (not Dart's HttpClient),
     // so we also configure the JVM-global SSLContext via a method channel.
@@ -49,12 +37,22 @@ class ClientCertificateInstaller {
     }
   }
 
-  Future<void> defaultClearClientCertificate() async {
-    await clearClientCertificate(SecurityContext.defaultContext);
+  /// Installs the given [cert] into [context].
+  void installCertificateInSecurityContext(ClientCertificate cert, SecurityContext context) {
+    try {
+      context.usePrivateKeyBytes(cert.data, password: cert.password);
+      // "On iOS one call to usePrivateKey […] is used instead of two calls
+      // to useCertificateChain and usePrivateKey." (see [SecurityContext.usePrivateKey]).
+      if (!Platform.isIOS) {
+        context.useCertificateChainBytes(cert.data, password: cert.password);
+      }
+    } catch (e) {
+      _logger.warning('Failed to install client certificate in SecurityContext: $e');
+    }
   }
 
-  Future<void> clearClientCertificate(SecurityContext context) async {
-    // TODO: clear certificate from context
+  Future<void> clearClientCertificate() async {
+    // TODO: clear certificate from SecurityContext.defaultContext
 
     if (Platform.isAndroid) {
       try {

--- a/lib/services/client_certificate_installer.dart
+++ b/lib/services/client_certificate_installer.dart
@@ -7,6 +7,8 @@ import 'package:logging/logging.dart';
 import 'finamp_settings_helper.dart';
 
 class ClientCertificateInstaller {
+  static final isSupported = Platform.isAndroid;
+
   static final _logger = Logger('ClientCertificateInstaller');
   static const _channel = MethodChannel('com.unicornsonlsd.finamp/client_certificate');
 
@@ -17,6 +19,9 @@ class ClientCertificateInstaller {
 
   /// Installs the configured [ClientCertificate] into the given [context], if available.
   Future<void> installClientCertificate(SecurityContext context) async {
+    if (!isSupported) {
+      return;
+    }
     var cert = FinampSettingsHelper.finampSettings.clientCertificate;
     if (cert == null) {
       return;

--- a/lib/services/client_certificate_installer.dart
+++ b/lib/services/client_certificate_installer.dart
@@ -1,8 +1,15 @@
 import 'dart:io';
 
+import 'package:finamp/models/finamp_models.dart';
+import 'package:flutter/services.dart';
+import 'package:logging/logging.dart';
+
 import 'finamp_settings_helper.dart';
 
 class ClientCertificateInstaller {
+  static final _logger = Logger('ClientCertificateInstaller');
+  static const _channel = MethodChannel('com.unicornsonlsd.finamp/client_certificate');
+
   /// Installs the configured [ClientCertificate] to the [SecurityContext.defaultContext], if available.
   Future<void> defaultInstallClientCertificate() async {
     await installClientCertificate(SecurityContext.defaultContext);
@@ -25,6 +32,16 @@ class ClientCertificateInstaller {
     } catch (e) {
       _logger.warning('Failed to install client certificate in SecurityContext: $e');
     }
+
+    // On Android, ExoPlayer uses HttpURLConnection (not Dart's HttpClient),
+    // so we also configure the JVM-global SSLContext via a method channel.
+    if (Platform.isAndroid) {
+      try {
+        await _channel.invokeMethod('installClientCertificate', {'bytes': cert.data, 'password': cert.password});
+      } catch (e) {
+        _logger.warning('Failed to install client certificate in Android SSL context: $e');
+      }
+    }
   }
 
   Future<void> defaultClearClientCertificate() async {
@@ -33,5 +50,13 @@ class ClientCertificateInstaller {
 
   Future<void> clearClientCertificate(SecurityContext context) async {
     // TODO: clear certificate from context
+
+    if (Platform.isAndroid) {
+      try {
+        await _channel.invokeMethod('clearClientCertificate');
+      } catch (e) {
+        _logger.warning('Failed to install client certificate in Android SSL context: $e');
+      }
+    }
   }
 }

--- a/lib/services/client_certificate_installer.dart
+++ b/lib/services/client_certificate_installer.dart
@@ -7,6 +7,8 @@ import 'package:logging/logging.dart';
 import 'finamp_settings_helper.dart';
 
 class ClientCertificateInstaller {
+  static final isSupported = Platform.isAndroid || Platform.isIOS || Platform.isMacOS;
+
   static final _logger = Logger('ClientCertificateInstaller');
   static const _channel = MethodChannel('com.unicornsonlsd.finamp/client_certificate');
 
@@ -17,6 +19,9 @@ class ClientCertificateInstaller {
 
   /// Installs the configured [ClientCertificate] into the given [context], if available.
   Future<void> installClientCertificate(SecurityContext context) async {
+    if (!isSupported) {
+      return;
+    }
     var cert = FinampSettingsHelper.finampSettings.clientCertificate;
     if (cert == null) {
       return;

--- a/lib/services/finamp_settings_helper.g.dart
+++ b/lib/services/finamp_settings_helper.g.dart
@@ -1274,6 +1274,14 @@ extension FinampSetters on FinampSettingsHelper {
     ).put("FinampSettings", finampSettingsTemp);
   }
 
+  static void setClientCertificate(ClientCertificate? newClientCertificate) {
+    FinampSettings finampSettingsTemp = FinampSettingsHelper.finampSettings;
+    finampSettingsTemp.clientCertificate = newClientCertificate;
+    Hive.box<FinampSettings>(
+      "FinampSettings",
+    ).put("FinampSettings", finampSettingsTemp);
+  }
+
   static void setBufferDuration(Duration newBufferDuration) {
     FinampSettings finampSettingsTemp = FinampSettingsHelper.finampSettings;
     finampSettingsTemp.bufferDuration = newBufferDuration;
@@ -1708,6 +1716,10 @@ extension FinampSettingsProviderSelectors on StreamProvider<FinampSettings> {
       .select((value) => value.requireValue.useAndroidGainEffect);
   ProviderListenable<int> get homeScreenImageSize => finampSettingsProvider
       .select((value) => value.requireValue.homeScreenImageSize);
+  ProviderListenable<ClientCertificate?> get clientCertificate =>
+      finampSettingsProvider.select(
+        (value) => value.requireValue.clientCertificate,
+      );
   ProviderListenable<DownloadProfile> get downloadTranscodingProfile =>
       finampSettingsProvider.select(
         (value) => value.requireValue.downloadTranscodingProfile,

--- a/lib/services/finamp_settings_helper.g.dart
+++ b/lib/services/finamp_settings_helper.g.dart
@@ -1270,6 +1270,14 @@ extension FinampSetters on FinampSettingsHelper {
     ).put("FinampSettings", finampSettingsTemp);
   }
 
+  static void setClientCertificate(ClientCertificate? newClientCertificate) {
+    FinampSettings finampSettingsTemp = FinampSettingsHelper.finampSettings;
+    finampSettingsTemp.clientCertificate = newClientCertificate;
+    Hive.box<FinampSettings>(
+      "FinampSettings",
+    ).put("FinampSettings", finampSettingsTemp);
+  }
+
   static void setBufferDuration(Duration newBufferDuration) {
     FinampSettings finampSettingsTemp = FinampSettingsHelper.finampSettings;
     finampSettingsTemp.bufferDuration = newBufferDuration;
@@ -1709,6 +1717,10 @@ extension FinampSettingsProviderSelectors on StreamProvider<FinampSettings> {
   get previousTracksPersistenceMode => finampSettingsProvider.select(
     (value) => value.requireValue.previousTracksPersistenceMode,
   );
+  ProviderListenable<ClientCertificate?> get clientCertificate =>
+      finampSettingsProvider.select(
+        (value) => value.requireValue.clientCertificate,
+      );
   ProviderListenable<DownloadProfile> get downloadTranscodingProfile =>
       finampSettingsProvider.select(
         (value) => value.requireValue.downloadTranscodingProfile,

--- a/lib/services/jellyfin_api_helper.dart
+++ b/lib/services/jellyfin_api_helper.dart
@@ -6,6 +6,7 @@ import 'dart:isolate';
 import 'package:chopper/chopper.dart';
 import 'package:collection/collection.dart';
 import 'package:finamp/components/global_snackbar.dart';
+import 'package:finamp/services/client_certificate_installer.dart';
 import 'package:finamp/services/http_aggregate_logging_interceptor.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
@@ -65,6 +66,8 @@ class JellyfinApiHelper {
     // Extend the default security context to trust Android user certificates.
     // This is a workaround for <https://github.com/dart-lang/sdk/issues/50435>.
     await FlutterUserCertificatesAndroid().trustAndroidUserCertificates(SecurityContext.defaultContext);
+
+    await ClientCertificateInstaller().defaultInstallClientCertificate();
 
     input.$1.send(requestPort.sendPort);
     final dir = (Platform.isAndroid || Platform.isIOS)

--- a/lib/services/jellyfin_api_helper.dart
+++ b/lib/services/jellyfin_api_helper.dart
@@ -49,7 +49,11 @@ class JellyfinApiHelper {
   JellyfinApiHelper() {
     ReceivePort startupPort = ReceivePort();
     var rootToken = RootIsolateToken.instance!;
-    Isolate.spawn(_processRequestsBackground, (startupPort.sendPort, rootToken));
+    // Pass client certificate to background isolates, since Hive isn't accessible from them.
+    var clientCertificate = ClientCertificateInstaller.isSupported
+        ? FinampSettingsHelper.finampSettings.clientCertificate
+        : null;
+    Isolate.spawn(_processRequestsBackground, (startupPort.sendPort, rootToken, clientCertificate));
     Future.sync(() async {
       _workerIsolatePort = await startupPort.first as SendPort?;
     });
@@ -59,7 +63,7 @@ class JellyfinApiHelper {
 
   /// This should only be run in a worker isolate
   /// Sets up singletons and listens for work.
-  static Future<void> _processRequestsBackground((SendPort, RootIsolateToken) input) async {
+  static Future<void> _processRequestsBackground((SendPort, RootIsolateToken, ClientCertificate?) input) async {
     BackgroundIsolateBinaryMessenger.ensureInitialized(input.$2);
     ReceivePort requestPort = ReceivePort();
 
@@ -67,7 +71,10 @@ class JellyfinApiHelper {
     // This is a workaround for <https://github.com/dart-lang/sdk/issues/50435>.
     await FlutterUserCertificatesAndroid().trustAndroidUserCertificates(SecurityContext.defaultContext);
 
-    await ClientCertificateInstaller().installClientCertificate();
+    // Configure SecurityContext to use client certificate, if provided.
+    if (input.$3 != null) {
+      ClientCertificateInstaller().installCertificateInSecurityContext(input.$3!, SecurityContext.defaultContext);
+    }
 
     input.$1.send(requestPort.sendPort);
     final dir = (Platform.isAndroid || Platform.isIOS)

--- a/lib/services/jellyfin_api_helper.dart
+++ b/lib/services/jellyfin_api_helper.dart
@@ -67,7 +67,7 @@ class JellyfinApiHelper {
     // This is a workaround for <https://github.com/dart-lang/sdk/issues/50435>.
     await FlutterUserCertificatesAndroid().trustAndroidUserCertificates(SecurityContext.defaultContext);
 
-    await ClientCertificateInstaller().defaultInstallClientCertificate();
+    await ClientCertificateInstaller().installClientCertificate();
 
     input.$1.send(requestPort.sendPort);
     final dir = (Platform.isAndroid || Platform.isIOS)

--- a/lib/services/jellyfin_api_helper.dart
+++ b/lib/services/jellyfin_api_helper.dart
@@ -6,6 +6,7 @@ import 'dart:isolate';
 import 'package:chopper/chopper.dart';
 import 'package:collection/collection.dart';
 import 'package:finamp/components/global_snackbar.dart';
+import 'package:finamp/services/client_certificate_installer.dart';
 import 'package:finamp/services/http_aggregate_logging_interceptor.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
@@ -62,6 +63,8 @@ class JellyfinApiHelper {
     // Extend the default security context to trust Android user certificates.
     // This is a workaround for <https://github.com/dart-lang/sdk/issues/50435>.
     await FlutterUserCertificatesAndroid().trustAndroidUserCertificates(SecurityContext.defaultContext);
+
+    await ClientCertificateInstaller().defaultInstallClientCertificate();
 
     input.$1.send(requestPort.sendPort);
     final dir = (Platform.isAndroid || Platform.isIOS)

--- a/lib/services/server_client_discovery_service.dart
+++ b/lib/services/server_client_discovery_service.dart
@@ -38,21 +38,29 @@ class JellyfinServerClientDiscovery {
       _discoverySocket.broadcastEnabled = true; // important to allow sending to broadcast address
       _discoverySocket.multicastHops = 5; // to account for weird network setups
 
-      _discoverySocket.listen((event) {
-        if (event == RawSocketEvent.read) {
-          final datagram = _discoverySocket.receive();
-          if (datagram != null) {
-            _clientDiscoveryLogger.finest("Received datagram: ${utf8.decode(datagram.data)}");
-            final response = ClientDiscoveryResponse.fromJson(
-              jsonDecode(utf8.decode(datagram.data)) as Map<String, dynamic>,
-            );
-            _clientDiscoveryLogger.fine(
-              "Received discovery response from ${datagram.address}:${datagram.port}: ${jsonEncode(response)}",
-            );
-            onServerFound(response);
+      _discoverySocket.listen(
+        (event) {
+          if (event == RawSocketEvent.read) {
+            final datagram = _discoverySocket.receive();
+            if (datagram != null) {
+              _clientDiscoveryLogger.finest("Received datagram: ${utf8.decode(datagram.data)}");
+              final response = ClientDiscoveryResponse.fromJson(
+                jsonDecode(utf8.decode(datagram.data)) as Map<String, dynamic>,
+              );
+              _clientDiscoveryLogger.fine(
+                "Received discovery response from ${datagram.address}:${datagram.port}: ${jsonEncode(response)}",
+              );
+              onServerFound(response);
+            }
           }
-        }
-      });
+        },
+        onError: (Object error) {
+          _clientDiscoveryLogger.severe("Discovery socket error: $error");
+        },
+        onDone: () {
+          _clientDiscoveryLogger.finest("Discovery socket closed");
+        },
+      );
 
       // Send discovery message repeatedly to scan for local servers (because UDP is unreliable)
       do {


### PR DESCRIPTION
## Changes
Adds a new setting that allows importing a `.p12` client certificate to be used for authenticating to a server/reverse proxy implementing mTLS.
The imported certificate and password are stored in Hive and applied to the Dart SecurityContext and Android/JVM SSLContext on startup, if available.
Linux/Windows are unsupported since we cannot supply a certificate to the MediaKit player, as this would require upstream library changes.

Tested on Android (fully functional) and Linux (library browsing works, downloads and media playback are broken).

## Todo before merging
- [ ] ~~Test on iOS/macOS~~ iOS support needs additional modifications, out of scope for this PR
- [x] Limit to supported platforms, e.g., Android + iOS + macOS
- [x] Allow to pick a certificate file during initial connection/login
- [ ] ~~Use separate SecurityContext and not the default one, so that we're able to reset it/clear the certificates (see TODO in `ClientCertificateInstaller`)~~ refactor moved to later PR
- [X] Translations
- [x] Reset Settings (should not be applicable for this)

## Related Issues
Fixes #1347
