### PR TITLE
Add a transcoding switch to the playback page.

### DIFF
--- a/lib/components/PlayerScreen/transcode_toggle_button.dart
+++ b/lib/components/PlayerScreen/transcode_toggle_button.dart
@@ -1,0 +1,35 @@
+import 'package:finamp/l10n/app_localizations.dart';
+import 'package:finamp/services/finamp_settings_helper.dart';
+import 'package:finamp/services/feedback_helper.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
+
+import '../../components/Buttons/simple_button.dart';
+
+/// A toggle button shown on the player screen to quickly enable/disable transcoding.
+///
+/// Only meaningful for streamed (non-downloaded) tracks. The button visually
+/// indicates the current state and toggles [FinampSettings.shouldTranscode],
+/// which triggers a queue reload via [DataSourceService].
+class TranscodeToggleButton extends ConsumerWidget {
+  const TranscodeToggleButton({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final shouldTranscode = ref.watch(finampSettingsProvider.shouldTranscode);
+    final l10n = AppLocalizations.of(context)!;
+
+    return SimpleButton(
+      text: l10n.transcodeToggleButtonTitle,
+      icon: shouldTranscode ? TablerIcons.transform : TablerIcons.transform,
+      iconColor: shouldTranscode
+          ? Theme.of(context).colorScheme.primary
+          : null,
+      onPressed: () {
+        FeedbackHelper.feedback(FeedbackType.light);
+        FinampSetters.setShouldTranscode(!shouldTranscode);
+      },
+    );
+  }
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2622,6 +2622,18 @@
   "@outputMenuButtonTitle": {
     "description": "Button title for opening the output menu/panel"
   },
+  "transcodeToggleButtonTitle": "Transcode",
+  "@transcodeToggleButtonTitle": {
+    "description": "Button title for toggling transcoding on/off from the player screen"
+  },
+  "transcodeToggleOnTooltip": "Transcoding is ON. Tap to disable.",
+  "@transcodeToggleOnTooltip": {
+    "description": "Tooltip shown when transcoding is enabled on the player screen toggle"
+  },
+  "transcodeToggleOffTooltip": "Transcoding is OFF. Tap to enable.",
+  "@transcodeToggleOffTooltip": {
+    "description": "Tooltip shown when transcoding is disabled on the player screen toggle"
+  },
   "outputMenuTitle": "Change Output",
   "@outputMenuTitle": {
     "description": "Title for the output menu that allows the user to change the audio output device and volume"

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1798,6 +1798,18 @@
     "@outputMenuButtonTitle": {
         "description": "Button title for opening the output menu/panel"
     },
+    "transcodeToggleButtonTitle": "转码",
+    "@transcodeToggleButtonTitle": {
+        "description": "Button title for toggling transcoding on/off from the player screen"
+    },
+    "transcodeToggleOnTooltip": "转码已开启。点击关闭。",
+    "@transcodeToggleOnTooltip": {
+        "description": "Tooltip shown when transcoding is enabled on the player screen toggle"
+    },
+    "transcodeToggleOffTooltip": "转码已关闭。点击开启。",
+    "@transcodeToggleOffTooltip": {
+        "description": "Tooltip shown when transcoding is disabled on the player screen toggle"
+    },
     "outputMenuVolumeSectionTitle": "音量",
     "@outputMenuVolumeSectionTitle": {
         "description": "Title for the volume section in the output menu"

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -1792,6 +1792,18 @@
     "@outputMenuButtonTitle": {
         "description": "Button title for opening the output menu/panel"
     },
+    "transcodeToggleButtonTitle": "轉碼",
+    "@transcodeToggleButtonTitle": {
+        "description": "Button title for toggling transcoding on/off from the player screen"
+    },
+    "transcodeToggleOnTooltip": "轉碼已開啟。點擊關閉。",
+    "@transcodeToggleOnTooltip": {
+        "description": "Tooltip shown when transcoding is enabled on the player screen toggle"
+    },
+    "transcodeToggleOffTooltip": "轉碼已關閉。點擊開啟。",
+    "@transcodeToggleOffTooltip": {
+        "description": "Tooltip shown when transcoding is disabled on the player screen toggle"
+    },
     "outputMenuTitle": "更改輸出",
     "@outputMenuTitle": {
         "description": "Title for the output menu that allows the user to change the audio output device and volume"

--- a/lib/screens/player_screen.dart
+++ b/lib/screens/player_screen.dart
@@ -9,6 +9,7 @@ import 'package:finamp/components/PlayerScreen/player_screen_album_image.dart';
 import 'package:finamp/components/PlayerScreen/player_screen_appbar_title.dart';
 import 'package:finamp/components/PlayerScreen/player_split_screen_scaffold.dart';
 import 'package:finamp/components/PlayerScreen/queue_button.dart';
+import 'package:finamp/components/PlayerScreen/transcode_toggle_button.dart';
 import 'package:finamp/components/PlayerScreen/queue_list.dart';
 import 'package:finamp/components/PlayerScreen/track_name_content.dart';
 import 'package:finamp/components/finamp_app_bar_button.dart';
@@ -370,6 +371,7 @@ class _PlayerScreenContent extends ConsumerWidget {
                 ),
               ),
               const Flexible(fit: FlexFit.tight, child: QueueButton()),
+              const Flexible(fit: FlexFit.tight, child: TranscodeToggleButton()),
               Flexible(
                 fit: FlexFit.tight,
                 child: SimpleButton(


### PR DESCRIPTION
<!-- Just a reminder that text in these brackets is not visible in the rendered output.
You also do **not** need to use this template. You can remove and modify anything however you like!
Its just a suggestion :)
-->

## Changes
<!-- Please describe what this Pull request adds or changes. Possibly with images -->
![3f109ad7f0d2637a1ec73d122978779e](https://github.com/user-attachments/assets/250959b2-ae10-4850-b081-3becd61a70ae)
A transcoding button has been added to the playback page, and relevant Chinese translations have been added to the translation function.

## Todo before merging
<!-- Add custom todos if deemed necessary to give others an overview on how far this PR is progressing -->

<!-- Did you add UI text? 
Yes. A transcoding button has been added to the playback page, and relevant Chinese translations have been added to the translation function.
- [ ] Translations
A transcoding button has been added to the playback page, and relevant Chinese translations have been added to the translation function.

I apologize, I'm not a professional software developer. The reason I submitted this PR is that I frequently need to use Finamp at home or outside, but for security reasons, I haven't directly exposed the Jellyfin server to the internet. When I'm at home, I expect to use un-transcoded high-definition music from the server, but my phone doesn't support that much storage. Therefore, I submitted this PR. If this PR doesn't comply with relevant specifications, I'm happy to remove it, as it's simply to solve a transcoding toggle issue.
