### PR TITLE
Fix validation when configuring address of a server outside the local network

### DIFF
--- a/lib/services/jellyfin_api_helper.dart
+++ b/lib/services/jellyfin_api_helper.dart
@@ -1022,7 +1022,7 @@ class JellyfinApiHelper {
       Response<dynamic> response = await client.send<dynamic, dynamic>($request);
       if (response.statusCode != 200) return false;
       final body = response.bodyOrThrow as Map<String, dynamic>;
-      // If IsInNetwork doesn't exist -> catch
+      // If IsInNetwork doesn't exist -> return false
       // because then its not a jellyfin server
       return body.containsKey("IsInNetwork");
     } catch (e) {

--- a/lib/services/jellyfin_api_helper.dart
+++ b/lib/services/jellyfin_api_helper.dart
@@ -1024,7 +1024,7 @@ class JellyfinApiHelper {
       final body = response.bodyOrThrow as Map<String, dynamic>;
       // If IsInNetwork doesn't exist -> catch
       // because then its not a jellyfin server
-      return body["IsInNetwork"] as bool;
+      return body.containsKey("IsInNetwork");
     } catch (e) {
       Logger("Ayoo").severe(e);
       return false;


### PR DESCRIPTION
## Changes
<!-- Please describe what this Pull request adds or changes. Possibly with images -->
Minor bug fix for checking if a URL is a jellyfin server. Previously, if you were not on the same network, the function would always false as if the server was not accessible even if it was. This just fixes that.

## Related Issues
Dicussed in the discord.
