### PR TITLE
Preserve server path for discovery info

### DIFF
--- a/lib/services/jellyfin_api_helper.dart
+++ b/lib/services/jellyfin_api_helper.dart
@@ -498,7 +498,9 @@ class JellyfinApiHelper {
   /// Can be used to check if the server is online / the URL is correct.
   /// Since we're potentially looking multiple servers, while the user is entering another base URL, we use a custom http client for this request.
   Future<PublicSystemInfoResult?> loadCustomServerPublicInfo(Uri customServerUrl) async {
-    final requestUrl = customServerUrl.replace(path: "/System/Info/Public");
+    final requestUrl = customServerUrl.replace(
+      pathSegments: customServerUrl.pathSegments.followedBy(["System", "Info", "Public"]),
+    );
     final httpClient = ChopperClient().httpClient; // http? where we're going, we don't need http
     final response = await httpClient.get(requestUrl);
     final responseJson = jsonDecode(response.body) as Map<String, dynamic>;


### PR DESCRIPTION
The manual `/System/Info/Public` probe discarded any path prefix from a discovered server URL, causing prefixed Jellyfin instances to be queried at the wrong endpoint.