### PR TITLE
(discussion) I nailed why gapless playback is broken with transcoding

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -84,9 +84,11 @@
               exec "$@"
             elif [[ "$1" == "target" && "$2" == "list" ]]; then
               # This handles rustup "target" "list" "--toolchain" "stable-x86_64-unknown-linux-gnu" "--installed"
-              # if cross-compiling (e.g. for android), add all four targets here (idk separator though) and to fenix
-              # Currently looks like discord rpc is not enabled on mobile
               echo "${targetName}"
+              echo "armv7-linux-androideabi"
+              echo "aarch64-linux-android"
+              echo "x86_64-linux-android"
+              echo "i686-linux-android"
             else
               echo "Can't run $*"
               exit 2
@@ -117,6 +119,11 @@
                 stable.cargo
                 stable.rustc
                 # rust-src in case of any issues
+
+                targets."armv7-linux-androideabi".stable.rust-std
+                targets."aarch64-linux-android".stable.rust-std
+                targets."x86_64-linux-android".stable.rust-std
+                targets."i686-linux-android".stable.rust-std
               ])
             ] else [
               rustup

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -2801,24 +2801,28 @@ enum KeepScreenOnOption {
 @HiveType(typeId: 73)
 enum FinampTranscodingStreamingFormat {
   @HiveField(0)
-  aacMpegTS("aac", "ts"),
+  aacMpegTS("aac", "ts", true),
   @HiveField(1)
-  aacFragmentedMp4("aac", "mp4"),
+  aacFragmentedMp4("aac", "mp4", true),
   @HiveField(2)
-  opusFragmentedMp4("opus", "mp4"),
+  opusFragmentedMp4("opus", "mp4", true),
   @HiveField(3)
-  flacFragmentedMp4("flac", "mp4"),
+  flacFragmentedMp4("flac", "mp4", true),
   @HiveField(4)
-  vorbisMpegTS("vorbis", "ts"),
+  vorbisMpegTS("vorbis", "ts", true),
   @HiveField(5)
-  vorbisFragmentedMp4("vorbis", "mp4");
+  vorbisFragmentedMp4("vorbis", "mp4", true),
+  @HiveField(6)
+  opusNonFragmented("opus", "ogg", false);
 
-  const FinampTranscodingStreamingFormat(this.codec, this.container);
+  const FinampTranscodingStreamingFormat(this.codec, this.container, this.isFragmented);
 
   final String codec;
 
   /// The container to use to transport the segments
   final String container;
+
+  final bool isFragmented;
 }
 
 @HiveType(typeId: 74)

--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -2458,6 +2458,8 @@ class FinampTranscodingStreamingFormatAdapter
         return FinampTranscodingStreamingFormat.vorbisMpegTS;
       case 5:
         return FinampTranscodingStreamingFormat.vorbisFragmentedMp4;
+      case 6:
+        return FinampTranscodingStreamingFormat.opusNonFragmented;
       default:
         return FinampTranscodingStreamingFormat.aacMpegTS;
     }
@@ -2478,6 +2480,8 @@ class FinampTranscodingStreamingFormatAdapter
         writer.writeByte(4);
       case FinampTranscodingStreamingFormat.vorbisFragmentedMp4:
         writer.writeByte(5);
+      case FinampTranscodingStreamingFormat.opusNonFragmented:
+        writer.writeByte(6);
     }
   }
 

--- a/lib/services/music_player_background_task.dart
+++ b/lib/services/music_player_background_task.dart
@@ -1414,28 +1414,65 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler with SeekHandler, Queue
     // queryParameters["PlaySessionId"] = _order.id; //!!! this currently breaks transcoding for some reason
 
     if (mediaItem.extras!["shouldTranscode"] as bool) {
-      builtPath.addAll(["Audio", mediaItem.extras!["itemJson"]["Id"] as String, "main.m3u8"]);
+      if (FinampSettingsHelper.finampSettings.transcodingStreamingFormat.isFragmented) {
+        builtPath.addAll([
+          "Audio",
+          mediaItem.extras!["itemJson"]["Id"] as String,
+          "main.m3u8"
+        ]);
 
-      queryParameters.addAll({
-        "audioCodec": FinampSettingsHelper.finampSettings.transcodingStreamingFormat.codec,
-        // Ideally we'd switch between 44.1/48kHz depending on the source is,
-        // realistically it doesn't matter too much
-        // default to 44100, only use 48000 for opus because opus doesn't support 44100
-        "playSessionId": mediaItem.extras!["playSessionId"] as String? ?? "",
-        "audioSampleRate": FinampSettingsHelper.finampSettings.transcodingStreamingFormat.codec == 'opus'
-            ? '48000'
-            : '44100',
-        "maxAudioBitDepth": "16",
-        "audioBitRate": FinampSettingsHelper.finampSettings.transcodeBitrate.toString(),
-        "segmentContainer": FinampSettingsHelper.finampSettings.transcodingStreamingFormat.container,
-      });
+        queryParameters.addAll({
+          "audioCodec": FinampSettingsHelper.finampSettings
+              .transcodingStreamingFormat.codec,
+          // Ideally we'd switch between 44.1/48kHz depending on the source is,
+          // realistically it doesn't matter too much
+          // default to 44100, only use 48000 for opus because opus doesn't support 44100
+          "playSessionId": mediaItem.extras!["playSessionId"] as String? ?? "",
+          "audioSampleRate": FinampSettingsHelper.finampSettings
+              .transcodingStreamingFormat.codec == 'opus'
+              ? '48000'
+              : '44100',
+          "maxAudioBitDepth": "16",
+          "audioBitRate": FinampSettingsHelper.finampSettings.transcodeBitrate
+              .toString(),
+          "segmentContainer": FinampSettingsHelper.finampSettings
+              .transcodingStreamingFormat.container,
+        });
 
-      if (FinampSettingsHelper.finampSettings.multichannelHandlingSetting ==
-              MultichannelHandlingSetting.stereoDownmixAll ||
-          (FinampSettingsHelper.finampSettings.multichannelHandlingSetting ==
-                  MultichannelHandlingSetting.stereoDownmixLossy &&
-              FinampSettingsHelper.finampSettings.transcodingStreamingFormat.codec != "flac")) {
-        queryParameters.addAll({"maxAudioChannels": "2"});
+        if (FinampSettingsHelper.finampSettings.multichannelHandlingSetting ==
+            MultichannelHandlingSetting.stereoDownmixAll ||
+            (FinampSettingsHelper.finampSettings.multichannelHandlingSetting ==
+                MultichannelHandlingSetting.stereoDownmixLossy &&
+                FinampSettingsHelper.finampSettings.transcodingStreamingFormat
+                    .codec != "flac")) {
+          queryParameters.addAll({"maxAudioChannels": "2"});
+        }
+      } else {
+        builtPath.addAll([
+          "Audio",
+          mediaItem.extras!["itemJson"]["Id"] as String,
+          "Universal"
+        ]);
+
+        queryParameters.addAll({
+          "transcodingContainer": FinampSettingsHelper.finampSettings
+              .transcodingStreamingFormat.container,
+          "audioCodec": FinampSettingsHelper.finampSettings
+              .transcodingStreamingFormat.codec,
+          // not supported here
+          //"playSessionId": mediaItem.extras!["playSessionId"] as String? ?? "",
+          "audioBitRate": FinampSettingsHelper.finampSettings.transcodeBitrate
+              .toString(),
+        });
+
+        if (FinampSettingsHelper.finampSettings.multichannelHandlingSetting ==
+            MultichannelHandlingSetting.stereoDownmixAll ||
+            (FinampSettingsHelper.finampSettings.multichannelHandlingSetting ==
+                MultichannelHandlingSetting.stereoDownmixLossy &&
+                FinampSettingsHelper.finampSettings.transcodingStreamingFormat
+                    .codec != "flac")) {
+          queryParameters.addAll({"maxAudioChannels": "2"});
+        }
       }
     } else {
       builtPath.addAll(["Items", mediaItem.extras!["itemJson"]["Id"] as String, "File"]);


### PR DESCRIPTION
## Changes

- Add "isFragmented" field in transcoding profiles and add a transcoding profile which uses /Audio/{id}/Universal API like downloads service which is the one that doesn't have gapped playback issue.  
  Other profiles still use Audio/{id}/main.m3u8 API which is different to downloads service and that's, I think, is the cause of difference.
- Break seeking with new profile

It still has some gap but it is the same as in offline mode - most likely a mismatch of signal between tracks which is pretty normal and means transcoding should go through whole playback, not individual tracks, but this requires server change.

Also, the "gapped playback" in my case is outright skipping some frames and even MPV itself (standalone, on desktop) is confused with those .m3u8 files (opus+mp4) sooo I think the issue is related to that. If I transcode them to flac with ffmpeg, everything's okay and the "some gap" is present in concatenation, too.

## Todo before merging

- [ ] Make all transcoding profiles non-fragmented
- [ ] Fix seeking :-)

## Related Issues

Fixes https://github.com/UnicornsOnLSD/finamp/issues/861

## Discussion

~~I'll of course try to fix seeking right now - I guess there's some code that uses the fact transcoding is enabled to seek inside fragments and now there's only one~~ there's none, idk why it broke - but is this fix even appropriate given it drastically changes behaviour and, I guess, will do some breaks on iOS?

I'll also try to upload some audio files from github web