### PR TITLE
feat(settings): add child mode toggle to hide download/delete buttons

### DIFF
--- a/lib/components/AlbumScreen/download_button.dart
+++ b/lib/components/AlbumScreen/download_button.dart
@@ -39,6 +39,10 @@ class DownloadButton extends ConsumerWidget {
     final downloadsService = GetIt.instance<DownloadsService>();
     DownloadItemStatus? status = ref.watch(downloadsService.statusProvider((item, childrenLength)));
     var isOffline = ref.watch(finampSettingsProvider.isOffline);
+    final enableChildMode = ref.watch(finampSettingsProvider.enableChildMode);
+    if (enableChildMode) {
+      return const SizedBox.shrink();
+    }
     bool canDeleteFromServer = false;
     if (item.type.requiresItem) {
       canDeleteFromServer = ref.watch(canDeleteFromServerProvider(item.baseItem!));

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3308,5 +3308,13 @@
   "androidGainDisabled": "Switching to gain effect fallback due to initialization error.",
   "@androidGainDisabled": {
     "description": "Message presented when the android gain effect fallback is enabled after an error occurs."
+  },
+  "enableChildModeTitle": "Enable child mode",
+  "@enableChildModeTitle": {
+    "description": "Title for the child mode toggle, which hides destructive actions like the download and delete buttons throughout the app."
+  },
+  "enableChildModeSubtitle": "Hides the download and delete buttons throughout the app to prevent accidental changes.",
+  "@enableChildModeSubtitle": {
+    "description": "Subtitle for the child mode toggle, explaining that it hides the download and delete buttons."
   }
 }

--- a/lib/menus/components/menuEntries/adaptive_download_lock_delete_menu_entry.dart
+++ b/lib/menus/components/menuEntries/adaptive_download_lock_delete_menu_entry.dart
@@ -19,6 +19,10 @@ class AdaptiveDownloadLockDeleteMenuEntry extends ConsumerWidget implements Hide
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    if (ref.watch(finampSettingsProvider.enableChildMode)) {
+      return const SizedBox.shrink();
+    }
+
     final downloadsService = GetIt.instance<DownloadsService>();
 
     final DownloadStub downloadStub = _getStub();
@@ -49,6 +53,9 @@ class AdaptiveDownloadLockDeleteMenuEntry extends ConsumerWidget implements Hide
 
   @override
   bool get isVisible {
+    if (FinampSettingsHelper.finampSettings.enableChildMode) {
+      return false;
+    }
     final DownloadItemStatus downloadStatus = GetIt.instance<DownloadsService>().getStatus(_getStub(), null);
 
     return downloadStatus.isRequired || !FinampSettingsHelper.finampSettings.isOffline;

--- a/lib/menus/components/menuEntries/delete_from_device_menu_entry.dart
+++ b/lib/menus/components/menuEntries/delete_from_device_menu_entry.dart
@@ -3,6 +3,7 @@ import 'package:finamp/l10n/app_localizations.dart';
 import 'package:finamp/menus/components/menuEntries/menu_entry.dart';
 import 'package:finamp/models/finamp_models.dart';
 import 'package:finamp/services/downloads_service.dart';
+import 'package:finamp/services/finamp_settings_helper.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:get_it/get_it.dart';
@@ -19,7 +20,7 @@ class DeleteFromDeviceMenuEntry extends ConsumerWidget implements HideableMenuEn
     final DownloadItemStatus downloadStatus = ref.watch(downloadsService.statusProvider((downloadStub, null)));
 
     return Visibility(
-      visible: downloadStatus.isRequired,
+      visible: downloadStatus.isRequired && !ref.watch(finampSettingsProvider.enableChildMode),
       child: MenuEntry(
         icon: Icons.delete_outlined,
         title: AppLocalizations.of(context)!.deleteFromTargetConfirmButton("device"),
@@ -31,5 +32,7 @@ class DeleteFromDeviceMenuEntry extends ConsumerWidget implements HideableMenuEn
   }
 
   @override
-  bool get isVisible => GetIt.instance<DownloadsService>().getStatus(downloadStub, null).isRequired;
+  bool get isVisible =>
+      GetIt.instance<DownloadsService>().getStatus(downloadStub, null).isRequired &&
+      !FinampSettingsHelper.finampSettings.enableChildMode;
 }

--- a/lib/menus/components/menuEntries/delete_from_server_menu_entry.dart
+++ b/lib/menus/components/menuEntries/delete_from_server_menu_entry.dart
@@ -20,7 +20,7 @@ class DeleteFromServerMenuEntry extends ConsumerWidget implements HideableMenuEn
     final canDelete = ref.watch(canDeleteFromServerProvider(baseItem));
 
     return Visibility(
-      visible: canDelete,
+      visible: canDelete && !ref.watch(finampSettingsProvider.enableChildMode),
       child: MenuEntry(
         icon: TablerIcons.trash_x,
         title: AppLocalizations.of(context)!.deleteFromTargetConfirmButton("server"),
@@ -41,6 +41,9 @@ class DeleteFromServerMenuEntry extends ConsumerWidget implements HideableMenuEn
   @override
   bool get isVisible {
     if (FinampSettingsHelper.finampSettings.isOffline) {
+      return false;
+    }
+    if (FinampSettingsHelper.finampSettings.enableChildMode) {
       return false;
     }
     var itemType = BaseItemDtoType.fromItem(baseItem);

--- a/lib/menus/components/menuEntries/download_menu_entry.dart
+++ b/lib/menus/components/menuEntries/download_menu_entry.dart
@@ -21,7 +21,10 @@ class DownloadMenuEntry extends ConsumerWidget implements HideableMenuEntry {
     final DownloadItemStatus? downloadStatus = ref.watch(downloadsService.statusProvider((downloadStub, null)));
 
     return Visibility(
-      visible: !ref.watch(finampSettingsProvider.isOffline) && downloadStatus == DownloadItemStatus.notNeeded,
+      visible:
+          !ref.watch(finampSettingsProvider.isOffline) &&
+          downloadStatus == DownloadItemStatus.notNeeded &&
+          !ref.watch(finampSettingsProvider.enableChildMode),
       child: MenuEntry(
         icon: TablerIcons.download,
         title: AppLocalizations.of(context)!.downloadItem,
@@ -38,5 +41,6 @@ class DownloadMenuEntry extends ConsumerWidget implements HideableMenuEntry {
   @override
   bool get isVisible =>
       GetIt.instance<DownloadsService>().getStatus(downloadStub, null) == DownloadItemStatus.notNeeded &&
-      !FinampSettingsHelper.finampSettings.isOffline;
+      !FinampSettingsHelper.finampSettings.isOffline &&
+      !FinampSettingsHelper.finampSettings.enableChildMode;
 }

--- a/lib/menus/components/menuEntries/lock_download_menu_entry.dart
+++ b/lib/menus/components/menuEntries/lock_download_menu_entry.dart
@@ -29,7 +29,10 @@ class LockDownloadMenuEntry extends ConsumerWidget implements HideableMenuEntry 
     }
 
     return Visibility(
-      visible: !ref.watch(finampSettingsProvider.isOffline) && (downloadStatus?.isIncidental ?? false),
+      visible:
+          !ref.watch(finampSettingsProvider.isOffline) &&
+          (downloadStatus?.isIncidental ?? false) &&
+          !ref.watch(finampSettingsProvider.enableChildMode),
       child: Tooltip(
         message: parentTooltip ?? "Widget shouldn't be visible",
         child: MenuEntry(
@@ -49,5 +52,6 @@ class LockDownloadMenuEntry extends ConsumerWidget implements HideableMenuEntry 
   @override
   bool get isVisible =>
       GetIt.instance<DownloadsService>().getStatus(downloadStub, null).isIncidental &&
-      !FinampSettingsHelper.finampSettings.isOffline;
+      !FinampSettingsHelper.finampSettings.isOffline &&
+      !FinampSettingsHelper.finampSettings.enableChildMode;
 }

--- a/lib/menus/music_screen_drawer.dart
+++ b/lib/menus/music_screen_drawer.dart
@@ -7,20 +7,23 @@ import 'package:finamp/components/MusicScreen/offline_mode_status_label.dart';
 import 'package:finamp/screens/playback_history_screen.dart';
 import 'package:finamp/screens/queue_restore_screen.dart';
 import 'package:finamp/screens/settings_screen.dart';
+import 'package:finamp/services/finamp_settings_helper.dart';
 import 'package:finamp/services/finamp_user_helper.dart';
 import 'package:flutter/material.dart';
 import 'package:finamp/l10n/app_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
 import 'package:get_it/get_it.dart';
 
-class MusicScreenDrawer extends StatelessWidget {
+class MusicScreenDrawer extends ConsumerWidget {
   const MusicScreenDrawer({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final finampUserHelper = GetIt.instance<FinampUserHelper>();
     final colorScheme = ColorScheme.of(context);
+    final enableChildMode = ref.watch(finampSettingsProvider.enableChildMode);
     return Drawer(
       surfaceTintColor: colorScheme.surfaceTint,
       backgroundColor: colorScheme.surface,
@@ -50,11 +53,12 @@ class MusicScreenDrawer extends StatelessWidget {
                 const OfflineModeSwitchListTile(),
                 const OfflineModeStatusLabel(),
                 Divider(),
-                ListTile(
-                  leading: const Padding(padding: EdgeInsets.only(right: 16), child: Icon(Icons.file_download)),
-                  title: Text(AppLocalizations.of(context)!.downloads),
-                  onTap: () => Navigator.of(context).pushNamed(DownloadsScreen.routeName),
-                ),
+                if (!enableChildMode)
+                  ListTile(
+                    leading: const Padding(padding: EdgeInsets.only(right: 16), child: Icon(Icons.file_download)),
+                    title: Text(AppLocalizations.of(context)!.downloads),
+                    onTap: () => Navigator.of(context).pushNamed(DownloadsScreen.routeName),
+                  ),
                 ListTile(
                   leading: const Padding(padding: EdgeInsets.only(right: 16), child: Icon(TablerIcons.clock)),
                   title: Text(AppLocalizations.of(context)!.playbackHistory),

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -251,6 +251,7 @@ class DefaultSettings {
   static const forceAudioOffloadingOnAndroid = false;
   static const previousTracksPersistenceMode = PreviousTracksPersistenceMode.persistent;
   static const useAndroidGainEffect = true;
+  static const enableChildMode = false;
 }
 
 @HiveType(typeId: 28)
@@ -396,6 +397,7 @@ class FinampSettings {
     this.forceAudioOffloadingOnAndroid = DefaultSettings.forceAudioOffloadingOnAndroid,
     this.previousTracksPersistenceMode = DefaultSettings.previousTracksPersistenceMode,
     this.useAndroidGainEffect = DefaultSettings.useAndroidGainEffect,
+    this.enableChildMode = DefaultSettings.enableChildMode,
   });
 
   @HiveField(0, defaultValue: DefaultSettings.isOffline)
@@ -856,6 +858,9 @@ class FinampSettings {
 
   @HiveField(147, defaultValue: DefaultSettings.useAndroidGainEffect)
   bool useAndroidGainEffect;
+
+  @HiveField(148, defaultValue: DefaultSettings.enableChildMode)
+  bool enableChildMode;
 
   static Future<FinampSettings> create() async {
     final downloadLocation = await DownloadLocation.create(

--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -452,6 +452,7 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
             ? PreviousTracksPersistenceMode.persistent
             : fields[145] as PreviousTracksPersistenceMode,
         useAndroidGainEffect: fields[147] == null ? true : fields[147] as bool,
+        enableChildMode: fields[148] == null ? false : fields[148] as bool,
       )
       ..disableGesture = fields[19] == null ? false : fields[19] as bool
       ..showFastScroller = fields[25] == null ? true : fields[25] as bool
@@ -470,7 +471,7 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
   @override
   void write(BinaryWriter writer, FinampSettings obj) {
     writer
-      ..writeByte(141)
+      ..writeByte(142)
       ..writeByte(0)
       ..write(obj.isOffline)
       ..writeByte(1)
@@ -752,7 +753,9 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       ..writeByte(146)
       ..write(obj.amoledTheme)
       ..writeByte(147)
-      ..write(obj.useAndroidGainEffect);
+      ..write(obj.useAndroidGainEffect)
+      ..writeByte(148)
+      ..write(obj.enableChildMode);
   }
 
   @override

--- a/lib/screens/interaction_settings_screen.dart
+++ b/lib/screens/interaction_settings_screen.dart
@@ -41,6 +41,7 @@ class _InteractionSettingsScreenState extends State<InteractionSettingsScreen> {
           FastScrollSelector(),
           AutoExpandPlayerScreenSelector(),
           ShowDeleteFromServerOptionToggle(),
+          EnableChildModeToggle(),
           KeepScreenOnDropdownListTile(),
           KeepScreenOnWhilePluggedInSelector(),
           PreferAddingToFavoritesOverPlaylistsToggle(),
@@ -133,6 +134,20 @@ class RememberLastUsedPlaybackActionRowPageToggle extends ConsumerWidget {
       subtitle: Text(AppLocalizations.of(context)!.rememberLastUsedPlaybackActionRowPageSubtitle),
       value: ref.watch(finampSettingsProvider.rememberLastUsedPlaybackActionRowPage),
       onChanged: (value) => FinampSetters.setRememberLastUsedPlaybackActionRowPage(value),
+    );
+  }
+}
+
+class EnableChildModeToggle extends ConsumerWidget {
+  const EnableChildModeToggle({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return SwitchListTile.adaptive(
+      title: Text(AppLocalizations.of(context)!.enableChildModeTitle),
+      subtitle: Text(AppLocalizations.of(context)!.enableChildModeSubtitle),
+      value: ref.watch(finampSettingsProvider.enableChildMode),
+      onChanged: FinampSetters.setEnableChildMode,
     );
   }
 }

--- a/lib/services/finamp_settings_helper.dart
+++ b/lib/services/finamp_settings_helper.dart
@@ -231,6 +231,7 @@ class FinampSettingsHelper {
     FinampSetters.setPreferNextUpPrepending(DefaultSettings.preferNextUpPrepending);
     FinampSetters.setRememberLastUsedPlaybackActionRowPage(DefaultSettings.rememberLastUsedPlaybackActionRowPage);
     FinampSetters.setPreviousTracksPersistenceMode(DefaultSettings.previousTracksPersistenceMode);
+    finampSettingsTemp.enableChildMode = DefaultSettings.enableChildMode;
 
     Hive.box<FinampSettings>("FinampSettings").put("FinampSettings", finampSettingsTemp);
   }

--- a/lib/services/finamp_settings_helper.g.dart
+++ b/lib/services/finamp_settings_helper.g.dart
@@ -1286,6 +1286,14 @@ extension FinampSetters on FinampSettingsHelper {
     ).put("FinampSettings", finampSettingsTemp);
   }
 
+  static void setEnableChildMode(bool newEnableChildMode) {
+    FinampSettings finampSettingsTemp = FinampSettingsHelper.finampSettings;
+    finampSettingsTemp.enableChildMode = newEnableChildMode;
+    Hive.box<FinampSettings>(
+      "FinampSettings",
+    ).put("FinampSettings", finampSettingsTemp);
+  }
+
   static void setBufferDuration(Duration newBufferDuration) {
     FinampSettings finampSettingsTemp = FinampSettingsHelper.finampSettings;
     finampSettingsTemp.bufferDuration = newBufferDuration;
@@ -1729,6 +1737,9 @@ extension FinampSettingsProviderSelectors on StreamProvider<FinampSettings> {
       finampSettingsProvider.select((value) => value.requireValue.amoledTheme);
   ProviderListenable<bool> get useAndroidGainEffect => finampSettingsProvider
       .select((value) => value.requireValue.useAndroidGainEffect);
+  ProviderListenable<bool> get enableChildMode => finampSettingsProvider.select(
+    (value) => value.requireValue.enableChildMode,
+  );
   ProviderListenable<DownloadProfile> get downloadTranscodingProfile =>
       finampSettingsProvider.select(
         (value) => value.requireValue.downloadTranscodingProfile,


### PR DESCRIPTION
## Summary

Adds a new "Enable child mode" toggle in **Interaction Settings** that hides every UI affordance for downloading or deleting items in the app. Originally requested by @yringler in #559: an offline-mode-friendly setting so kids using the app for playback can't accidentally delete the parent's downloaded library.

Closes #559

## Implementation

Followed the "Adding a New Setting" guide in `CONTRIBUTING.md`:

- `lib/models/finamp_models.dart`: new `enableChildMode` field on `FinampSettings` (`@HiveField(148)`) + `DefaultSettings.enableChildMode = false`.
- `lib/services/finamp_settings_helper.dart`: reset added to `resetInteractionsSettings()`.
- `lib/screens/interaction_settings_screen.dart`: new `EnableChildModeToggle` placed right after `ShowDeleteFromServerOptionToggle` (both are protective settings).
- `lib/l10n/app_en.arb`: `enableChildModeTitle` / `enableChildModeSubtitle`.
- Generated files (`finamp_models.g.dart`, `finamp_settings_helper.g.dart`) regenerated via `dart run build_runner build --delete-conflicting-outputs`.

To make sure the toggle covers the actual issue text ("the app just wouldn't show the ability to download or delete downloaded files **anywhere**"), I patched every entry point I could find while testing the build on Windows desktop:

- **Inline `DownloadButton`** (Album/Artist/Genre/Library tile): `lib/components/AlbumScreen/download_button.dart` returns `SizedBox.shrink()` when child mode is on.
- **Per-item context menus (3-dots)** - five menu entries, each with both a `Visibility(visible: ...)` gate in `build()` and an `isVisible` getter for the `HideableMenuEntry` interface:
  - `lib/menus/components/menuEntries/download_menu_entry.dart`
  - `lib/menus/components/menuEntries/delete_from_device_menu_entry.dart`
  - `lib/menus/components/menuEntries/delete_from_server_menu_entry.dart`
  - `lib/menus/components/menuEntries/lock_download_menu_entry.dart`
  - `lib/menus/components/menuEntries/adaptive_download_lock_delete_menu_entry.dart`
- **Navigation drawer**: `lib/menus/music_screen_drawer.dart` was converted to a `ConsumerWidget` and the "Downloads" `ListTile` is conditionally rendered. Other entries (Playback History, Saved Queues, Logs, Settings) are kept - none of them expose a way to delete downloaded files.

`flutter analyze` returns 0 new errors. Code formatted with `dart format`.

## Question for reviewers - scope of "anywhere"

While testing I hit one ambiguity: the drawer's **"Saved Queues"** entry uses an `Icons.auto_delete` icon and the screen's tiles use `TablerIcons.restore`. Reading the code, that screen only restores past playback queues; it doesn't delete any downloaded file. So I left it visible in child mode. Happy to also gate it behind `enableChildMode` if you prefer the stricter interpretation - let me know.

## Test plan

Tested on Windows desktop (`flutter run -d windows`) against a real Jellyfin server. With child mode **on**:

- [x] Toggle persists across app restarts
- [x] Album screen header has no download / delete icons
- [x] Album screen 3-dots menu has no Download / Delete / Lock entries
- [x] Same on Artist, Genre, and individual track menus (same 5 menu entries are reused)
- [x] Drawer no longer shows the "Downloads" link
- [x] Saved Queues entry still works (intentionally - see question above)
- [x] Reset button on Interaction Settings restores `enableChildMode = false`

With child mode **off**, every download/delete affordance reappears unchanged.

## Code assistance

Used Claude (LLM) to scaffold the new setting following `CONTRIBUTING.md`, to grep for every download/delete entry point after the first round of manual testing surfaced gaps in the initial fix, and to verify the screens that were left visible (Saved Queues) actually don't expose any download/delete action.
