### PR TITLE
feat(accessibility): add toggle to disable overscroll effect

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3308,5 +3308,13 @@
   "androidGainDisabled": "Switching to gain effect fallback due to initialization error.",
   "@androidGainDisabled": {
     "description": "Message presented when the android gain effect fallback is enabled after an error occurs."
+  },
+  "disableOverscrollTitle": "Disable overscroll effect",
+  "@disableOverscrollTitle": {
+    "description": "Title for the accessibility setting that disables the overscroll stretch/glow effect on scrollable lists."
+  },
+  "disableOverscrollSubtitle": "Removes the bouncing or glowing effect when scrolling past the end of a list. Useful for users sensitive to motion.",
+  "@disableOverscrollSubtitle": {
+    "description": "Subtitle for the disable overscroll toggle, explaining the motion-related rationale."
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -735,7 +735,7 @@ class FinampApp extends ConsumerWidget {
         ),
         pageTransitionsTheme: transitionBuilder,
       ),
-      scrollBehavior: FinampScrollBehavior(),
+      scrollBehavior: FinampScrollBehavior(disableOverscroll: ref.watch(finampSettingsProvider.disableOverscroll)),
       themeMode: themeMode,
       localizationsDelegates: const [
         AppLocalizations.delegate,
@@ -895,11 +895,12 @@ class ErrorScreen extends StatelessWidget {
 
 // Show scrollbars on all vertically scrolling widgets by default
 class FinampScrollBehavior extends MaterialScrollBehavior {
-  const FinampScrollBehavior({this.interactive, this.scrollbars = true});
+  const FinampScrollBehavior({this.interactive, this.scrollbars = true, this.disableOverscroll = false});
 
   // If interactive is null, platform default will be used
   final bool? interactive;
   final bool scrollbars;
+  final bool disableOverscroll;
 
   @override
   Widget buildScrollbar(BuildContext context, Widget child, ScrollableDetails details) {
@@ -913,6 +914,14 @@ class FinampScrollBehavior extends MaterialScrollBehavior {
         assert(details.controller != null);
         return Scrollbar(controller: details.controller, interactive: interactive, child: child);
     }
+  }
+
+  @override
+  Widget buildOverscrollIndicator(BuildContext context, Widget child, ScrollableDetails details) {
+    if (disableOverscroll) {
+      return child;
+    }
+    return super.buildOverscrollIndicator(context, child, details);
   }
 }
 

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -859,7 +859,7 @@ class FinampSettings {
   @HiveField(147, defaultValue: DefaultSettings.useAndroidGainEffect)
   bool useAndroidGainEffect;
 
-  @HiveField(148, defaultValue: DefaultSettings.disableOverscroll)
+  @HiveField(149, defaultValue: DefaultSettings.disableOverscroll)
   bool disableOverscroll;
 
   static Future<FinampSettings> create() async {

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -251,6 +251,7 @@ class DefaultSettings {
   static const forceAudioOffloadingOnAndroid = false;
   static const previousTracksPersistenceMode = PreviousTracksPersistenceMode.persistent;
   static const useAndroidGainEffect = true;
+  static const disableOverscroll = false;
 }
 
 @HiveType(typeId: 28)
@@ -396,6 +397,7 @@ class FinampSettings {
     this.forceAudioOffloadingOnAndroid = DefaultSettings.forceAudioOffloadingOnAndroid,
     this.previousTracksPersistenceMode = DefaultSettings.previousTracksPersistenceMode,
     this.useAndroidGainEffect = DefaultSettings.useAndroidGainEffect,
+    this.disableOverscroll = DefaultSettings.disableOverscroll,
   });
 
   @HiveField(0, defaultValue: DefaultSettings.isOffline)
@@ -856,6 +858,9 @@ class FinampSettings {
 
   @HiveField(147, defaultValue: DefaultSettings.useAndroidGainEffect)
   bool useAndroidGainEffect;
+
+  @HiveField(148, defaultValue: DefaultSettings.disableOverscroll)
+  bool disableOverscroll;
 
   static Future<FinampSettings> create() async {
     final downloadLocation = await DownloadLocation.create(

--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -452,6 +452,7 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
             ? PreviousTracksPersistenceMode.persistent
             : fields[145] as PreviousTracksPersistenceMode,
         useAndroidGainEffect: fields[147] == null ? true : fields[147] as bool,
+        disableOverscroll: fields[148] == null ? false : fields[148] as bool,
       )
       ..disableGesture = fields[19] == null ? false : fields[19] as bool
       ..showFastScroller = fields[25] == null ? true : fields[25] as bool
@@ -470,7 +471,7 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
   @override
   void write(BinaryWriter writer, FinampSettings obj) {
     writer
-      ..writeByte(141)
+      ..writeByte(142)
       ..writeByte(0)
       ..write(obj.isOffline)
       ..writeByte(1)
@@ -752,7 +753,9 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       ..writeByte(146)
       ..write(obj.amoledTheme)
       ..writeByte(147)
-      ..write(obj.useAndroidGainEffect);
+      ..write(obj.useAndroidGainEffect)
+      ..writeByte(148)
+      ..write(obj.disableOverscroll);
   }
 
   @override

--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -452,7 +452,7 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
             ? PreviousTracksPersistenceMode.persistent
             : fields[145] as PreviousTracksPersistenceMode,
         useAndroidGainEffect: fields[147] == null ? true : fields[147] as bool,
-        disableOverscroll: fields[148] == null ? false : fields[148] as bool,
+        disableOverscroll: fields[149] == null ? false : fields[149] as bool,
       )
       ..disableGesture = fields[19] == null ? false : fields[19] as bool
       ..showFastScroller = fields[25] == null ? true : fields[25] as bool
@@ -754,7 +754,7 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       ..write(obj.amoledTheme)
       ..writeByte(147)
       ..write(obj.useAndroidGainEffect)
-      ..writeByte(148)
+      ..writeByte(149)
       ..write(obj.disableOverscroll);
   }
 

--- a/lib/screens/accessibility_settings_screen.dart
+++ b/lib/screens/accessibility_settings_screen.dart
@@ -26,7 +26,12 @@ class _AccessibilitySettingsScreenState extends State<AccessibilitySettingsScree
       ),
       body: ListView(
         padding: const EdgeInsets.only(bottom: 200.0),
-        children: const [UseHighContrastColorsToggle(), DisableGestureSelector(), DisableVibrationSelector()],
+        children: const [
+          UseHighContrastColorsToggle(),
+          DisableGestureSelector(),
+          DisableVibrationSelector(),
+          DisableOverscrollToggle(),
+        ],
       ),
     );
   }
@@ -70,6 +75,20 @@ class DisableVibrationSelector extends ConsumerWidget {
       subtitle: Text(AppLocalizations.of(context)!.enableVibrationSubtitle),
       value: ref.watch(finampSettingsProvider.enableVibration),
       onChanged: (value) => FinampSetters.setEnableVibration(value),
+    );
+  }
+}
+
+class DisableOverscrollToggle extends ConsumerWidget {
+  const DisableOverscrollToggle({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return SwitchListTile.adaptive(
+      title: Text(AppLocalizations.of(context)!.disableOverscrollTitle),
+      subtitle: Text(AppLocalizations.of(context)!.disableOverscrollSubtitle),
+      value: ref.watch(finampSettingsProvider.disableOverscroll),
+      onChanged: FinampSetters.setDisableOverscroll,
     );
   }
 }

--- a/lib/services/finamp_settings_helper.dart
+++ b/lib/services/finamp_settings_helper.dart
@@ -248,6 +248,7 @@ class FinampSettingsHelper {
     FinampSetters.setUseHighContrastColors(DefaultSettings.useHighContrastColors);
     FinampSetters.setDisableGesture(DefaultSettings.disableGesture);
     FinampSetters.setEnableVibration(DefaultSettings.enableVibration);
+    FinampSetters.setDisableOverscroll(DefaultSettings.disableOverscroll);
   }
 
   static void resetLocale() {

--- a/lib/services/finamp_settings_helper.g.dart
+++ b/lib/services/finamp_settings_helper.g.dart
@@ -1286,6 +1286,14 @@ extension FinampSetters on FinampSettingsHelper {
     ).put("FinampSettings", finampSettingsTemp);
   }
 
+  static void setDisableOverscroll(bool newDisableOverscroll) {
+    FinampSettings finampSettingsTemp = FinampSettingsHelper.finampSettings;
+    finampSettingsTemp.disableOverscroll = newDisableOverscroll;
+    Hive.box<FinampSettings>(
+      "FinampSettings",
+    ).put("FinampSettings", finampSettingsTemp);
+  }
+
   static void setBufferDuration(Duration newBufferDuration) {
     FinampSettings finampSettingsTemp = FinampSettingsHelper.finampSettings;
     finampSettingsTemp.bufferDuration = newBufferDuration;
@@ -1729,6 +1737,8 @@ extension FinampSettingsProviderSelectors on StreamProvider<FinampSettings> {
       finampSettingsProvider.select((value) => value.requireValue.amoledTheme);
   ProviderListenable<bool> get useAndroidGainEffect => finampSettingsProvider
       .select((value) => value.requireValue.useAndroidGainEffect);
+  ProviderListenable<bool> get disableOverscroll => finampSettingsProvider
+      .select((value) => value.requireValue.disableOverscroll);
   ProviderListenable<DownloadProfile> get downloadTranscodingProfile =>
       finampSettingsProvider.select(
         (value) => value.requireValue.downloadTranscodingProfile,


### PR DESCRIPTION
## Summary

Adds a new "Disable overscroll effect" toggle in **Accessibility Settings**. When enabled, the stretch (Android 12+) / glow / bounce indicators are removed across every scrollable list in the app.

This addresses a motion-sickness accessibility concern raised in the issue. The original reporter mentioned that the elongation/stretch effect (introduced with the redesign branch on Android 12+) triggers motion sickness, while older Material glow effects were fine; a per-user toggle gives them an opt-out without changing default behavior for everyone else.

Closes #690

## Implementation

Followed the "Adding a New Setting" guide in `CONTRIBUTING.md`:

- `lib/models/finamp_models.dart`: new `disableOverscroll` field on `FinampSettings` (`@HiveField(149)`) + `DefaultSettings.disableOverscroll = false` (off by default - no behavior change for existing users)
- `lib/services/finamp_settings_helper.dart`: reset added to `resetAccessibilitySettings()`
- `lib/screens/accessibility_settings_screen.dart`: new `DisableOverscrollToggle` widget appended after the existing accessibility toggles
- `lib/main.dart`: `FinampScrollBehavior` now accepts a `disableOverscroll` flag and overrides `buildOverscrollIndicator` to return the child unchanged when enabled. The flag is fed from `ref.watch(finampSettingsProvider.disableOverscroll)` at the `MaterialApp.scrollBehavior` site, so the toggle takes effect live without needing a restart.
- `lib/l10n/app_en.arb`: `disableOverscrollTitle` / `disableOverscrollSubtitle`
- Generated files (`finamp_models.g.dart`, `finamp_settings_helper.g.dart`) regenerated via `dart run build_runner build --delete-conflicting-outputs`; `flutter gen-l10n` regenerated `AppLocalizations` getters

`flutter analyze` returns 0 new issues. Code formatted with `dart format`.

## Test plan

I tested this locally on **Windows desktop** (`flutter run -d windows`). Setting works there, but it's effectively a no-op on desktop platforms because the framework's `MaterialScrollBehavior.buildOverscrollIndicator` already returns the child unchanged on iOS/Linux/macOS/Windows ([Flutter source](https://github.com/flutter/flutter/blob/3.41.9/packages/flutter/lib/src/material/app.dart#L877-L881)). I verified that:

- [x] Toggle appears in Settings → Accessibility, after "Enable Vibration"
- [x] Toggling persists across app restarts
- [x] On Windows desktop nothing visible changes (expected - overscroll wasn't drawn there in the first place)
- [x] Reset button on Accessibility Settings restores the toggle to off

The change that actually matters is for Android, where `MaterialScrollBehavior.buildOverscrollIndicator` decides between `StretchingOverscrollIndicator` (M3) and `GlowingOverscrollIndicator` (M2) and wraps the child. With `disableOverscroll = true`, my override short-circuits both and returns the child raw.

> ⚠️ **Honest disclosure:** I haven't been able to run this on an Android device yet. The code path I added uses an existing well-supported Flutter API and is gated behind a default-off setting, so I'm confident there's no regression risk; but a runtime check on Android (verify stretch is gone when ON, glow is gone on older Androids when ON, both reappear when OFF) from a reviewer with an emulator/device handy would be very welcome before merge.

## Notes

- I considered respecting `MediaQuery.disableAnimations` (the system "Remove animations" preference) automatically, as the original reporter suggested. I went with an explicit toggle instead because the existing animation-related code (`MediaQuery.disableAnimationsOf` in `main.dart` for page transitions) treats it as a separate concern, and motion sickness from overscroll specifically may not always overlap with full animation removal. Happy to switch to system-aware behavior if you'd prefer.
