### PR TITLE
feat(customization): add toggle to expand long track titles

### DIFF
--- a/lib/components/AlbumScreen/track_list_tile.dart
+++ b/lib/components/AlbumScreen/track_list_tile.dart
@@ -811,31 +811,37 @@ class TrackListItemTile extends ConsumerWidget {
           AlbumImage(item: baseItem, borderRadius: BorderRadius.circular(albumCoverCornerRadius)),
       ],
     );
+    final expandTrackTitles = ref.watch(finampSettingsProvider.expandTrackTitles);
+    final titleTextWidget = Text(
+      baseItem.name ?? AppLocalizations.of(context)!.unknownName,
+      style: TextStyle(
+        color: Theme.of(context).textTheme.bodyLarge!.color,
+        fontSize: 15.5,
+        fontWeight: FontWeight.w500,
+        height: 1.1,
+      ),
+      overflow: expandTrackTitles ? TextOverflow.visible : TextOverflow.ellipsis,
+      softWrap: true,
+      maxLines: expandTrackTitles ? null : 2,
+    );
     final tileTitle = ConstrainedBox(
-      constraints: const BoxConstraints(maxHeight: defaultTileHeight),
+      constraints: expandTrackTitles ? const BoxConstraints() : const BoxConstraints(maxHeight: defaultTileHeight),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
-        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-        mainAxisSize: MainAxisSize.max,
+        mainAxisAlignment: expandTrackTitles ? MainAxisAlignment.start : MainAxisAlignment.spaceEvenly,
+        mainAxisSize: expandTrackTitles ? MainAxisSize.min : MainAxisSize.max,
         children: [
-          Flexible(
-            fit: FlexFit.loose,
-            flex: 3,
-            child: Text(
-              baseItem.name ?? AppLocalizations.of(context)!.unknownName,
-              style: TextStyle(
-                color: Theme.of(context).textTheme.bodyLarge!.color,
-                fontSize: 15.5,
-                fontWeight: FontWeight.w500,
-                height: 1.1,
-              ),
-              overflow: TextOverflow.ellipsis,
-              maxLines: 2,
+          if (expandTrackTitles)
+            Padding(padding: const EdgeInsets.symmetric(vertical: 6), child: titleTextWidget)
+          else
+            Flexible(
+              fit: FlexFit.loose,
+              flex: 3,
+              child: titleTextWidget,
             ),
-          ),
           Flexible(
             fit: FlexFit.loose,
-            flex: 2,
+            flex: expandTrackTitles ? 0 : 2,
             child: Text.rich(
               overflow: TextOverflow.clip,
               softWrap: false,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3308,5 +3308,13 @@
   "androidGainDisabled": "Switching to gain effect fallback due to initialization error.",
   "@androidGainDisabled": {
     "description": "Message presented when the android gain effect fallback is enabled after an error occurs."
+  },
+  "expandTrackTitlesTitle": "Expand long track titles",
+  "@expandTrackTitlesTitle": {
+    "description": "Title for the customization setting that lets long track titles wrap onto multiple lines instead of being truncated after two lines."
+  },
+  "expandTrackTitlesSubtitle": "Lets long track titles wrap onto as many lines as needed instead of being cut off. Useful for classical music and long titles.",
+  "@expandTrackTitlesSubtitle": {
+    "description": "Subtitle for the expand track titles toggle, explaining the wrapping behavior and use case."
   }
 }

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -251,6 +251,7 @@ class DefaultSettings {
   static const forceAudioOffloadingOnAndroid = false;
   static const previousTracksPersistenceMode = PreviousTracksPersistenceMode.persistent;
   static const useAndroidGainEffect = true;
+  static const expandTrackTitles = false;
 }
 
 @HiveType(typeId: 28)
@@ -396,6 +397,7 @@ class FinampSettings {
     this.forceAudioOffloadingOnAndroid = DefaultSettings.forceAudioOffloadingOnAndroid,
     this.previousTracksPersistenceMode = DefaultSettings.previousTracksPersistenceMode,
     this.useAndroidGainEffect = DefaultSettings.useAndroidGainEffect,
+    this.expandTrackTitles = DefaultSettings.expandTrackTitles,
   });
 
   @HiveField(0, defaultValue: DefaultSettings.isOffline)
@@ -856,6 +858,9 @@ class FinampSettings {
 
   @HiveField(147, defaultValue: DefaultSettings.useAndroidGainEffect)
   bool useAndroidGainEffect;
+
+  @HiveField(150, defaultValue: DefaultSettings.expandTrackTitles)
+  bool expandTrackTitles;
 
   static Future<FinampSettings> create() async {
     final downloadLocation = await DownloadLocation.create(

--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -452,6 +452,7 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
             ? PreviousTracksPersistenceMode.persistent
             : fields[145] as PreviousTracksPersistenceMode,
         useAndroidGainEffect: fields[147] == null ? true : fields[147] as bool,
+        expandTrackTitles: fields[150] == null ? false : fields[150] as bool,
       )
       ..disableGesture = fields[19] == null ? false : fields[19] as bool
       ..showFastScroller = fields[25] == null ? true : fields[25] as bool
@@ -470,7 +471,7 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
   @override
   void write(BinaryWriter writer, FinampSettings obj) {
     writer
-      ..writeByte(141)
+      ..writeByte(142)
       ..writeByte(0)
       ..write(obj.isOffline)
       ..writeByte(1)
@@ -752,7 +753,9 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       ..writeByte(146)
       ..write(obj.amoledTheme)
       ..writeByte(147)
-      ..write(obj.useAndroidGainEffect);
+      ..write(obj.useAndroidGainEffect)
+      ..writeByte(150)
+      ..write(obj.expandTrackTitles);
   }
 
   @override

--- a/lib/screens/customization_settings_screen.dart
+++ b/lib/screens/customization_settings_screen.dart
@@ -42,6 +42,7 @@ class _CustomizationSettingsScreenState extends State<CustomizationSettingsScree
           if (!Platform.isIOS) const ShowFavoriteButtonOnMediaNotificationToggle(),
           const ShowSeekControlsOnMediaNotificationToggle(),
           const OneLineMarqueeTextSwitch(),
+          const ExpandTrackTitlesToggle(),
           const ReleaseDateFormatDropdownListTile(),
           const TileAdditionalInfoTypeTitleListTile(),
           ...TabContentType.values.map((type) => TileAdditionalInfoTypeDropdownListTile(tabContentType: type)),
@@ -61,6 +62,20 @@ class OneLineMarqueeTextSwitch extends ConsumerWidget {
       subtitle: Text(AppLocalizations.of(context)!.oneLineMarqueeTextButtonSubtitle),
       value: ref.watch(finampSettingsProvider.oneLineMarqueeTextButton),
       onChanged: FinampSetters.setOneLineMarqueeTextButton,
+    );
+  }
+}
+
+class ExpandTrackTitlesToggle extends ConsumerWidget {
+  const ExpandTrackTitlesToggle({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return SwitchListTile.adaptive(
+      title: Text(AppLocalizations.of(context)!.expandTrackTitlesTitle),
+      subtitle: Text(AppLocalizations.of(context)!.expandTrackTitlesSubtitle),
+      value: ref.watch(finampSettingsProvider.expandTrackTitles),
+      onChanged: FinampSetters.setExpandTrackTitles,
     );
   }
 }

--- a/lib/services/finamp_settings_helper.dart
+++ b/lib/services/finamp_settings_helper.dart
@@ -62,6 +62,7 @@ class FinampSettingsHelper {
     finampSettingsTemp.showSeekControlsOnMediaNotification = DefaultSettings.showSeekControlsOnMediaNotification;
     finampSettingsTemp.oneLineMarqueeTextButton = DefaultSettings.oneLineMarqueeTextButton;
     finampSettingsTemp.tileAdditionalInfoType = DefaultSettings.tileAdditionalInfoType;
+    finampSettingsTemp.expandTrackTitles = DefaultSettings.expandTrackTitles;
 
     Hive.box<FinampSettings>("FinampSettings").put("FinampSettings", finampSettingsTemp);
   }

--- a/lib/services/finamp_settings_helper.g.dart
+++ b/lib/services/finamp_settings_helper.g.dart
@@ -1286,6 +1286,14 @@ extension FinampSetters on FinampSettingsHelper {
     ).put("FinampSettings", finampSettingsTemp);
   }
 
+  static void setExpandTrackTitles(bool newExpandTrackTitles) {
+    FinampSettings finampSettingsTemp = FinampSettingsHelper.finampSettings;
+    finampSettingsTemp.expandTrackTitles = newExpandTrackTitles;
+    Hive.box<FinampSettings>(
+      "FinampSettings",
+    ).put("FinampSettings", finampSettingsTemp);
+  }
+
   static void setBufferDuration(Duration newBufferDuration) {
     FinampSettings finampSettingsTemp = FinampSettingsHelper.finampSettings;
     finampSettingsTemp.bufferDuration = newBufferDuration;
@@ -1729,6 +1737,8 @@ extension FinampSettingsProviderSelectors on StreamProvider<FinampSettings> {
       finampSettingsProvider.select((value) => value.requireValue.amoledTheme);
   ProviderListenable<bool> get useAndroidGainEffect => finampSettingsProvider
       .select((value) => value.requireValue.useAndroidGainEffect);
+  ProviderListenable<bool> get expandTrackTitles => finampSettingsProvider
+      .select((value) => value.requireValue.expandTrackTitles);
   ProviderListenable<DownloadProfile> get downloadTranscodingProfile =>
       finampSettingsProvider.select(
         (value) => value.requireValue.downloadTranscodingProfile,


### PR DESCRIPTION
## Summary

Adds a new "Expand long track titles" toggle in **Customization Settings**. When enabled, track titles in album/artist/genre/playlist tile lists drop the per-tile height cap and the soft `maxLines: 2` ellipsis, so titles that previously got cut to a single line (with "...") on narrow window widths now use a second line and the tile grows to fit.

Closes #995

## Implementation (in `lib/components/AlbumScreen/track_list_tile.dart`)

- Pulled the title `Text` out of the inline tree into a `titleTextWidget` local so it can be conditionally wrapped.
- Removed the `BoxConstraints(maxHeight: defaultTileHeight)` ceiling on the title `Column` when the toggle is on, so the column can grow with its content.
- Switched the column to `mainAxisSize: MainAxisSize.min` and `mainAxisAlignment: MainAxisAlignment.start` when expanded - the previous `MainAxisSize.max + spaceEvenly` was distributing fixed space across the rigid 60-px tile, which is what was clipping the second line on narrow windows.
- When expanded the title is rendered raw (with vertical padding) instead of inside a `Flexible(flex: 3)`, and the subtitle's `Flexible` is set to `flex: 0` so it requests no extra space - both changes are needed for `MainAxisSize.min` to actually shrink-wrap.
- Title's `maxLines` becomes `null` and `overflow: TextOverflow.visible` when expanded; `softWrap: true` is explicit.

Other PRs:

- `lib/models/finamp_models.dart`: new `expandTrackTitles` field on `FinampSettings` (`@HiveField(150)`) + `DefaultSettings.expandTrackTitles = false` (off by default - no behavior change for existing users).
- `lib/services/finamp_settings_helper.dart`: reset added to `resetCustomizationSettings()`.
- `lib/screens/customization_settings_screen.dart`: new `ExpandTrackTitlesToggle` widget, placed right after `OneLineMarqueeTextSwitch` (the closest semantic neighbor - both control how text is presented in tiles).
- `lib/l10n/app_en.arb`: `expandTrackTitlesTitle` / `expandTrackTitlesSubtitle`.
- Generated files (`finamp_models.g.dart`, `finamp_settings_helper.g.dart`) regenerated via `dart run build_runner build --delete-conflicting-outputs`; `flutter gen-l10n` regenerated `AppLocalizations` getters.

## Why this stops at 2 lines (and not "as many as needed")

The original report asked for titles to wrap on as many lines as needed. Tested locally on Windows desktop, the practical effect of the toggle is to free titles from "1 line + ellipsis" up to two full lines - `ListTile` Material's title slot does not grow much past two lines without dropping the `ListTile` widget entirely. **I chose to stop here on purpose**, for two reasons that came up in the issue thread:

1. **@Chaphasilor's reservation on scrolling performance** ("it could cause issues with scrolling performance since not all tracks will have the same height any more"): two lines means tile heights stay close to uniform and the existing `ListView` scroll performance is preserved. Letting tiles grow to 4-5 lines for occasional classical-music titles would create much larger height variance.
2. **Layout consistency**: the existing tile structure (leading cover, title column, trailing duration/actions) was designed around a ~60-px tile. Two lines is the largest height where the tile layout still looks cohesive without the trailing actions feeling detached.

If reviewers prefer a true "as-many-lines-as-needed" behavior, I'd be happy to take a follow-up PR that drops the `ListTile` widget for tracks and uses a `Material + InkWell + Padding + Row` skeleton - that's the cleanest way to lift the cap without fighting `ListTile`'s internal layout. Just say the word.

## Test plan

Tested on Windows desktop (`flutter run -d windows`) against a real Jellyfin server with a classical-music-style album that has long track titles like "Becoming one of 'The People' Becoming…":

- [x] Toggle appears in Settings → Customization, between "One-line marquee text" and "Release date format"
- [x] Toggling persists across app restarts
- [x] On a narrow window with the toggle **off**, long titles get cut to 1 line with `…` (existing behavior)
- [x] On the same narrow window with the toggle **on**, the same titles wrap onto 2 lines and the tiles grow to fit
- [x] On wide windows, behavior is unchanged either way (titles already fit on a single line)
- [x] Reset button on Customization Settings restores the toggle to off

## Code assistance

Used Claude (LLM) to scaffold the new setting following `CONTRIBUTING.md`, to iterate on the `Column` constraints after the first attempts (dropping the height cap alone was not enough; `mainAxisSize` and the `Flexible` wrappers also had to flip), and to verify the chosen 2-line cap against the maintainer's perf concern.
