### PR TITLE
feat(album): show total album size on the album header

### DIFF
--- a/lib/components/AlbumScreen/item_info.dart
+++ b/lib/components/AlbumScreen/item_info.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../models/jellyfin_models.dart';
+import '../format_bytes.dart';
 import '../icon_and_text.dart';
 import '../print_duration.dart';
 
@@ -30,6 +31,16 @@ class ItemInfo extends ConsumerWidget {
     final trackDurationString = (genreFilter == null && (itemTracks.length == item.childCount))
         ? "$trackCountString (${printDuration(item.runTimeTicksDuration())})"
         : "$trackCountString (${printDuration(itemTracks.map((t) => t.runTimeTicksDuration()).whereType<Duration>().fold<Duration>(Duration.zero, (sum, dur) => sum + dur))})";
+
+    // Sum the size of every track that has it; if no track reports a size,
+    // skip showing the row entirely (mirrors the maintainer's "only if the
+    // server gives us the size" guidance from #1146). The size lives on
+    // each track's first MediaSourceInfo rather than on BaseItemDto itself.
+    final totalSizeBytes = itemTracks.fold<int>(0, (sum, t) {
+      final sources = t.mediaSources;
+      final trackBytes = (sources != null && sources.isNotEmpty) ? (sources.first.size ?? 0) : 0;
+      return sum + trackBytes;
+    });
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -54,6 +65,11 @@ class ItemInfo extends ConsumerWidget {
           iconData: Icons.music_note,
           textSpan: TextSpan(text: trackDurationString),
         ),
+        if (totalSizeBytes > 0)
+          IconAndText(
+            iconData: Icons.sd_storage,
+            textSpan: TextSpan(text: formatBytes(totalSizeBytes)),
+          ),
         if (item.type != "Playlist")
           IconAndText(
             iconData: Icons.event,

--- a/lib/components/format_bytes.dart
+++ b/lib/components/format_bytes.dart
@@ -1,0 +1,14 @@
+/// Formats a byte count into a human-readable string using binary (1024)
+/// units. Returns "B" for under 1 KiB, "KB"/"MB"/"GB" for larger sizes.
+/// Uses one decimal for KB and MB, two decimals for GB.
+String formatBytes(int bytes) {
+  if (bytes < 1024) {
+    return "$bytes B";
+  } else if (bytes < 1024 * 1024) {
+    return "${(bytes / 1024).toStringAsFixed(1)} KB";
+  } else if (bytes < 1024 * 1024 * 1024) {
+    return "${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB";
+  } else {
+    return "${(bytes / (1024 * 1024 * 1024)).toStringAsFixed(2)} GB";
+  }
+}

--- a/lib/services/jellyfin_api.dart
+++ b/lib/services/jellyfin_api.dart
@@ -18,7 +18,8 @@ import 'jellyfin_api_helper.dart';
 
 part 'jellyfin_api.chopper.dart';
 
-const String defaultFields = "ChildCount,DateCreated,DateLastMediaAdded,Etag,Genres,ParentId,ProviderIds,Tags";
+const String defaultFields =
+    "ChildCount,DateCreated,DateLastMediaAdded,Etag,Genres,ParentId,ProviderIds,Tags,MediaSources";
 
 @ChopperApi()
 abstract class JellyfinApi extends ChopperService {


### PR DESCRIPTION
## Summary

Shows the total size of an album right next to the existing track count and runtime on the album screen header. The size is computed by summing the `Size` field of each track's first `MediaSourceInfo` and is rendered with an adaptive `B / KB / MB / GB` formatter. The row is hidden whenever the server does not report sizes for any track in the album.

Closes #1146 (scoped to the first bullet only - the other three were already separately addressed or duplicated, per the maintainer's reply on the issue).

## Implementation

Three small files:

- **`lib/components/format_bytes.dart` (new)** - top-level `formatBytes(int)` helper that picks `B`, `KB`, `MB` or `GB` based on the magnitude. Modeled on the existing `print_duration.dart` (also a top-level helper in the same folder, no class).
- **`lib/components/AlbumScreen/item_info.dart`** - reads each track's `mediaSources?.first?.size`, sums them with `fold`, and adds an `IconAndText(iconData: Icons.sd_storage, ...)` between the track-count/duration row and the release-date row when the total is greater than zero.
- **`lib/services/jellyfin_api.dart`** - adds `MediaSources` to the `defaultFields` constant. Without this, the Items API does not include `mediaSources` in the response, so `t.mediaSources?.first?.size` is always null and the size row never appears. The `MediaSources` field is documented as a valid `Fields` value directly in the same file's `getItems` parameter docstring.

## Notes

- **Conflict with #1619 expected**: that PR also amends `defaultFields` (it adds `SortName`). If #1619 lands first, this PR will need a trivial rebase to keep both fields. If reviewers prefer a single PR that adds both fields, I can fold them together - happy to follow whichever is easier on review.
- I deliberately did not add a `FinampSettings` toggle for this. The original report and the maintainer's response treat the size as plain metadata to display, in line with how track count and duration are already shown. A toggle could always be added in a follow-up if reviewers want one.
- The size is read from `MediaSourceInfo.size` (already on the existing `BaseItemDto.mediaSources` field). Computation happens once per `ItemInfo.build`, which already runs on each album-screen open - same cost as the existing `runTimeTicksDuration` summation a few lines above.
- If a track is missing both `mediaSources` and `mediaSources.first.size`, it contributes 0 to the sum. The row is hidden when the total is 0, so albums where no track has a size value reported render exactly as today.
- Binary units (1024-based) to match how disk usage is typically displayed on mobile OSes; happy to swap to decimal (1000) or to a localized formatter if you prefer.

## Test plan

Tested on Windows desktop (`flutter run -d windows`) against a real Jellyfin server:

- [x] Open an album whose tracks have a `Size` reported by the server: a row with the SD-storage icon shows the formatted total (verified, e.g. "32.9 MB" on a one-track album)
- [x] `MediaSources` was confirmed required: without it on `defaultFields` the row never appeared even when the player itself shows the per-track size when playing
- [x] Open a playlist: the size row works the same way (sums up across the playlist's tracks)
- [x] Numbers stay readable on narrow window widths

## Out of scope (per maintainer's reply on the issue)

- Persistent download button after an album is downloaded - already re-added on the downloads screen
- Offline favorites/playlists - duplicate of #1065 and #933
- "Wrapped"-style highlights - handled by [jellyfin-rewind](https://github.com/Chaphasilor/jellyfin-rewind)

## Code assistance

Used Claude (LLM) to follow the existing helpers' structure, to discover that the size lives on `MediaSourceInfo` rather than on `BaseItemDto` directly, and to find that `MediaSources` had to be added to `defaultFields` for the Items API to actually include the data we read.
