### PR TITLE
fix(api): request SortName field so fast scroll matches the sorted list

### DIFF
--- a/lib/services/jellyfin_api.dart
+++ b/lib/services/jellyfin_api.dart
@@ -18,7 +18,7 @@ import 'jellyfin_api_helper.dart';
 
 part 'jellyfin_api.chopper.dart';
 
-const String defaultFields = "ChildCount,DateCreated,DateLastMediaAdded,Etag,Genres,ParentId,ProviderIds,Tags";
+const String defaultFields = "ChildCount,DateCreated,DateLastMediaAdded,Etag,Genres,ParentId,ProviderIds,Tags,SortName";
 
 @ChopperApi()
 abstract class JellyfinApi extends ChopperService {


### PR DESCRIPTION
## Summary

Fixes the fast scroll alphabet jumping to the wrong letter for items whose display name and sort name differ. The bug reported in the issue (and reproduced by `@DanielDeur` in the linked video) is "click `L` → jumps to *Les Bains Douches* even though the album is correctly sorted under `B` because its sort title is *Bains Douches, Les*".

Closes #978

## Root cause

`music_screen_tab_view.dart`'s `scrollToLetter` already uses `BaseItemDto.nameForSorting`, and `nameForSorting` already prefers `sortName` over `name` when available. The actual problem is that `sortName` was never being filled in by Jellyfin in the first place: the `defaultFields` constant in [`jellyfin_api.dart:21`](https://github.com/jmshrv/finamp/blob/redesign/lib/services/jellyfin_api.dart#L21) didn't list `SortName`, so the Items API never returned it. With `sortName == null`, `nameForSorting` falls back to `name` (and the English-only "the / a / an" stripping), which doesn't match the server-side sort order for non-English titles like the "Les …" example, items with `forcedSortName`, or any user-customized sort key.

## The fix

Add `SortName` to `defaultFields`. That's the only change. `nameForSorting` already does the right thing once `sortName` is populated.

```diff
-const String defaultFields = "…,ProviderIds,Tags";
+const String defaultFields = "…,ProviderIds,Tags,SortName";
```

`SortName` is documented as a valid `Fields` value directly inside this same file (the inline docstring on the `getItems` `@Query("Fields")` parameter lists it), so this isn't introducing anything that needs a Jellyfin server-version gate.

## Why this is safe

- The change is purely additive: existing callers that pass an explicit `fields` argument are unaffected, and no field is removed.
- Cost: one extra short string per item in the API response. Negligible vs. the existing payload (covers, tags, blurhash, etc.).
- No new code path: `nameForSorting` already handles `sortName` correctly; we're just feeding it data.
- Touches no Hive schema and adds no setting, so there's no migration concern.

`flutter analyze` returns 0 new issues. Code formatted with `dart format`.

## Test plan

> ⚠️ **Transparency:** Like #1615, #1616, #1617, #1618, this PR is opened as a draft because I have not been able to run the app on a physical device yet. Help testing it on a device would be very welcome.

Manual checks to perform on a device (a library with at least one album whose `name` starts with a different letter than its `sortName` is needed - French, Spanish, German articles, or any album with a custom `forcedSortName` works):

- [ ] Open the music tab, sort by "Sort name"
- [ ] Verify the album sits in the list at the letter of its sort name (e.g. *Les Bains Douches* under `B`)
- [ ] Tap the `B` letter on the right-hand fast scroller - the list should now jump to that section
- [ ] Tap the `L` letter - should NOT jump to *Les Bains Douches* anymore (it should land on actual `L*` items)
- [ ] Same checks while sorted by "Album artist"
- [ ] Reinstall: first-load albums also have `sortName` populated (this would catch any cache invalidation oversight, but I don't believe one is needed here)
