### PR TITLE
Fix(fast scroll)/jump to letter when ordered by album artist

### DIFF
--- a/lib/components/AlbumScreen/track_list_tile.dart
+++ b/lib/components/AlbumScreen/track_list_tile.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:collection/collection.dart';
 import 'package:finamp/components/AddToPlaylistScreen/add_to_playlist_button.dart';
 import 'package:finamp/components/MusicScreen/music_screen_tab_view.dart';
 import 'package:finamp/components/global_snackbar.dart';
@@ -755,9 +756,14 @@ class TrackListItemTile extends ConsumerWidget {
     final String artistsString;
     if (forceAlbumArtists || (baseItem.artists?.isEmpty ?? true)) {
       artistsString =
-          baseItem.albumArtists?.map((e) => e.name).joinNonNull(", ") ?? AppLocalizations.of(context)!.unknownArtist;
+          baseItem.albumArtists
+              ?.sortedBy((e) => e.name ?? '')
+              .map((e) => e.name)
+              .joinNonNull(", ") ??
+          AppLocalizations.of(context)!.unknownArtist;
     } else {
-      artistsString = baseItem.artists?.joinNonNull(", ") ?? AppLocalizations.of(context)!.unknownArtist;
+      artistsString =
+          baseItem.artists?.sortedBy((e) => e).joinNonNull(", ") ?? AppLocalizations.of(context)!.unknownArtist;
     }
     final downloadedIndicator = DownloadedIndicator(
       item: DownloadStub.fromItem(item: baseItem, type: DownloadItemType.track),

--- a/lib/components/AlbumScreen/track_list_tile.dart
+++ b/lib/components/AlbumScreen/track_list_tile.dart
@@ -756,10 +756,7 @@ class TrackListItemTile extends ConsumerWidget {
     final String artistsString;
     if (forceAlbumArtists || (baseItem.artists?.isEmpty ?? true)) {
       artistsString =
-          baseItem.albumArtists
-              ?.sortedBy((e) => e.name ?? '')
-              .map((e) => e.name)
-              .joinNonNull(", ") ??
+          baseItem.albumArtists?.sortedBy((e) => e.name ?? '').map((e) => e.name).joinNonNull(", ") ??
           AppLocalizations.of(context)!.unknownArtist;
     } else {
       artistsString =

--- a/lib/components/MusicScreen/music_screen_tab_view.dart
+++ b/lib/components/MusicScreen/music_screen_tab_view.dart
@@ -282,17 +282,13 @@ class _MusicScreenTabViewState extends ConsumerState<MusicScreenTabView>
     SortBy? tabSortBy = FinampSettingsHelper.finampSettings.tabSortBy[widget.tabContentType];
     bool reversed = FinampSettingsHelper.finampSettings.tabSortOrder[widget.tabContentType] == SortOrder.descending;
 
-    String getSortName(dynamic item) {
-      switch (tabSortBy) {
-        case SortBy.albumArtist:
-          final artists = item.albumArtists as List<NameIdPair>?;
-          return removeDiacritics(
-                artists?.sortedBy((e) => e.name ?? '').map((e) => e.name ?? '').join(", ") ?? item.albumArtist ?? "",
-              )
-              as String;
-        default:
-          return removeDiacritics(item.nameForSorting ?? "") as String;
+    String getSortName(BaseItemDto item) {
+      if (tabSortBy == SortBy.albumArtist) {
+        final artists = item.albumArtists;
+        return removeDiacritics(artists?.sortedBy((e) => e.name ?? '').map((e) => e.name ?? '').join(", ") ?? item.albumArtist ?? "");
       }
+
+      return removeDiacritics(item.nameForSorting ?? "");
     }
 
     var targetIndex = itemList.indexWhere((item) {

--- a/lib/components/MusicScreen/music_screen_tab_view.dart
+++ b/lib/components/MusicScreen/music_screen_tab_view.dart
@@ -286,7 +286,10 @@ class _MusicScreenTabViewState extends ConsumerState<MusicScreenTabView>
       switch (tabSortBy) {
         case SortBy.albumArtist:
           final artists = item.albumArtists as List<NameIdPair>?;
-          return removeDiacritics(artists?.sortedBy((e) => e.name ?? '').map((e) => e.name ?? '').join(", ") ?? item.albumArtist ?? "") as String;
+          return removeDiacritics(
+                artists?.sortedBy((e) => e.name ?? '').map((e) => e.name ?? '').join(", ") ?? item.albumArtist ?? "",
+              )
+              as String;
         default:
           return removeDiacritics(item.nameForSorting ?? "") as String;
       }
@@ -296,9 +299,7 @@ class _MusicScreenTabViewState extends ConsumerState<MusicScreenTabView>
       final sortName = getSortName(item).toLowerCase();
       if (sortName.isEmpty) return false;
       final itemCodePoint = sortName.codeUnitAt(0);
-      return reversed
-          ? itemCodePoint <= codePointToScrollTo
-          : itemCodePoint >= codePointToScrollTo;
+      return reversed ? itemCodePoint <= codePointToScrollTo : itemCodePoint >= codePointToScrollTo;
     });
 
     if (targetIndex != -1) {

--- a/lib/components/MusicScreen/music_screen_tab_view.dart
+++ b/lib/components/MusicScreen/music_screen_tab_view.dart
@@ -645,7 +645,7 @@ List<BaseItemDto> sortItems(List<BaseItemDto> itemsToSort, SortBy? sortBy, SortO
           if (a.artists == null || b.artists == null) {
             return 0;
           } else {
-            return a.artists!.join(', ').compareTo(b.artists!.join(', '));
+            return a.artists!.sortedBy((e) => e).join(", ").compareTo(b.artists!.sortedBy((e) => e).join(", "));
           }
         case SortBy.communityRating:
           if (a.communityRating == null || b.communityRating == null) {

--- a/lib/components/MusicScreen/music_screen_tab_view.dart
+++ b/lib/components/MusicScreen/music_screen_tab_view.dart
@@ -326,7 +326,7 @@ class _MusicScreenTabViewState extends ConsumerState<MusicScreenTabView>
       }
       letterToSearch = null;
     } else {
-      // More pages available — request the next page and scroll to the bottom
+      // More pages available - request the next page and scroll to the bottom
       // to trigger loading. Retry will happen via letterToSearch being set.
       timer = Timer(const Duration(seconds: 8), () {
         // If page loading takes too long, cancel search and allow image loading.

--- a/lib/components/MusicScreen/music_screen_tab_view.dart
+++ b/lib/components/MusicScreen/music_screen_tab_view.dart
@@ -1,6 +1,10 @@
 import 'dart:async';
 import 'dart:math';
 
+import 'package:collection/collection.dart';
+
+import 'package:diacritic/diacritic.dart';
+
 import 'package:finamp/components/Buttons/cta_medium.dart';
 import 'package:finamp/l10n/app_localizations.dart';
 import 'package:finamp/services/finamp_user_helper.dart';
@@ -269,10 +273,6 @@ class _MusicScreenTabViewState extends ConsumerState<MusicScreenTabView>
     letterToSearch = letter;
     var codePointToScrollTo = letter.toLowerCase().codeUnitAt(0);
 
-    // Max code point is lower case z to increase the chance of seeing a character
-    // past the target but below the ignore point
-    final maxCodePoint = 'z'.codeUnitAt(0);
-
     if (letter == '#') {
       codePointToScrollTo = 0;
     }
@@ -281,66 +281,72 @@ class _MusicScreenTabViewState extends ConsumerState<MusicScreenTabView>
     var itemList = _pagingController.itemList!;
     SortBy? tabSortBy = FinampSettingsHelper.finampSettings.tabSortBy[widget.tabContentType];
     bool reversed = FinampSettingsHelper.finampSettings.tabSortOrder[widget.tabContentType] == SortOrder.descending;
-    for (var i = 0; i < itemList.length; i++) {
-      String sortName;
+
+    String getSortName(dynamic item) {
       switch (tabSortBy) {
         case SortBy.albumArtist:
-          sortName = itemList[i].albumArtist ?? "";
-          break;
+          final artists = item.albumArtists as List<NameIdPair>?;
+          return removeDiacritics(artists?.sortedBy((e) => e.name ?? '').map((e) => e.name ?? '').join(", ") ?? item.albumArtist ?? "") as String;
         default:
-          sortName = itemList[i].nameForSorting ?? "";
-          break;
-      }
-      if (sortName.isEmpty) continue; // assume empty names are at the start
-      int itemCodePoint = sortName.toLowerCase().codeUnitAt(0);
-      if (itemCodePoint <= maxCodePoint) {
-        final comparisonResult = itemCodePoint - codePointToScrollTo;
-        if (comparisonResult == 0) {
-          timer?.cancel();
-          await controller.scrollToIndex(
-            i,
-            duration: _getAnimationDurationForOffsetToIndex(i),
-            preferPosition: AutoScrollPosition.begin,
-          );
-
-          letterToSearch = null;
-          return;
-        } else if (reversed ? comparisonResult < 0 : comparisonResult > 0) {
-          // If the letter is before the current item, there was no previous match (letter doesn't seem to exist in library)
-          // scroll to the previous item instead
-          timer?.cancel();
-          await controller.scrollToIndex(
-            (i - 1).clamp(0, itemList.length - 1),
-            // duration: scrollDuration,
-            duration: _getAnimationDurationForOffsetToIndex(i),
-            preferPosition: AutoScrollPosition.middle,
-          );
-
-          letterToSearch = null;
-          return;
-        }
+          return removeDiacritics(item.nameForSorting ?? "") as String;
       }
     }
 
+    var targetIndex = itemList.indexWhere((item) {
+      final sortName = getSortName(item).toLowerCase();
+      if (sortName.isEmpty) return false;
+      final itemCodePoint = sortName.codeUnitAt(0);
+      return reversed
+          ? itemCodePoint <= codePointToScrollTo
+          : itemCodePoint >= codePointToScrollTo;
+    });
+
+    if (targetIndex != -1) {
+      final originalIndex = itemList.indexOf(itemList[targetIndex]);
+
+      timer?.cancel();
+      await controller.scrollToIndex(
+        originalIndex,
+        duration: _getAnimationDurationForOffsetToIndex(originalIndex),
+        preferPosition: AutoScrollPosition.begin,
+      );
+
+      letterToSearch = null;
+      return;
+    }
+
+    // No match found in the currently loaded items.
+    // If all pages are loaded, fall back to the last element in the list.
     timer?.cancel();
     if (fullyLoadedRefresh == refreshCount) {
+      if (itemList.isNotEmpty) {
+        final lastIndex = itemList.indexOf(itemList.last);
+        await controller.scrollToIndex(
+          lastIndex,
+          duration: _getAnimationDurationForOffsetToIndex(lastIndex),
+          preferPosition: AutoScrollPosition.begin,
+        );
+      }
       letterToSearch = null;
     } else {
+      // More pages available — request the next page and scroll to the bottom
+      // to trigger loading. Retry will happen via letterToSearch being set.
       timer = Timer(const Duration(seconds: 8), () {
-        // If page loading takes >5 seconds, cancel search and allow image loading.
+        // If page loading takes too long, cancel search and allow image loading.
         letterToSearch = null;
       });
 
       _pagingController.notifyPageRequestListeners(_pagingController.nextPageKey!);
-    }
-    if (MediaQuery.disableAnimationsOf(context)) {
-      controller.jumpTo(controller.position.maxScrollExtent);
-    } else {
-      await controller.animateTo(
-        controller.position.maxScrollExtent,
-        duration: const Duration(milliseconds: 500),
-        curve: Curves.ease,
-      );
+
+      if (MediaQuery.disableAnimationsOf(context)) {
+        controller.jumpTo(controller.position.maxScrollExtent);
+      } else {
+        await controller.animateTo(
+          controller.position.maxScrollExtent,
+          duration: const Duration(milliseconds: 500),
+          curve: Curves.ease,
+        );
+      }
     }
   }
 

--- a/lib/components/PlayerScreen/artist_chip.dart
+++ b/lib/components/PlayerScreen/artist_chip.dart
@@ -42,7 +42,9 @@ class ArtistChips extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final artists = ((artistType == ArtistType.albumArtist) ? baseItem?.albumArtists : baseItem?.artistItems) ?? [];
-    final filteredArtists = {for (var artist in artists) artist.id: artist}.values.sortedBy((e) => e.name ?? '').toList();
+    final filteredArtists = {
+      for (var artist in artists) artist.id: artist,
+    }.values.sortedBy((e) => e.name ?? '').toList();
 
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 4),

--- a/lib/components/PlayerScreen/artist_chip.dart
+++ b/lib/components/PlayerScreen/artist_chip.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:finamp/l10n/app_localizations.dart';
 import 'package:finamp/models/finamp_models.dart';
 import 'package:flutter/material.dart';
@@ -41,7 +42,7 @@ class ArtistChips extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final artists = ((artistType == ArtistType.albumArtist) ? baseItem?.albumArtists : baseItem?.artistItems) ?? [];
-    final filteredArtists = {for (var artist in artists) artist.id: artist}.values.toList();
+    final filteredArtists = {for (var artist in artists) artist.id: artist}.values.sortedBy((e) => e.name ?? '').toList();
 
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 4),

--- a/lib/services/generate_subtitle.dart
+++ b/lib/services/generate_subtitle.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:finamp/models/finamp_models.dart';
 import 'package:finamp/services/datetime_helper.dart';
 import 'package:flutter/material.dart';
@@ -23,7 +24,7 @@ String? generateSubtitle({
       return item.albumArtists != null &&
               item.albumArtists!.isNotEmpty &&
               (item.albumArtists!.length > 1 || item.albumArtists?.first.name != item.albumArtist)
-          ? item.albumArtists?.map((e) => processArtist(e.name, context)).join(", ")
+          ? item.albumArtists!.sortedBy((e) => e.name ?? '').map((e) => processArtist(e.name, context)).join(", ")
           : processArtist(item.albumArtist, context);
     case BaseItemDtoType.playlist:
       return AppLocalizations.of(context)!.trackCount(item.childCount!);

--- a/lib/services/queue_service.dart
+++ b/lib/services/queue_service.dart
@@ -1447,7 +1447,7 @@ class QueueService {
       playable:
           isItemPlayable, // this dictates whether clicking on an item will try to play it or browse it in media browsers like Android Auto
       album: item.album,
-      artist: item.artists?.join(", ") ?? item.albumArtist,
+      artist: item.artists?.sortedBy((e) => e).join(", ") ?? item.albumArtist,
       title: item.name ?? "unknown",
       extras: {
         //!!! this ID has to be consistent across the transcoding URL and the playback reporting status, otherwise the server won't show that we're transcoding

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -482,6 +482,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.3"
+  diacritic:
+    dependency: "direct main"
+    description:
+      name: diacritic
+      sha256: "12981945ec38931748836cd76f2b38773118d0baef3c68404bdfde9566147876"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.6"
   dynamic_color:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -148,6 +148,7 @@ dependencies:
   dynamic_color: ^1.8.1
   dbus: ^0.7.11
   bits: ^1.4.0
+  diacritic: ^0.1.6
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Changes
#### fix: fix quick-scroll to letter for album artists
* Multiple album-artists are sorted, before taken into consideration for quick-scroll
   * Why is this an issue:
   I.e. Album-Artists `["Wolfgang Amadeus Mozart", "Academy of St Martin in the Fields"]` will be sorted by `A` for `"Academy..."`, but filterd by `"Wolfgang..."`, since it is the first element of the `albumArtists`. This causes all letters between `A` and (including) `W` to be jumping to the album of Mozart and  the Academy of  St Martin in the Fields. 
* Diacritic are removed for quick-scroll
#### fix: album-artists and artists are sorted before displayed

## Todo before merging


## Related Issues
- fixes #1609

