### PR TITLE
Keep audio service foreground while paused to fix background playback (#956)

### DIFF
--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -109,7 +109,11 @@ class DefaultSettings {
   static const Color? accentColor = null;
   static const shouldTranscode = false;
   static const transcodeBitrate = 320000;
-  static const androidStopForegroundOnPause = true;
+  // Default to keeping the audio service in the foreground while paused.
+  // Entering a low-priority state on pause lets Android (12+/API 31) deny the
+  // background foreground-service restart needed to resume after a transient
+  // audio-focus interruption, silently stopping playback. See issue #956.
+  static const androidStopForegroundOnPause = false;
   static const onlyShowFavorites = false;
   static const trackShuffleItemCount = 250;
 

--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -91,7 +91,7 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
             : (fields[2] as num).toInt(),
         downloadLocations: (fields[3] as List).cast<DownloadLocation>(),
         androidStopForegroundOnPause: fields[4] == null
-            ? true
+            ? false
             : fields[4] as bool,
         showTabs: (fields[5] as Map).cast<TabContentType, bool>(),
         onlyShowFavorites: fields[6] == null ? false : fields[6] as bool,


### PR DESCRIPTION
Opening this as a proposal / discussion starter for #956 rather than a definitive fix — happy to adjust or drop it.

### Root cause

A transient audio-focus loss while Finamp is backgrounded (a notification, an alarm, a nav prompt, or a few seconds of audio from another app) pauses playback. With `androidStopForegroundOnPause = true`, the audio service then drops out of the foreground. When focus returns and playback tries to resume, Android 12+ blocks restarting the foreground service from the background:

```
ActivityManager: Background started FGS: Disallowed ... AudioService; code:DENIED
ActivityManager: startForegroundService() not allowed due to mAllowStartForeground false
ActivityManager: Stopping service due to app idle ... AudioService
```

Playback then stays dead until the app is foregrounded again (foreground starts are allowed — which is why reopening "fixes" it). This is the part the 0.6.27 API-34 manifest fix didn't cover.

On `redesign`, toggling **Enter Low-Priority State on Pause** OFF resolves it (some older 0.6.x reports said the toggle made no difference, which may have steered people away from this lever). Before/after with adb logcat on a Pixel 9 Pro / Android 16 / 0.9.23-beta:

- **ON:** `onAudioFocusChange(-2)` (transient loss) → `(+1)` (gain) → `FGS: Disallowed`, playback stays dead.
- **OFF:** same `-2 → +1` focus cycle, no denial, playback resumes immediately.

### This change

Default `androidStopForegroundOnPause` to `false`, so the service stays in the foreground across a pause and can resume without a restricted background restart. The toggle is kept for anyone who prefers the low-priority behaviour (swipe-away notification, less battery while paused).

### Open questions

- You set `true` deliberately. If you'd rather keep that default and instead only stay foreground during *transient* interruptions, that's a deeper change in the audio_service interaction — open to that direction if you prefer it.
- This only affects new installs; existing users keep their stored value (the whole `FinampSettings` object persists the field). A one-time migration could flip it for them (with the toggle to opt back in), but it overrides a deliberate choice once, so I left it out pending your call — happy to add it.
- I couldn't build an APK locally (no Android SDK on my machine), but the behaviour above was verified on-device by toggling the setting, which sets the same runtime value this default produces.

Thanks for Finamp — curious what you think.
