### PR TITLE
Fix empty Genres tab

### DIFF
--- a/lib/services/jellyfin_api_helper.dart
+++ b/lib/services/jellyfin_api_helper.dart
@@ -1276,7 +1276,9 @@ class JellyfinApiHelper {
     // I guess part of the reason for this is that it's not possible to favorite a genre through the Jellyfin Web UI at all...
     if ([finamp_models.ContentType.genres, finamp_models.ContentType.mixed].contains(contentType)) {
       // Only send isFavorite when the filter is actually active. Passing isFavorite=false makes
-      // Jellyfin 10.10/10.11 return HTTP 500 on the /Genres endpoint, leaving the Genres tab empty (#1653).
+      // Jellyfin 10.11 return HTTP 500 on the /Genres endpoint, leaving the Genres tab empty (#1653).
+      // On Jellyfin 10.10 and 12.0, isFavorite=false returns only items that are *not* favorites,
+      // which is also not what we want here (we want all genres to be shown, unfiltered)
       return filters.any((filter) => filter.type == ItemFilterType.isFavorite) ? true : null;
     }
     return null;

--- a/lib/services/jellyfin_api_helper.dart
+++ b/lib/services/jellyfin_api_helper.dart
@@ -1275,7 +1275,9 @@ class JellyfinApiHelper {
     // Jellyfin 10.10 and 10.11 use the [isFavorite] boolean filter instead of the list-based [filters] parameter for genres, so add that here
     // I guess part of the reason for this is that it's not possible to favorite a genre through the Jellyfin Web UI at all...
     if ([finamp_models.ContentType.genres, finamp_models.ContentType.mixed].contains(contentType)) {
-      return filters.any((filter) => filter.type == ItemFilterType.isFavorite);
+      // Only send isFavorite when the filter is actually active. Passing isFavorite=false makes
+      // Jellyfin 10.10/10.11 return HTTP 500 on the /Genres endpoint, leaving the Genres tab empty (#1653).
+      return filters.any((filter) => filter.type == ItemFilterType.isFavorite) ? true : null;
     }
     return null;
   }


### PR DESCRIPTION
## Problem
The Genres tab is empty when online. Other tabs work and offline mode lists genres fine.

I had Claude (Opus 4.8) debug the issue and it came up with the below.

## Cause
`getIsFavoriteFilter` returns `false` (instead of `null`) for the genres/mixed tabs when no favorite filter is active, so finamp sends `isFavorite=false` to the `/Genres` endpoint. Jellyfin 10.10/10.11 returns HTTP 500 on `/Genres` whenever `isFavorite` is present (`true` or `false`), so the request fails and the tab stays empty. `/Items` (used by the other tabs) accepts `isFavorite=false`, and offline never calls `/Genres` — which is why only the online Genres tab breaks.

## Fix
Return `null` when the favorite filter is inactive, so `isFavorite` is omitted from the `/Genres` request.

## Verification (Jellyfin 10.11.11)
- `/Genres?…&isFavorite=false` → 500
- `/Genres?…` (no `isFavorite`) → 200
- `/Items?…&isFavorite=false` → 200

## Out of scope
Filtering the Genres tab *by favorites* still won't work on 10.11 (that path sends `isFavorite=true`, which also 500s). That looks like a server-side bug in Jellyfin's `/Genres` endpoint and may be worth reporting upstream separately.

Fixes #1653
