### PR TITLE
fix(android-auto): refresh playback state after toggling shuffle

### DIFF
--- a/lib/services/music_player_background_task.dart
+++ b/lib/services/music_player_background_task.dart
@@ -1103,7 +1103,8 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler with SeekHandler, Queue
       switch (action) {
         case CustomPlaybackActions.shuffle:
           final queueService = GetIt.instance<QueueService>();
-          return queueService.togglePlaybackOrder();
+          await queueService.togglePlaybackOrder();
+          return refreshPlaybackStateAndMediaNotification();
         case CustomPlaybackActions.radio:
           RadioServiceHelper.toggleRadio();
         case CustomPlaybackActions.toggleFavorite:

--- a/lib/services/music_player_background_task.dart
+++ b/lib/services/music_player_background_task.dart
@@ -1103,8 +1103,7 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler with SeekHandler, Queue
       switch (action) {
         case CustomPlaybackActions.shuffle:
           final queueService = GetIt.instance<QueueService>();
-          await queueService.togglePlaybackOrder();
-          return refreshPlaybackStateAndMediaNotification();
+          return queueService.togglePlaybackOrder();
         case CustomPlaybackActions.radio:
           RadioServiceHelper.toggleRadio();
         case CustomPlaybackActions.toggleFavorite:

--- a/lib/services/queue_service.dart
+++ b/lib/services/queue_service.dart
@@ -1349,6 +1349,7 @@ class QueueService {
     await _audioHandler.setShuffleMode(mode);
     //await _audioHandler.playbackState.where((event) => event.shuffleMode == mode).first;
     _buildQueueFromNativePlayerQueue();
+    await _audioHandler.refreshPlaybackStateAndMediaNotification();
   }
 
   FinampPlaybackOrder get playbackOrder => _playbackOrder;


### PR DESCRIPTION
## Changes

Toggling shuffle from the Android Auto / now-playing controls didn't update the shuffle icon visually.

`togglePlaybackOrder()` wasn't awaited and `refreshPlaybackStateAndMediaNotification()` wasn't called afterwards — unlike `toggleFavoriteStatusOfCurrentTrack()`, which already does both. This aligns the shuffle action with that pattern.

1 file, +2/-1.


