### PR TITLE
Add DLNA/UPnP audio output support

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -6,6 +6,9 @@
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
   <uses-permission android:name="android.permission.VIBRATE"/>
+  <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
+  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+  <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE"/>
   <!-- io.flutter.app.FlutterApplication is an android.app.Application that
          calls FlutterMain.startInitialization(this); in its onCreate method.
          In most cases you can leave this as-is, but you if you want to provide

--- a/lib/components/now_playing_bar.dart
+++ b/lib/components/now_playing_bar.dart
@@ -453,6 +453,15 @@ class NowPlayingBar extends ConsumerWidget {
                                           Row(
                                             mainAxisAlignment: MainAxisAlignment.end,
                                             children: [
+                                              if (audioHandler.isDlnaMode)
+                                                Padding(
+                                                  padding: const EdgeInsets.only(top: 4.0, right: 4.0),
+                                                  child: Icon(
+                                                    Icons.cast_connected,
+                                                    size: 16,
+                                                    color: Theme.of(context).colorScheme.primary,
+                                                  ),
+                                                ),
                                               Padding(
                                                 padding: const EdgeInsets.only(top: 4.0, right: 4.0),
                                                 child: AddToPlaylistButton(

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -2854,5 +2854,12 @@
     "previousTracksPersistenceModeExpanded": "موسع (ظاهر)",
     "@previousTracksPersistenceModeExpanded": {
         "description": "Overrides saved value to expand previous tracks header on queue list open"
-    }
+    },
+    "outputDevices": "أجهزة الإخراج",
+    "thisDevice": "هذا الجهاز",
+    "scanningForDevices": "البحث عن الأجهزة...",
+    "noDevicesFound": "لم يتم العثور على أجهزة",
+    "addDeviceManually": "إضافة جهاز يدوياً",
+    "castingTo": "البث إلى {deviceName}",
+    "noDeviceFoundAt": "لم يتم العثور على جهاز DLNA في {address}"
 }

--- a/lib/l10n/app_bg.arb
+++ b/lib/l10n/app_bg.arb
@@ -239,5 +239,12 @@
     "size": "",
     "@size": {
         "description": "Label for the feature chips showing the size (original file size or transcoded size, if available) of a track"
-    }
+    },
+    "outputDevices": "Изходни устройства",
+    "thisDevice": "Това устройство",
+    "scanningForDevices": "Сканиране за устройства...",
+    "noDevicesFound": "Няма намерени устройства",
+    "addDeviceManually": "Добави устройство ръчно",
+    "castingTo": "Предава се към {deviceName}",
+    "noDeviceFoundAt": "Не е намерено DLNA устройство на адрес {address}"
 }

--- a/lib/l10n/app_bn.arb
+++ b/lib/l10n/app_bn.arb
@@ -10,5 +10,12 @@
     "startupErrorTitle": "অ্যাপ শুরু করার সময় কোনো সমস্যা হয়েছে!",
     "@startupErrorTitle": {
         "description": "The title for the error screen that shows when startup fails."
-    }
+    },
+    "outputDevices": "আউটপুট ডিভাইস",
+    "thisDevice": "এই ডিভাইস",
+    "scanningForDevices": "ডিভাইস স্ক্যান করা হচ্ছে...",
+    "noDevicesFound": "কোনো ডিভাইস পাওয়া যায়নি",
+    "addDeviceManually": "ম্যানুয়ালি ডিভাইস যোগ করুন",
+    "castingTo": "{deviceName} এ কাস্ট করা হচ্ছে",
+    "noDeviceFoundAt": "{address} এ কোনো DLNA ডিভাইস পাওয়া যায়নি"
 }

--- a/lib/l10n/app_ca.arb
+++ b/lib/l10n/app_ca.arb
@@ -3053,5 +3053,12 @@
             }
         },
         "description": "Label for sleep timer track count slider"
-    }
+    },
+    "outputDevices": "Dispositius de sortida",
+    "thisDevice": "Aquest dispositiu",
+    "scanningForDevices": "Cercant dispositius...",
+    "noDevicesFound": "No s'han trobat dispositius",
+    "addDeviceManually": "Afegeix dispositiu manualment",
+    "castingTo": "Transmetent a {deviceName}",
+    "noDeviceFoundAt": "No s'ha trobat cap dispositiu DLNA a {address}"
 }

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -3464,5 +3464,12 @@
                 "example": "syncingLocal"
             }
         }
-    }
+    },
+    "outputDevices": "Výstupní zařízení",
+    "thisDevice": "Toto zařízení",
+    "scanningForDevices": "Hledání zařízení...",
+    "noDevicesFound": "Nebyla nalezena žádná zařízení",
+    "addDeviceManually": "Přidat zařízení ručně",
+    "castingTo": "Přehrávání na {deviceName}",
+    "noDeviceFoundAt": "Žádné DLNA zařízení nenalezeno na adrese {address}"
 }

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -1836,5 +1836,12 @@
             }
         },
         "description": "Tooltip for downloadbutton on incidental downloads, which show a lock icon. It says one of the requiring downloads."
-    }
+    },
+    "outputDevices": "Udgangsenheder",
+    "thisDevice": "Denne enhed",
+    "scanningForDevices": "Søger efter enheder...",
+    "noDevicesFound": "Ingen enheder fundet",
+    "addDeviceManually": "Tilføj enhed manuelt",
+    "castingTo": "Caster til {deviceName}",
+    "noDeviceFoundAt": "Ingen DLNA-enhed fundet på {address}"
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -3454,5 +3454,12 @@
                 "example": "syncingLocal"
             }
         }
-    }
+    },
+    "outputDevices": "Ausgabegeräte",
+    "thisDevice": "Dieses Gerät",
+    "scanningForDevices": "Suche nach Geräten...",
+    "noDevicesFound": "Keine Geräte gefunden",
+    "addDeviceManually": "Gerät manuell hinzufügen",
+    "castingTo": "Wird an {deviceName} übertragen",
+    "noDeviceFoundAt": "Kein DLNA-Gerät unter {address} gefunden"
 }

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -1671,5 +1671,12 @@
     "genreScreen": "Οθόνη Είδους",
     "@genreScreen": {
         "description": "Name for the view/screen that shows genres"
-    }
+    },
+    "outputDevices": "Συσκευές εξόδου",
+    "thisDevice": "Αυτή η συσκευή",
+    "scanningForDevices": "Σάρωση για συσκευές...",
+    "noDevicesFound": "Δεν βρέθηκαν συσκευές",
+    "addDeviceManually": "Χειροκίνητη προσθήκη συσκευής",
+    "castingTo": "Μετάδοση σε {deviceName}",
+    "noDeviceFoundAt": "Δεν βρέθηκε συσκευή DLNA στη διεύθυνση {address}"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3576,5 +3576,33 @@
     "clientCertificateRequired": "Client certificate required",
     "@clientCertificateRequired": {
         "description": "Message shown on the server selection screen when the server requires a client certificate to be provided."
+    },
+    "outputDevices": "Output Devices",
+    "@outputDevices": {},
+    "thisDevice": "This Device",
+    "@thisDevice": {},
+    "scanningForDevices": "Scanning for devices...",
+    "@scanningForDevices": {},
+    "noDevicesFound": "No devices found",
+    "@noDevicesFound": {},
+    "castingTo": "Casting to {deviceName}",
+    "@castingTo": {
+        "placeholders": {
+            "deviceName": {
+                "type": "String",
+                "example": "Living Room Speaker"
+            }
+        }
+    },
+    "addDeviceManually": "Add device manually",
+    "@addDeviceManually": {},
+    "noDeviceFoundAt": "No DLNA device found at {address}",
+    "@noDeviceFoundAt": {
+        "placeholders": {
+            "address": {
+                "type": "String",
+                "example": "192.168.0.5"
+            }
+        }
     }
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -2417,5 +2417,12 @@
     "multichannelHandlingSubtitle": "Cómo gestionar pistas multicanal (más de 2 canales) al realizar la transcodificación. Se aplica tanto al streaming como a las descargas.",
     "@multichannelHandlingSubtitle": {
         "description": "Subtitle for multi-channel handling dropdown"
-    }
+    },
+    "outputDevices": "Dispositivos de salida",
+    "thisDevice": "Este dispositivo",
+    "scanningForDevices": "Buscando dispositivos...",
+    "noDevicesFound": "No se encontraron dispositivos",
+    "addDeviceManually": "Añadir dispositivo manualmente",
+    "castingTo": "Transmitiendo a {deviceName}",
+    "noDeviceFoundAt": "No se encontró ningún dispositivo DLNA en {address}"
 }

--- a/lib/l10n/app_et.arb
+++ b/lib/l10n/app_et.arb
@@ -2814,5 +2814,12 @@
             }
         },
         "description": "Options in multi-channel handling dropdown"
-    }
+    },
+    "outputDevices": "Väljundseadmed",
+    "thisDevice": "See seade",
+    "scanningForDevices": "Seadmete otsimine...",
+    "noDevicesFound": "Seadmeid ei leitud",
+    "addDeviceManually": "Lisa seade käsitsi",
+    "castingTo": "Edastatakse seadmesse {deviceName}",
+    "noDeviceFoundAt": "DLNA seadet ei leitud aadressilt {address}"
 }

--- a/lib/l10n/app_fa.arb
+++ b/lib/l10n/app_fa.arb
@@ -1641,5 +1641,12 @@
     "playOnStaleDelaySubtitle": "مدت زمانی که یک نشست «پخش روی» از راه دور پس از دریافت فرمان فعال در نظر گرفته می‌شود. هنگام فعال بودن، وضعیت پخش با دفعات بیشتری گزارش می‌شود که می‌تواند باعث افزایش مصرف پهنای‌باند شود.",
     "@playOnStaleDelaySubtitle": {
         "description": "Description of the setting that controls how long a PlayOn remote session is considered active"
-    }
+    },
+    "outputDevices": "دستگاه‌های خروجی",
+    "thisDevice": "این دستگاه",
+    "scanningForDevices": "در حال اسکن دستگاه‌ها...",
+    "noDevicesFound": "دستگاهی یافت نشد",
+    "addDeviceManually": "افزودن دستی دستگاه",
+    "castingTo": "در حال ارسال به {deviceName}",
+    "noDeviceFoundAt": "دستگاه DLNA در آدرس {address} یافت نشد"
 }

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -3470,5 +3470,12 @@
                 "example": "syncingLocal"
             }
         }
-    }
+    },
+    "outputDevices": "Laitetyypit",
+    "thisDevice": "Tämä laite",
+    "scanningForDevices": "Etsitään laitteita...",
+    "noDevicesFound": "Laitteita ei löytynyt",
+    "addDeviceManually": "Lisää laite manuaalisesti",
+    "castingTo": "Lähetetään laitteeseen {deviceName}",
+    "noDeviceFoundAt": "DLNA-laitetta ei löytynyt osoitteesta {address}"
 }

--- a/lib/l10n/app_fil.arb
+++ b/lib/l10n/app_fil.arb
@@ -182,5 +182,12 @@
     "tracks": "Mga Track",
     "albums": "Mga Album",
     "appearsOnAlbums": "Nasa",
-    "artists": "Mga Arista"
+    "artists": "Mga Arista",
+    "outputDevices": "Mga output device",
+    "thisDevice": "Itong device",
+    "scanningForDevices": "Nag-iiscan ng mga device...",
+    "noDevicesFound": "Walang nahanap na device",
+    "addDeviceManually": "Idagdag device manually",
+    "castingTo": "Nag-cacast sa {deviceName}",
+    "noDeviceFoundAt": "Walang nahanap na DLNA device sa {address}"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -3478,5 +3478,12 @@
                 "example": "syncingLocal"
             }
         }
-    }
+    },
+    "outputDevices": "Périphériques de sortie",
+    "thisDevice": "Cet appareil",
+    "scanningForDevices": "Recherche d'appareils...",
+    "noDevicesFound": "Aucun appareil trouvé",
+    "addDeviceManually": "Ajouter un appareil manuellement",
+    "castingTo": "Diffusion vers {deviceName}",
+    "noDeviceFoundAt": "Aucun appareil DLNA trouvé à l'adresse {address}"
 }

--- a/lib/l10n/app_he.arb
+++ b/lib/l10n/app_he.arb
@@ -2942,5 +2942,12 @@
     "cannotDeleteLocation": "לא ניתן למחוק מיקום",
     "@cannotDeleteLocation": {
         "description": "Message that a download location cannot currently be deleted."
-    }
+    },
+    "outputDevices": "התקני פלט",
+    "thisDevice": "מכשיר זה",
+    "scanningForDevices": "סורק מכשירים...",
+    "noDevicesFound": "לא נמצאו מכשירים",
+    "addDeviceManually": "הוסף מכשיר ידנית",
+    "castingTo": "משדר ל{deviceName}",
+    "noDeviceFoundAt": "לא נמצא מכשיר DLNA בכתובת {address}"
 }

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -1614,5 +1614,12 @@
     "@allLibraries": {
         "description": "All Libraries"
     },
-    "appearsOnAlbums": "दिखाई देता है"
+    "appearsOnAlbums": "दिखाई देता है",
+    "outputDevices": "आउटपुट डिवाइस",
+    "thisDevice": "यह डिवाइस",
+    "scanningForDevices": "डिवाइस स्कैन कर रहा है...",
+    "noDevicesFound": "कोई डिवाइस नहीं मिला",
+    "addDeviceManually": "डिवाइस मैन्युअली जोड़ें",
+    "castingTo": "{deviceName} पर कास्ट कर रहा है",
+    "noDeviceFoundAt": "{address} पर कोई DLNA डिवाइस नहीं मिला"
 }

--- a/lib/l10n/app_hr.arb
+++ b/lib/l10n/app_hr.arb
@@ -1993,5 +1993,12 @@
     "loopingUnavailableWhileRadioActiveWarning": "Mijenjanje modusa petlje nije dostupno dok je radio aktivan, jer će red čekanja beskonačno nastavljati.",
     "@loopingUnavailableWhileRadioActiveWarning": {
         "description": "Warning message when trying to change the loop mode while radio is active."
-    }
+    },
+    "outputDevices": "Izlazni uređaji",
+    "thisDevice": "Ovaj uređaj",
+    "scanningForDevices": "Pretraživanje uređaja...",
+    "noDevicesFound": "Nema pronađenih uređaja",
+    "addDeviceManually": "Ručno dodaj uređaj",
+    "castingTo": "Prebacivanje na {deviceName}",
+    "noDeviceFoundAt": "Nije pronađen DLNA uređaj na adresi {address}"
 }

--- a/lib/l10n/app_hu.arb
+++ b/lib/l10n/app_hu.arb
@@ -2543,5 +2543,12 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "outputDevices": "Kimeneti eszközök",
+    "thisDevice": "Ez az eszköz",
+    "scanningForDevices": "Eszközök keresése...",
+    "noDevicesFound": "Nem található eszköz",
+    "addDeviceManually": "Eszköz hozzáadása manuálisan",
+    "castingTo": "Közvetítés ide: {deviceName}",
+    "noDeviceFoundAt": "Nem található DLNA eszköz a következő címen: {address}"
 }

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -3525,5 +3525,12 @@
                 "example": "syncingLocal"
             }
         }
-    }
+    },
+    "outputDevices": "Perangkat output",
+    "thisDevice": "Perangkat ini",
+    "scanningForDevices": "Memindai perangkat...",
+    "noDevicesFound": "Tidak ada perangkat ditemukan",
+    "addDeviceManually": "Tambah perangkat manual",
+    "castingTo": "Mengirim ke {deviceName}",
+    "noDeviceFoundAt": "Tidak ada perangkat DLNA ditemukan di {address}"
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -3008,5 +3008,12 @@
     "sectionType": "Tipo di sezione",
     "@sectionType": {
         "description": "Title for home screen section editor section type dropdown (tab view, collection, ect...)"
-    }
+    },
+    "outputDevices": "Dispositivi di output",
+    "thisDevice": "Questo dispositivo",
+    "scanningForDevices": "Ricerca dispositivi...",
+    "noDevicesFound": "Nessun dispositivo trovato",
+    "addDeviceManually": "Aggiungi dispositivo manualmente",
+    "castingTo": "Trasmissione a {deviceName}",
+    "noDeviceFoundAt": "Nessun dispositivo DLNA trovato a {address}"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -2861,5 +2861,12 @@
     "losslessNoBitrate": "FLACへのトランスコード時には適用されません",
     "@losslessNoBitrate": {
         "description": "Settings text informing the user that transcoding bitrate does not apply to lossless transcodes."
-    }
+    },
+    "outputDevices": "出力デバイス",
+    "thisDevice": "このデバイス",
+    "scanningForDevices": "デバイスをスキャン中...",
+    "noDevicesFound": "デバイスが見つかりません",
+    "addDeviceManually": "デバイスを手動で追加",
+    "castingTo": "{deviceName}にキャスト中",
+    "noDeviceFoundAt": "{address}にDLNAデバイスが見つかりません"
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -1963,5 +1963,12 @@
     "shuffleSomeToNextUp": "Next Up에 임의 재생 곡 추가",
     "@shuffleSomeToNextUp": {
         "description": "Used for shuffling some tracks to the end of the \"Next Up\" queue, to play after all prior tracks from Next Up have played"
-    }
+    },
+    "outputDevices": "출력 장치",
+    "thisDevice": "이 기기",
+    "scanningForDevices": "장치 검색 중...",
+    "noDevicesFound": "장치를 찾을 수 없음",
+    "addDeviceManually": "기기 수동 추가",
+    "castingTo": "{deviceName}으로 전송 중",
+    "noDeviceFoundAt": "{address}에서 DLNA 장치를 찾을 수 없음"
 }

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -347,5 +347,12 @@
     "login": "Logg in",
     "@login": {
         "description": "Label for the login button."
-    }
+    },
+    "outputDevices": "Utdataenheter",
+    "thisDevice": "Denne enheten",
+    "scanningForDevices": "Søker etter enheter...",
+    "noDevicesFound": "Ingen enheter funnet",
+    "addDeviceManually": "Legg til enhet manuelt",
+    "castingTo": "Caster til {deviceName}",
+    "noDeviceFoundAt": "Ingen DLNA-enhet funnet på {address}"
 }

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -1694,5 +1694,12 @@
             }
         },
         "description": "Localized names of special downloadable collection representing cached images for a certain library."
-    }
+    },
+    "outputDevices": "Uitvoerapparaten",
+    "thisDevice": "Dit apparaat",
+    "scanningForDevices": "Apparaten zoeken...",
+    "noDevicesFound": "Geen apparaten gevonden",
+    "addDeviceManually": "Apparaat handmatig toevoegen",
+    "castingTo": "Casten naar {deviceName}",
+    "noDeviceFoundAt": "Geen DLNA-apparaat gevonden op {address}"
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -1673,5 +1673,12 @@
     "applyFilterOnGenreChipTapTitle": "Zastosuj filtr przy karty gatunku",
     "@applyFilterOnGenreChipTapTitle": {
         "description": "Title for the setting that controls if taps on genre chips should apply a genre filter to the current screen or should redirect to the GenreScreen."
-    }
+    },
+    "outputDevices": "Urządzenia wyjściowe",
+    "thisDevice": "To urządzenie",
+    "scanningForDevices": "Skanowanie urządzeń...",
+    "noDevicesFound": "Nie znaleziono urządzeń",
+    "addDeviceManually": "Dodaj urządzenie ręcznie",
+    "castingTo": "Przesyłanie do {deviceName}",
+    "noDeviceFoundAt": "Nie znaleziono urządzenia DLNA pod adresem {address}"
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -3477,5 +3477,12 @@
                 "example": "syncingLocal"
             }
         }
-    }
+    },
+    "outputDevices": "Dispositivos de saída",
+    "thisDevice": "Este dispositivo",
+    "scanningForDevices": "Procurando dispositivos...",
+    "noDevicesFound": "Nenhum dispositivo encontrado",
+    "addDeviceManually": "Adicionar dispositivo manualmente",
+    "castingTo": "Transmitindo para {deviceName}",
+    "noDeviceFoundAt": "Nenhum dispositivo DLNA encontrado em {address}"
 }

--- a/lib/l10n/app_pt_BR.arb
+++ b/lib/l10n/app_pt_BR.arb
@@ -1701,5 +1701,12 @@
     "@colorCodeHint": {
         "description": "Hint text for the color code input field. Don't translate 'coffee', unless the translation is also a valid hex color code."
     },
-    "save": "Salvar"
+    "save": "Salvar",
+    "outputDevices": "Dispositivos de saída",
+    "thisDevice": "Este dispositivo",
+    "scanningForDevices": "Procurando dispositivos...",
+    "noDevicesFound": "Nenhum dispositivo encontrado",
+    "addDeviceManually": "Adicionar dispositivo manualmente",
+    "castingTo": "Transmitindo para {deviceName}",
+    "noDeviceFoundAt": "Nenhum dispositivo DLNA encontrado em {address}"
 }

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -1,1 +1,9 @@
-{}
+{
+    "outputDevices": "Dispozitive de ieșire",
+    "thisDevice": "Acest dispozitiv",
+    "scanningForDevices": "Se caută dispozitive...",
+    "noDevicesFound": "Niciun dispozitiv găsit",
+    "addDeviceManually": "Adaugă dispozitiv manual",
+    "castingTo": "Se transmite către {deviceName}",
+    "noDeviceFoundAt": "Niciun dispozitiv DLNA găsit la adresa {address}"
+}

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -2747,5 +2747,12 @@
     "explicit": "Explicit",
     "@explicit": {
         "description": "Label for content that is considered explicit, usually marked by an 'E' in music apps"
-    }
+    },
+    "outputDevices": "Устройства вывода",
+    "thisDevice": "Это устройство",
+    "scanningForDevices": "Поиск устройств...",
+    "noDevicesFound": "Устройства не найдены",
+    "addDeviceManually": "Добавить устройство вручную",
+    "castingTo": "Трансляция на {deviceName}",
+    "noDeviceFoundAt": "Устройство DLNA не найдено по адресу {address}"
 }

--- a/lib/l10n/app_sl.arb
+++ b/lib/l10n/app_sl.arb
@@ -208,5 +208,12 @@
                 "example": "401"
             }
         }
-    }
+    },
+    "outputDevices": "Izhodne naprave",
+    "thisDevice": "Ta naprava",
+    "scanningForDevices": "Iskanje naprav...",
+    "noDevicesFound": "Najdenih ni bilo naprav",
+    "addDeviceManually": "Ročno dodaj napravo",
+    "castingTo": "Predvajanje na {deviceName}",
+    "noDeviceFoundAt": "Nobena naprava DLNA ni bila najdena na naslovu {address}"
 }

--- a/lib/l10n/app_sr.arb
+++ b/lib/l10n/app_sr.arb
@@ -251,5 +251,12 @@
     },
     "activeDownloadsTitle": "Aktivna preuzimanja",
     "noActiveDownloads": "Nema aktivnih preuzimanja.",
-    "error": "Greška"
+    "error": "Greška",
+    "outputDevices": "Уређаји за излаз",
+    "thisDevice": "Овај уређај",
+    "scanningForDevices": "Скенирање уређаја...",
+    "noDevicesFound": "Није пронађен ниједан уређај",
+    "addDeviceManually": "Додај уређај ручно",
+    "castingTo": "Пренос на {deviceName}",
+    "noDeviceFoundAt": "Није пронађен DLNA уређај на адреси {address}"
 }

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -2867,5 +2867,12 @@
     "shuffleSomeAlbumsToQueue": "Shuffla vissa Album till Kö",
     "@shuffleSomeAlbumsToQueue": {
         "description": "Label for action that shuffles all albums of a genre and adds them at the end of the regular queue"
-    }
+    },
+    "outputDevices": "Utgångsenheter",
+    "thisDevice": "Denna enhet",
+    "scanningForDevices": "Söker efter enheter...",
+    "noDevicesFound": "Inga enheter hittades",
+    "addDeviceManually": "Lägg till enhet manuellt",
+    "castingTo": "Castar till {deviceName}",
+    "noDeviceFoundAt": "Ingen DLNA-enhet hittades på {address}"
 }

--- a/lib/l10n/app_sw.arb
+++ b/lib/l10n/app_sw.arb
@@ -1,1 +1,9 @@
-{}
+{
+    "outputDevices": "Vifaa vya pato",
+    "thisDevice": "Kifaa hiki",
+    "scanningForDevices": "Inatafuta vifaa...",
+    "noDevicesFound": "Hakuna vifaa vilivyopatikana",
+    "addDeviceManually": "Ongeza kifaa kwa mkono",
+    "castingTo": "Inatuma kwa {deviceName}",
+    "noDeviceFoundAt": "Hakuna kifaa cha DLNA kilichopatikana kwenye {address}"
+}

--- a/lib/l10n/app_szl.arb
+++ b/lib/l10n/app_szl.arb
@@ -207,5 +207,12 @@
             }
         }
     },
-    "removeFromMix": "Wymaż ze miksu"
+    "removeFromMix": "Wymaż ze miksu",
+    "outputDevices": "Wyjściowe masziny",
+    "thisDevice": "Ta maszina",
+    "scanningForDevices": "Skanowanie maszin...",
+    "noDevicesFound": "Niy znolesiyż maszin",
+    "addDeviceManually": "Dodej maszina ręcznie",
+    "castingTo": "Przesyłanie do {deviceName}",
+    "noDeviceFoundAt": "Niy znolesiyż maszin DLNA na adresie {address}"
 }

--- a/lib/l10n/app_ta.arb
+++ b/lib/l10n/app_ta.arb
@@ -3487,5 +3487,12 @@
                 "example": "syncingLocal"
             }
         }
-    }
+    },
+    "outputDevices": "வெளியீட்டு சாதனங்கள்",
+    "thisDevice": "இந்த சாதனம்",
+    "scanningForDevices": "சாதனங்களை ஸ்கேன் செய்கிறது...",
+    "noDevicesFound": "சாதனங்கள் இல்லை",
+    "addDeviceManually": "சாதனத்தை கைமுறையாக சேர்க்கவும்",
+    "castingTo": "{deviceName} க்கு காஸ்ட் செய்யப்படுகிறது",
+    "noDeviceFoundAt": "{address} இல் DLNA சாதனம் இல்லை"
 }

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -229,5 +229,12 @@
         "description": "Title for message that shows on the views screen when no music libraries could be found."
     },
     "showFastScroller": "แสดงตัวเลื่อนแบบเร็ว",
-    "interactions": "การกระทำ"
+    "interactions": "การกระทำ",
+    "outputDevices": "อุปกรณ์เอาต์พุต",
+    "thisDevice": "อุปกรณ์นี้",
+    "scanningForDevices": "กำลังสแกนอุปกรณ์...",
+    "noDevicesFound": "ไม่พบอุปกรณ์",
+    "addDeviceManually": "เพิ่มอุปกรณ์ด้วยตนเอง",
+    "castingTo": "กำลังแคสต์ไปยัง{deviceName}",
+    "noDeviceFoundAt": "ไม่พบอุปกรณ์ DLNA ที่{address}"
 }

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -1715,5 +1715,12 @@
     "customizeHomeScreen": "Ana ekranı düzenle",
     "@customizeHomeScreen": {
         "description": "Label for home screen customize button"
-    }
+    },
+    "outputDevices": "Çıkış cihazları",
+    "thisDevice": "Bu cihaz",
+    "scanningForDevices": "Cihazlar taranıyor...",
+    "noDevicesFound": "Cihaz bulunamadı",
+    "addDeviceManually": "Cihazı manuel olarak ekle",
+    "castingTo": "{deviceName} cihazına yayın yapılıyor",
+    "noDeviceFoundAt": "{address} adresinde DLNA cihazı bulunamadı"
 }

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -2770,5 +2770,12 @@
     "multichannelHandlingTitle": "Транскодування багатоканальних треків",
     "@multichannelHandlingTitle": {
         "description": "Title for multi-channel handling dropdown"
-    }
+    },
+    "outputDevices": "Пристрої виводу",
+    "thisDevice": "Цей пристрій",
+    "scanningForDevices": "Пошук пристроїв...",
+    "noDevicesFound": "Пристроїв не знайдено",
+    "addDeviceManually": "Додати пристрій вручну",
+    "castingTo": "Трансляція на {deviceName}",
+    "noDeviceFoundAt": "Пристрій DLNA не знайдено за адресою {address}"
 }

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -1117,5 +1117,12 @@
     "discordRPCSettingDescription": "Bật Discord Rich Presence để phát bài hát bạn đang nghe trên trạng thái Discord. Sẽ không kết nối Discord nếu Chế độ ngoại tuyến được bật.",
     "@discordRPCSettingDescription": {
         "description": "Description for the setting that controls if the Discord RPC (Rich Presence) feature is enabled"
-    }
+    },
+    "outputDevices": "Thiết bị xuất",
+    "thisDevice": "Thiết bị này",
+    "scanningForDevices": "Đang quét thiết bị...",
+    "noDevicesFound": "Không tìm thấy thiết bị",
+    "addDeviceManually": "Thêm thiết bị thủ công",
+    "castingTo": "Đang truyền đến {deviceName}",
+    "noDeviceFoundAt": "Không tìm thấy thiết bị DLNA tại {address}"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -3464,5 +3464,12 @@
                 "example": "syncingLocal"
             }
         }
-    }
+    },
+    "outputDevices": "输出设备",
+    "thisDevice": "此设备",
+    "scanningForDevices": "正在扫描设备...",
+    "noDevicesFound": "未找到设备",
+    "addDeviceManually": "手动添加设备",
+    "castingTo": "正在投射到{deviceName}",
+    "noDeviceFoundAt": "在{address}未找到DLNA设备"
 }

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -3467,5 +3467,12 @@
                 "example": "syncingLocal"
             }
         }
-    }
+    },
+    "outputDevices": "輸出裝置",
+    "thisDevice": "此裝置",
+    "scanningForDevices": "正在掃描裝置...",
+    "noDevicesFound": "未找到裝置",
+    "addDeviceManually": "手動新增裝置",
+    "castingTo": "正在投射到{deviceName}",
+    "noDeviceFoundAt": "在{address}未找到DLNA裝置"
 }

--- a/lib/l10n/app_zh_Hant_HK.arb
+++ b/lib/l10n/app_zh_Hant_HK.arb
@@ -598,5 +598,12 @@
     "confirmAddedToPlaylist": "已加入至播放清單",
     "@confirmAddedToPlaylist": {
         "description": "Snackbar message that shows when the user successfully adds items to a playlist."
-    }
+    },
+    "outputDevices": "輸出裝置",
+    "thisDevice": "此裝置",
+    "scanningForDevices": "正在掃描裝置...",
+    "noDevicesFound": "未找到裝置",
+    "addDeviceManually": "手動新增裝置",
+    "castingTo": "正在投射到{deviceName}",
+    "noDeviceFoundAt": "在{address}未找到DLNA裝置"
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -109,6 +109,7 @@ import 'screens/transcoding_settings_screen.dart';
 import 'screens/view_selector.dart';
 import 'screens/volume_normalization_settings_screen.dart';
 import 'services/audio_service_helper.dart';
+import 'services/dlna_service.dart';
 import 'services/jellyfin_api_helper.dart';
 import 'services/music_player_background_task.dart';
 import 'setup_logging.dart';
@@ -160,6 +161,8 @@ Future<void> main({bool integrationTesting = false, bool loginTesting = false}) 
     _mainLog.info("Setup os integrations");
     await _setupPlayOnService();
     _mainLog.info("Setup PlayOnService");
+    _setupDlnaService();
+    _mainLog.info("Setup DLNA service");
     await _setupPlaybackServices();
     _mainLog.info("Setup audio player");
     await _setupKeepScreenOnHelper();
@@ -231,6 +234,10 @@ Future<void> _setupJellyfinApiData() async {
 
 void _setupOfflineListenLogHelper() {
   GetIt.instance.registerSingleton(OfflineListenLogHelper());
+}
+
+void _setupDlnaService() {
+  GetIt.instance.registerSingleton(DlnaService());
 }
 
 Future<void> _setupDownloadsHelper() async {

--- a/lib/menus/output_menu.dart
+++ b/lib/menus/output_menu.dart
@@ -10,12 +10,14 @@ import 'package:finamp/components/themed_bottom_sheet.dart';
 import 'package:finamp/components/toggleable_list_tile.dart';
 import 'package:finamp/l10n/app_localizations.dart';
 import 'package:finamp/models/finamp_models.dart';
+import 'package:finamp/services/dlna_service.dart';
 import 'package:finamp/services/feedback_helper.dart';
 import 'package:finamp/services/finamp_settings_helper.dart';
 import 'package:finamp/services/music_player_background_task.dart';
 import 'package:finamp/services/queue_service.dart';
 import 'package:finamp/services/theme_provider.dart';
 import 'package:finamp/utils/platform_helper.dart';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_sticky_header/flutter_sticky_header.dart';
@@ -43,10 +45,11 @@ Future<void> showOutputMenu({required BuildContext context, bool usePlayerTheme 
         // ),
         Consumer(
           builder: (context, ref, child) {
+            final audioHandler = GetIt.instance<MusicPlayerBackgroundTask>();
+            final isDlnaMode = audioHandler.isDlnaMode;
             return VolumeSlider(
-              initialValue: (ref.watch(finampSettingsProvider.currentVolume) * 100).floor() / 100.0,
+              initialValue: isDlnaMode ? 0.5 : (ref.watch(finampSettingsProvider.currentVolume) * 100).floor() / 100.0,
               onChange: (double currentValue) async {
-                final audioHandler = GetIt.instance<MusicPlayerBackgroundTask>();
                 audioHandler.setVolume(currentValue);
               },
               forceLoading: true,
@@ -86,24 +89,21 @@ Future<void> showOutputMenu({required BuildContext context, bool usePlayerTheme 
             child: SliverList(delegate: SliverChildListDelegate.fixed(menuEntries)),
           ),
         ),
-        if (Platform.isAndroid)
-          SliverStickyHeader(
-            header: Padding(
-              padding: const EdgeInsets.only(top: 10.0, bottom: 8.0, left: 16.0, right: 16.0),
-              child: Text(
-                AppLocalizations.of(context)!.outputMenuDevicesSectionTitle,
-                // AppLocalizations.of(context)!.outputMenuDevicesSectionTitle,
-                style: Theme.of(context).textTheme.titleMedium,
-              ),
-            ),
-            sliver: MenuMask(
-              height: OutputMenuHeader.defaultHeight,
-              child: OutputTargetList(), // Pass the outputRoutes
+        // Devices section — shows Bluetooth routes (Android) and DLNA
+        // devices in a single unified list.
+        SliverStickyHeader(
+          header: Padding(
+            padding: const EdgeInsets.only(top: 10.0, bottom: 8.0, left: 16.0, right: 16.0),
+            child: Text(
+              AppLocalizations.of(context)!.outputMenuDevicesSectionTitle,
+              style: Theme.of(context).textTheme.titleMedium,
             ),
           ),
+          sliver: MenuMask(height: OutputMenuHeader.defaultHeight, child: OutputTargetList()),
+        ),
       ];
       // TODO better estimate, how to deal with lag getting playlists?
-      var stackHeight = MediaQuery.heightOf(context) * (Platform.isAndroid ? 0.65 : 0.4);
+      var stackHeight = MediaQuery.heightOf(context) * (Platform.isAndroid ? 0.75 : 0.5);
       return (stackHeight, menu);
     },
   );
@@ -181,55 +181,319 @@ class OutputTargetList extends StatefulWidget {
 
 class _OutputTargetListState extends State<OutputTargetList> {
   final audioHandler = GetIt.instance<MusicPlayerBackgroundTask>();
+  final _dlnaService = GetIt.instance<DlnaService>();
   String? switchingToRoute;
 
+  // Bluetooth route state
+  List<FinampOutputRoute> _bluetoothRoutes = [];
+  bool _bluetoothLoading = true;
+
+  // DLNA state
+  bool _isScanning = false;
+  List<DlnaOutputDevice> _dlnaDevices = [];
+  StreamSubscription? _dlnaDiscoverySub;
+  DlnaOutputDevice? _connectedDlnaDevice;
+  StreamSubscription? _dlnaDeviceSub;
+  bool _showManualEntry = false;
+  bool _isManualConnecting = false;
+  final _ipController = TextEditingController();
+  DlnaOutputDevice? _connectingDlnaDevice;
+
   @override
-  Widget build(BuildContext context) {
-    Future<List<FinampOutputRoute>> outputRoutes = audioHandler.getRoutes();
-    return FutureBuilder(
-      future: outputRoutes,
-      builder: (context, snapshot) {
-        if (snapshot.hasData) {
-          return SliverList(
-            delegate: SliverChildBuilderDelegate((context, index) {
-              if (index == snapshot.data!.length) {
-                return openOsOutputOptionsButton(context);
-              }
-              final route = snapshot.data![index];
-              if (route.isSelected) {
-                switchingToRoute = null; // Reset switching state if route is selected
-              }
-              return OutputSelectorTile(
-                routeInfo: route,
-                isLoading: switchingToRoute == route.name,
-                onSelect: ({bool loading = false, bool value = false}) {
-                  setState(() {
-                    switchingToRoute = loading ? route.name : null;
-                    outputRoutes = audioHandler.getRoutes();
-                  });
-                },
-              );
-            }, childCount: snapshot.data!.length + 1),
-          );
-        } else if (snapshot.hasError) {
-          GlobalSnackbar.error(snapshot.error);
-          return const SliverToBoxAdapter(child: Center(heightFactor: 3.0, child: Icon(Icons.error, size: 64)));
-        } else {
-          return SliverList(
-            delegate: SliverChildBuilderDelegate((context, index) {
-              if (index == 1) {
-                return openOsOutputOptionsButton(context);
-              } else {
-                return const Center(child: CircularProgressIndicator.adaptive());
-              }
-            }, childCount: 2),
-          );
+  void initState() {
+    super.initState();
+    _connectedDlnaDevice = _dlnaService.connectedDevice;
+    _dlnaDeviceSub = _dlnaService.deviceStream.listen((device) {
+      if (mounted) {
+        setState(() {
+          _connectedDlnaDevice = device;
+        });
+      }
+    });
+    _startDlnaScanning();
+    _loadBluetoothRoutes();
+  }
+
+  void _loadBluetoothRoutes() async {
+    try {
+      final routes = await audioHandler.getRoutes();
+      if (mounted) {
+        setState(() {
+          _bluetoothRoutes = routes;
+          _bluetoothLoading = false;
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _bluetoothLoading = false;
+        });
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _dlnaService.stopDiscovery();
+    _dlnaDiscoverySub?.cancel();
+    _dlnaDeviceSub?.cancel();
+    _ipController.dispose();
+    super.dispose();
+  }
+
+  void _startDlnaScanning() {
+    setState(() {
+      _isScanning = true;
+      _dlnaDevices.clear();
+    });
+    _dlnaDiscoverySub = _dlnaService.startDiscoveryStream().listen(
+      (devices) {
+        if (mounted) {
+          setState(() {
+            _dlnaDevices = List.from(devices);
+          });
+        }
+      },
+      onDone: () {
+        if (mounted) {
+          setState(() {
+            _isScanning = false;
+          });
+        }
+      },
+      onError: (_) {
+        if (mounted) {
+          setState(() {
+            _isScanning = false;
+          });
         }
       },
     );
   }
 
-  Widget openOsOutputOptionsButton(BuildContext context) {
+  Future<void> _selectDlnaDevice(DlnaOutputDevice device) async {
+    setState(() {
+      _connectingDlnaDevice = device;
+    });
+    try {
+      await _dlnaService.disconnect();
+      final success = await _dlnaService.connect(device);
+      if (success) {
+        await audioHandler.connectToDlna(_dlnaService);
+      }
+    } catch (_) {}
+    if (mounted) {
+      setState(() {
+        _connectingDlnaDevice = null;
+      });
+    }
+  }
+
+  Future<void> _selectLocalDevice() async {
+    await audioHandler.disconnectFromDlna();
+  }
+
+  Future<void> _connectManually() async {
+    final ip = _ipController.text.trim();
+    if (ip.isEmpty) return;
+    setState(() {
+      _isManualConnecting = true;
+    });
+    try {
+      final device = await _dlnaService.discoverDeviceByAddress(ip);
+      if (device != null) {
+        await _dlnaService.disconnect();
+        final success = await _dlnaService.connect(device);
+        if (success) {
+          await audioHandler.connectToDlna(_dlnaService);
+          if (mounted) {
+            setState(() {
+              _showManualEntry = false;
+              _isManualConnecting = false;
+            });
+          }
+          return;
+        }
+      }
+      if (mounted) {
+        setState(() {
+          _isManualConnecting = false;
+        });
+        GlobalSnackbar.error(Exception(AppLocalizations.of(context)!.noDeviceFoundAt(ip)));
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _isManualConnecting = false;
+        });
+        GlobalSnackbar.error(e);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final theme = Theme.of(context);
+    final isDlnaMode = audioHandler.isDlnaMode;
+
+    final items = <Widget>[];
+
+    // "This Device" — local playback
+    items.add(
+      ToggleableListTile(
+        title: l10n.thisDevice,
+        subtitle: l10n.deviceType("speaker"),
+        leading: Container(
+          padding: const EdgeInsets.all(16.0),
+          color: theme.colorScheme.primary.withOpacity(0.3),
+          child: Icon(TablerIcons.device_speaker),
+        ),
+        icon: isDlnaMode ? TablerIcons.device_speaker : TablerIcons.device_speaker_filled,
+        state: !isDlnaMode,
+        onToggle: (_) => _selectLocalDevice(),
+        confirmationFeedback: false,
+        enabled: true,
+      ),
+    );
+
+    // Bluetooth / system output routes (Android only)
+    if (Platform.isAndroid) {
+      if (_bluetoothLoading) {
+        items.add(
+          const Padding(
+            padding: EdgeInsets.all(16.0),
+            child: Center(child: CircularProgressIndicator.adaptive()),
+          ),
+        );
+      } else {
+        for (final route in _bluetoothRoutes) {
+          if (route.isSelected) {
+            switchingToRoute = null;
+          }
+          items.add(
+            OutputSelectorTile(
+              routeInfo: route,
+              isLoading: switchingToRoute == route.name,
+              onSelect: ({bool loading = false, bool value = false}) {
+                setState(() {
+                  switchingToRoute = loading ? route.name : null;
+                  _loadBluetoothRoutes();
+                });
+              },
+            ),
+          );
+        }
+      }
+    }
+
+    // Discovered DLNA devices
+    for (final device in _dlnaDevices) {
+      final isActive = isDlnaMode && _connectedDlnaDevice?.name == device.name;
+      final isConnecting = _connectingDlnaDevice == device;
+      items.add(
+        ToggleableListTile(
+          title: device.name,
+          subtitle: device.address,
+          leading: Container(
+            padding: const EdgeInsets.all(16.0),
+            color: theme.colorScheme.primary.withOpacity(0.3),
+            child: Icon(TablerIcons.cast),
+          ),
+          icon: TablerIcons.cast,
+          state: isActive,
+          isLoading: isConnecting,
+          onToggle: (_) => _selectDlnaDevice(device),
+          confirmationFeedback: false,
+          enabled: true,
+        ),
+      );
+    }
+
+    // Scanning indicator
+    if (_isScanning && _dlnaDevices.isEmpty) {
+      items.add(
+        const Padding(
+          padding: EdgeInsets.all(16.0),
+          child: Center(child: CircularProgressIndicator.adaptive()),
+        ),
+      );
+    }
+
+    // No devices found message (only if no Bluetooth routes either)
+    if (!_isScanning && _dlnaDevices.isEmpty) {
+      items.add(
+        Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Center(
+            child: Text(
+              l10n.noDevicesFound,
+              style: theme.textTheme.bodyMedium?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+            ),
+          ),
+        ),
+      );
+    }
+
+    // Manual IP entry
+    if (!_showManualEntry) {
+      items.add(
+        Padding(
+          padding: const EdgeInsets.only(top: 16.0),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              CTAMedium(
+                text: l10n.addDeviceManually,
+                icon: TablerIcons.plus,
+                onPressed: () {
+                  setState(() {
+                    _showManualEntry = true;
+                  });
+                },
+              ),
+            ],
+          ),
+        ),
+      );
+    } else {
+      items.add(
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+          child: Row(
+            children: [
+              Expanded(
+                child: TextField(
+                  controller: _ipController,
+                  decoration: InputDecoration(
+                    hintText: "192.168.0.5",
+                    isDense: true,
+                    border: OutlineInputBorder(borderRadius: BorderRadius.circular(8)),
+                  ),
+                  keyboardType: TextInputType.number,
+                  enabled: !_isManualConnecting,
+                  onSubmitted: (_) => _connectManually(),
+                ),
+              ),
+              const SizedBox(width: 8),
+              _isManualConnecting
+                  ? const SizedBox(width: 24, height: 24, child: CircularProgressIndicator(strokeWidth: 2))
+                  : IconButton(icon: Icon(TablerIcons.send), onPressed: _connectManually),
+            ],
+          ),
+        ),
+      );
+    }
+
+    // Open OS output settings (Android only)
+    if (Platform.isAndroid) {
+      items.add(_openOsOutputOptionsButton(context));
+    }
+
+    return SliverList(delegate: SliverChildListDelegate.fixed(items));
+  }
+
+  Widget _openOsOutputOptionsButton(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.only(top: 16.0),
       child: Row(
@@ -238,10 +502,8 @@ class _OutputTargetListState extends State<OutputTargetList> {
           CTAMedium(
             text: AppLocalizations.of(context)!.outputMenuOpenConnectionSettingsButtonTitle,
             icon: TablerIcons.cast,
-            //accentColor: Theme.of(context).colorScheme.primary,
             onPressed: () async {
               final audioHandler = GetIt.instance<MusicPlayerBackgroundTask>();
-              // await audioHandler.showOutputSwitcherDialog();
               await audioHandler.openBluetoothSettings();
             },
           ),

--- a/lib/screens/player_screen.dart
+++ b/lib/screens/player_screen.dart
@@ -5,6 +5,7 @@ import 'dart:math';
 import 'package:balanced_text/balanced_text.dart';
 import 'package:finamp/components/Buttons/simple_button.dart';
 import 'package:finamp/components/PlayerScreen/control_area.dart';
+
 import 'package:finamp/components/PlayerScreen/player_screen_album_image.dart';
 import 'package:finamp/components/PlayerScreen/player_screen_appbar_title.dart';
 import 'package:finamp/components/PlayerScreen/player_split_screen_scaffold.dart';
@@ -200,7 +201,6 @@ class _PlayerScreenContent extends ConsumerWidget {
             toolbarHeight: toolbarHeight,
             title: PlayerScreenAppBarTitle(maxLines: maxToolbarLines),
             leading: usingPlayerSplitScreen ? null : FinampAppBarBackButton(dismissDirection: AxisDirection.down),
-            actions: [],
           ),
           // Required for sleep timer input
           resizeToAvoidBottomInset: false,

--- a/lib/services/dlna_media_proxy.dart
+++ b/lib/services/dlna_media_proxy.dart
@@ -1,0 +1,323 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+/// A minimal HTTP proxy that serves media to DLNA renderers with the
+/// correct DLNA content-feature headers.
+///
+/// Unlike general-purpose proxies, this adds `contentFeatures.dlna.org`
+/// and `transferMode.dlna.org` headers to every response. Some DLNA
+/// devices (notably Samsung TVs) refuse to honour Pause/Stop/Seek SOAP
+/// actions unless these headers are present on the media stream.
+///
+/// Two registration modes:
+/// - [registerFile] — serves a local file from the filesystem.
+/// - [registerUrl] — proxies a remote URL (e.g. a Jellyfin direct-play URL),
+///   forwarding Range requests and streaming the upstream response through.
+class DlnaMediaProxy {
+  HttpServer? _server;
+  String? _baseUrl;
+  final _routes = <String, _ProxyRoute>{};
+
+  /// Starts the proxy, binding to the local IP on the same subnet as
+  /// [targetDeviceIp] so the DLNA device can reach us.
+  Future<void> start({String? targetDeviceIp}) async {
+    if (_server != null) return;
+
+    final ip = await _getLocalIp(targetDeviceIp);
+    final bindAddress = ip ?? '0.0.0.0';
+    _server = await HttpServer.bind(bindAddress, 0);
+    // Clear default security headers that some DLNA renderers reject.
+    _server!.defaultResponseHeaders.clear();
+    final port = _server!.port;
+    _baseUrl = 'http://${ip ?? bindAddress}:$port';
+    _server!.listen(_handleRequest);
+  }
+
+  /// Stops the proxy and clears all registered routes.
+  Future<void> stop() async {
+    await _server?.close(force: true);
+    _server = null;
+    _baseUrl = null;
+    _routes.clear();
+  }
+
+  /// The base URL the DLNA device should use to reach this proxy.
+  String? get baseUrl => _baseUrl;
+
+  /// Registers a local file for serving. Returns a URL the DLNA device
+  /// can fetch.
+  String registerFile(String filePath, {required String mimeType}) {
+    final token = _generateToken();
+    final ext = _extForMime(mimeType);
+    _routes['$token$ext'] = _ProxyRoute(type: _RouteType.file, path: filePath, mimeType: mimeType);
+    return '$_baseUrl/file/$token$ext';
+  }
+
+  /// Registers a remote URL for proxying. Returns a URL the DLNA device
+  /// can fetch.
+  String registerUrl(String url, {required String mimeType}) {
+    final token = _generateToken();
+    final ext = _extForMime(mimeType);
+    _routes['$token$ext'] = _ProxyRoute(type: _RouteType.remote, path: url, mimeType: mimeType);
+    return '$_baseUrl/stream/$token$ext';
+  }
+
+  // ── HTTP handling ──────────────────────────────────────────────
+
+  Future<void> _handleRequest(HttpRequest request) async {
+    try {
+      final path = request.uri.path;
+      String token;
+      if (path.startsWith('/file/')) {
+        token = path.substring('/file/'.length);
+        await _serveFile(request, token);
+      } else if (path.startsWith('/stream/')) {
+        token = path.substring('/stream/'.length);
+        await _serveStream(request, token);
+      } else {
+        request.response.statusCode = HttpStatus.notFound;
+        await request.response.close();
+      }
+    } catch (e) {
+      try {
+        request.response.statusCode = HttpStatus.internalServerError;
+        await request.response.close();
+      } catch (_) {}
+    }
+  }
+
+  Future<void> _serveFile(HttpRequest request, String token) async {
+    final route = _routes[token];
+    if (route == null || route.type != _RouteType.file) {
+      request.response.statusCode = HttpStatus.notFound;
+      await request.response.close();
+      return;
+    }
+
+    final file = File(route.path);
+    if (!await file.exists()) {
+      request.response.statusCode = HttpStatus.notFound;
+      await request.response.close();
+      return;
+    }
+
+    final fileLength = await file.length();
+    final rangeHeader = request.headers.value('Range');
+    int start = 0, end = fileLength - 1;
+    int statusCode = 200;
+    String statusText = 'OK';
+
+    if (rangeHeader != null && rangeHeader.startsWith('bytes=')) {
+      final spec = rangeHeader.substring('bytes='.length);
+      final parts = spec.split('-');
+      if (parts[0].isEmpty) {
+        final suffix = int.tryParse(parts[1]) ?? 0;
+        start = (fileLength - suffix).clamp(0, fileLength - 1);
+      } else {
+        start = int.tryParse(parts[0]) ?? 0;
+        if (parts[1].isNotEmpty) {
+          end = (int.tryParse(parts[1]) ?? fileLength - 1).clamp(0, fileLength - 1);
+        }
+      }
+      statusCode = 206;
+      statusText = 'Partial Content';
+    }
+
+    if (start > end || start >= fileLength) {
+      request.response.statusCode = HttpStatus.requestedRangeNotSatisfiable;
+      request.response.headers.set('Content-Range', 'bytes */$fileLength');
+      await request.response.close();
+      return;
+    }
+
+    final length = end - start + 1;
+
+    // Detach socket and write HTTP/1.0 response manually for maximum
+    // DLNA compatibility — some renderers reject HTTP/1.1 from Dart's
+    // HttpServer.
+    final socket = await request.response.detachSocket(writeHeaders: false);
+    try {
+      final headers = StringBuffer()
+        ..write('HTTP/1.0 $statusCode $statusText\r\n')
+        ..write('Content-Type: ${route.mimeType}\r\n')
+        ..write('Content-Length: $length\r\n')
+        ..write('Accept-Ranges: bytes\r\n')
+        ..write('transferMode.dlna.org: Streaming\r\n')
+        ..write('contentFeatures.dlna.org: ${_contentFeatures(route.mimeType)}\r\n');
+      if (statusCode == 206) {
+        headers.write('Content-Range: bytes $start-$end/$fileLength\r\n');
+      }
+      headers.write('\r\n');
+      socket.add(utf8.encode(headers.toString()));
+
+      if (request.method != 'HEAD') {
+        await file.openRead(start, end + 1).pipe(socket);
+      }
+    } finally {
+      await socket.close();
+    }
+  }
+
+  Future<void> _serveStream(HttpRequest request, String token) async {
+    final route = _routes[token];
+    if (route == null || route.type != _RouteType.remote) {
+      request.response.statusCode = HttpStatus.notFound;
+      await request.response.close();
+      return;
+    }
+
+    final upstreamUri = Uri.parse(route.path);
+    final httpClient = HttpClient();
+    try {
+      final upstreamReq = await httpClient.openUrl('GET', upstreamUri);
+      final rangeHeader = request.headers.value('Range');
+      if (rangeHeader != null) {
+        upstreamReq.headers.set('Range', rangeHeader);
+      }
+      final upstreamResp = await upstreamReq.close();
+
+      // Detach and write HTTP/1.0 response with DLNA headers.
+      final socket = await request.response.detachSocket(writeHeaders: false);
+      try {
+        final statusCode = upstreamResp.statusCode;
+        final statusText = upstreamResp.reasonPhrase;
+        final contentLength = upstreamResp.headers.value('Content-Length');
+        final contentRange = upstreamResp.headers.value('Content-Range');
+
+        final headers = StringBuffer()
+          ..write('HTTP/1.0 $statusCode $statusText\r\n')
+          ..write('Content-Type: ${route.mimeType}\r\n');
+        if (contentLength != null) {
+          headers.write('Content-Length: $contentLength\r\n');
+        }
+        if (contentRange != null) {
+          headers.write('Content-Range: $contentRange\r\n');
+        }
+        headers
+          ..write('Accept-Ranges: bytes\r\n')
+          ..write('transferMode.dlna.org: Streaming\r\n')
+          ..write('contentFeatures.dlna.org: ${_contentFeatures(route.mimeType)}\r\n')
+          ..write('\r\n');
+        socket.add(utf8.encode(headers.toString()));
+
+        if (request.method != 'HEAD') {
+          await upstreamResp.pipe(socket);
+        }
+      } finally {
+        await socket.close();
+      }
+    } finally {
+      httpClient.close(force: true);
+    }
+  }
+
+  // ── DLNA helpers ────────────────────────────────────────────────
+
+  /// Build the `contentFeatures.dlna.org` header value for a MIME type.
+  ///
+  /// `DLNA.ORG_OP=01` advertises byte-range seek support.
+  /// `DLNA.ORG_CI=0` means no transcoding/conversion.
+  /// `DLNA.ORG_FLAGS=01700000...` is the standard streaming flag set.
+  static const _dlnaFlags = '01700000000000000000000000000000';
+
+  static String _contentFeatures(String mimeType) {
+    final pn = _dlnaPn(mimeType);
+    if (pn != null) {
+      return '$pn;DLNA.ORG_OP=01;DLNA.ORG_CI=0;DLNA.ORG_FLAGS=$_dlnaFlags';
+    }
+    return 'DLNA.ORG_OP=01;DLNA.ORG_CI=0;DLNA.ORG_FLAGS=$_dlnaFlags';
+  }
+
+  /// Map a MIME type to its DLNA.ORG_PN profile name, if known.
+  static String? _dlnaPn(String mimeType) {
+    return switch (mimeType) {
+      'audio/mpeg' => 'DLNA.ORG_PN=MP3',
+      'audio/x-ms-wma' => 'DLNA.ORG_PN=WMABASE',
+      'audio/vnd.dlna.adts' => 'DLNA.ORG_PN=AAC_ADTS',
+      'audio/mp4' || 'audio/m4a' || 'audio/aac' => 'DLNA.ORG_PN=AAC_ISO',
+      'audio/wav' || 'audio/x-wav' => 'DLNA.ORG_PN=LPCM',
+      _ => null,
+    };
+  }
+
+  /// Pick a file extension for a MIME type so the proxy URL ends with
+  /// a recognisable extension (some DLNA devices rely on this).
+  static String _extForMime(String mimeType) {
+    return switch (mimeType) {
+      'audio/mpeg' => '.mp3',
+      'audio/flac' => '.flac',
+      'audio/wav' || 'audio/x-wav' => '.wav',
+      'audio/m4a' => '.m4a',
+      'audio/aac' => '.aac',
+      'audio/ogg' => '.ogg',
+      'audio/x-ms-wma' => '.wma',
+      'audio/ape' || 'audio/x-ape' => '.ape',
+      'audio/ac3' => '.ac3',
+      'audio/vnd.dlna.adts' => '.adts',
+      _ => '',
+    };
+  }
+
+  static String _generateToken() {
+    return DateTime.now().microsecondsSinceEpoch.toRadixString(36) +
+        (DateTime.now().millisecond % 1000).toRadixString(36);
+  }
+
+  /// Find the local IP on the same subnet as [targetDeviceIp].
+  static Future<String?> _getLocalIp(String? targetDeviceIp) async {
+    final interfaces = await NetworkInterface.list(type: InternetAddressType.IPv4);
+    final addresses = <InternetAddress>[];
+    for (final iface in interfaces) {
+      for (final addr in iface.addresses) {
+        if (!addr.isLoopback && !addr.isLinkLocal) {
+          addresses.add(addr);
+        }
+      }
+    }
+    if (addresses.isEmpty) return null;
+
+    if (targetDeviceIp != null) {
+      final targetPrefix = _subnetPrefix(targetDeviceIp);
+      if (targetPrefix != null) {
+        for (final addr in addresses) {
+          if (_subnetPrefix(addr.address) == targetPrefix) return addr.address;
+        }
+      }
+    }
+
+    // Prefer RFC 1918 private addresses.
+    for (final addr in addresses) {
+      if (_isPrivate(addr.address)) return addr.address;
+    }
+    return addresses.first.address;
+  }
+
+  static String? _subnetPrefix(String ip) {
+    final parts = ip.split('.');
+    if (parts.length != 4) return null;
+    return '${parts[0]}.${parts[1]}.${parts[2]}';
+  }
+
+  static bool _isPrivate(String ip) {
+    final parts = ip.split('.');
+    if (parts.length != 4) return false;
+    final a = int.tryParse(parts[0]);
+    final b = int.tryParse(parts[1]);
+    if (a == null || b == null) return false;
+    if (a == 10) return true;
+    if (a == 172 && b >= 16 && b <= 31) return true;
+    if (a == 192 && b == 168) return true;
+    return false;
+  }
+}
+
+enum _RouteType { file, remote }
+
+class _ProxyRoute {
+  final _RouteType type;
+  final String path; // file path or remote URL
+  final String mimeType;
+
+  const _ProxyRoute({required this.type, required this.path, required this.mimeType});
+}

--- a/lib/services/dlna_service.dart
+++ b/lib/services/dlna_service.dart
@@ -1,0 +1,792 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+import 'package:logging/logging.dart';
+import 'package:multicast_dns/multicast_dns.dart';
+import 'package:upnp_client/upnp_client.dart' as upnp;
+import 'package:xml/xml.dart' as xml;
+
+import 'dlna_media_proxy.dart';
+
+/// A discovered DLNA device that can be used for output.
+class DlnaOutputDevice {
+  final String name;
+  final String id;
+  final String address;
+  final int port;
+
+  /// The location URL (description.xml endpoint) of the device.
+  /// Used to re-fetch the device description for [DlnaService.connect].
+  final String locationUrl;
+
+  DlnaOutputDevice({
+    required this.name,
+    required this.id,
+    required this.address,
+    required this.port,
+    required this.locationUrl,
+  });
+
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is DlnaOutputDevice && id == other.id;
+
+  @override
+  int get hashCode => id.hashCode;
+
+  @override
+  String toString() => 'DlnaOutputDevice(name: $name, address: $address)';
+}
+
+/// State of a DLNA playback session.
+enum DlnaPlaybackState { stopped, playing, paused, transitioning, unknown }
+
+/// Snapshot of DLNA playback status.
+class DlnaPlaybackStatus {
+  final DlnaPlaybackState state;
+  final Duration position;
+  final Duration duration;
+
+  DlnaPlaybackStatus({required this.state, required this.position, required this.duration});
+}
+
+/// Service that manages DLNA/UPnP device discovery and playback control.
+///
+/// Uses [upnp.UpnpClient] (the `upnp_client` package) for SOAP/UPnP control
+/// and a custom [DlnaMediaProxy] for serving media with DLNA content-feature
+/// headers. Registered in GetIt as a singleton.
+class DlnaService {
+  final _logger = Logger("DlnaService");
+
+  /// The media proxy that serves files/streams to the DLNA device with
+  /// correct DLNA content-feature headers.
+  final DlnaMediaProxy _mediaProxy = DlnaMediaProxy();
+
+  /// The connected upnp_client device, or null when disconnected.
+  upnp.Device? _device;
+
+  /// The AVTransport service of the connected device.
+  upnp.AvTransportService? _avTransport;
+
+  /// The RenderingControl service of the connected device.
+  upnp.RenderingControlService? _renderingControl;
+
+  /// The currently connected device info, or null when disconnected.
+  DlnaOutputDevice? _connectedDevice;
+
+  /// Stream controller for the current playback status.
+  final _statusController = StreamController<DlnaPlaybackStatus>.broadcast();
+
+  /// Stream controller for the currently connected device.
+  final _deviceController = StreamController<DlnaOutputDevice?>.broadcast();
+
+  /// Timer for polling DLNA playback position.
+  Timer? _pollTimer;
+
+  /// Timestamp when playback started, used to avoid false STOPPED detection
+  /// during the first few seconds after loading.
+  DateTime? _playbackStartTime;
+
+  /// Current cached playback state.
+  DlnaPlaybackState _playbackState = DlnaPlaybackState.stopped;
+
+  /// Current cached position.
+  Duration _position = Duration.zero;
+
+  /// Current cached duration.
+  Duration _duration = Duration.zero;
+
+  /// Active discovery stream subscriptions, cancelled on stopDiscovery.
+  final List<StreamSubscription<dynamic>> _discoverySubs = [];
+
+  // ── Public API ──────────────────────────────────────────────────
+
+  /// Stream of playback status updates (position, state, duration).
+  Stream<DlnaPlaybackStatus> get statusStream => _statusController.stream;
+
+  /// Stream of the currently connected device (null when disconnected).
+  Stream<DlnaOutputDevice?> get deviceStream => _deviceController.stream;
+
+  /// The currently connected device, or null.
+  DlnaOutputDevice? get connectedDevice => _connectedDevice;
+
+  /// Whether a DLNA device is currently connected.
+  bool get isConnected => _device != null && _connectedDevice != null;
+
+  /// Whether a DLNA device is currently playing.
+  bool get isPlaying => _playbackState == DlnaPlaybackState.playing;
+
+  /// Get the current playback position.
+  Duration get position => _position;
+
+  /// Get the media duration.
+  Duration get duration => _duration;
+
+  /// Get the current playback state.
+  DlnaPlaybackState get playbackState => _playbackState;
+
+  // ── Discovery ────────────────────────────────────────────────────
+
+  /// Start a combined discovery stream using both SSDP and mDNS.
+  ///
+  /// SSDP (via [upnp.DeviceDiscoverer]) finds standard DLNA devices that
+  /// advertise via multicast. mDNS (via `_raop._tcp.local`) finds devices
+  /// like the Up2Stream PRO that advertise AirPlay/RAOP but not SSDP — we
+  /// then fetch their DLNA description.xml to get the control URLs.
+  ///
+  /// [timeout] controls how long discovery runs before the stream closes.
+  Stream<List<DlnaOutputDevice>> startDiscoveryStream({Duration timeout = const Duration(seconds: 15)}) {
+    final controller = StreamController<List<DlnaOutputDevice>>.broadcast();
+    final devices = <String, DlnaOutputDevice>{};
+
+    void emit() {
+      if (!controller.isClosed) {
+        controller.add(devices.values.toList());
+      }
+    }
+
+    // 1. SSDP discovery via upnp_client
+    final discoverer = upnp.DeviceDiscoverer();
+    final ssdpSub = discoverer.devices.listen(
+      (device) {
+        // Only care about MediaRenderer devices.
+        if (device.description?.deviceType?.contains('MediaRenderer') != true) {
+          return;
+        }
+        final id = device.description?.uuid ?? device.url ?? '';
+        if (id.isEmpty) return;
+
+        final uri = Uri.parse(device.url!);
+        final dlnaDevice = DlnaOutputDevice(
+          name: device.description?.friendlyName ?? 'Unknown',
+          id: id,
+          address: uri.host,
+          port: uri.port,
+          locationUrl: device.url!,
+        );
+        devices[dlnaDevice.id] = dlnaDevice;
+        emit();
+      },
+      onError: (Object e) => _logger.warning("SSDP discovery error: $e"),
+      onDone: () {
+        // Don't close controller yet — mDNS might still be running
+      },
+    );
+
+    // Start the SSDP search — must call start() first to create the
+    // UDP sockets, then getDevices() to send M-SEARCH packets.
+    // Use the MediaRenderer-specific search target so devices like
+    // Samsung TVs respond (they may not answer to upnp:rootdevice).
+    discoverer
+        .start(addressTypes: [InternetAddressType.IPv4])
+        .then(
+          (_) => discoverer.getDevices(timeout: timeout, searchTarget: 'urn:schemas-upnp-org:device:MediaRenderer:1'),
+        )
+        .catchError((Object e) {
+          _logger.warning("SSDP search error: $e");
+          return <upnp.Device>[];
+        })
+        .whenComplete(() {
+          ssdpSub.cancel();
+          discoverer.dispose();
+        });
+
+    _discoverySubs.add(ssdpSub);
+
+    // 2. mDNS discovery for _raop._tcp.local (AirPlay audio devices
+    //    that also have a DLNA control endpoint)
+    _discoverViaMdns(
+      serviceType: '_raop._tcp.local',
+      timeout: timeout,
+      onDevice: (device) {
+        devices[device.id] = device;
+        emit();
+      },
+      onDone: () {
+        // Both discovery streams are done
+        _discoverySubs.remove(ssdpSub);
+        if (!controller.isClosed) {
+          controller.close();
+        }
+      },
+    );
+
+    return controller.stream;
+  }
+
+  /// Stop an active discovery scan.
+  void stopDiscovery() {
+    for (final sub in _discoverySubs) {
+      sub.cancel();
+    }
+    _discoverySubs.clear();
+  }
+
+  /// mDNS discovery for DLNA renderers that advertise via RAOP/AirPlay.
+  ///
+  /// Queries [serviceType] (e.g. `_raop._tcp.local`), resolves each found
+  /// service to an IP address, then fetches `http://{ip}:49152/description.xml`
+  /// to extract DLNA control URLs. Tries common UPnP ports.
+  Future<void> _discoverViaMdns({
+    required String serviceType,
+    required Duration timeout,
+    required void Function(DlnaOutputDevice device) onDevice,
+    required void Function() onDone,
+  }) async {
+    final client = MDnsClient();
+    try {
+      await client.start();
+    } catch (e) {
+      _logger.warning("mDNS client failed to start: $e");
+      onDone();
+      return;
+    }
+
+    try {
+      final seen = <String>{};
+
+      // Send multiple rounds of queries (devices may not respond to first)
+      for (int round = 0; round < 3; round++) {
+        if (round > 0) {
+          await Future<void>.delayed(const Duration(seconds: 2));
+        }
+
+        await for (final PtrResourceRecord ptr in client.lookup<PtrResourceRecord>(
+          ResourceRecordQuery.serverPointer(serviceType),
+        )) {
+          if (seen.contains(ptr.domainName)) continue;
+          seen.add(ptr.domainName);
+
+          // Resolve SRV record to get host + port
+          await for (final SrvResourceRecord srv
+              in client
+                  .lookup<SrvResourceRecord>(ResourceRecordQuery.service(ptr.domainName))
+                  .timeout(const Duration(seconds: 3), onTimeout: (sink) => sink.close())) {
+            // Resolve A record to get IP
+            await for (final IPAddressResourceRecord ip
+                in client
+                    .lookup<IPAddressResourceRecord>(ResourceRecordQuery.addressIPv4(srv.target))
+                    .timeout(const Duration(seconds: 3), onTimeout: (sink) => sink.close())) {
+              final addressStr = ip.address.address;
+              _logger.fine("mDNS found: ${ptr.domainName} at $addressStr");
+
+              // Fetch DLNA description from the device
+              final device = await _fetchDlnaDescription(addressStr);
+              if (device != null) {
+                onDevice(device);
+              }
+            }
+          }
+        }
+      }
+    } catch (e) {
+      _logger.warning("mDNS discovery error: $e");
+    } finally {
+      client.stop();
+      onDone();
+    }
+  }
+
+  /// Fetch the DLNA device description from `http://{address}:{port}/description.xml`.
+  /// Tries common UPnP ports. Returns a [DlnaOutputDevice] if a MediaRenderer is found.
+  Future<DlnaOutputDevice?> _fetchDlnaDescription(String address) async {
+    final ports = [49152, 49153, 49154, 80, 8080, 8200, 50000];
+    for (final port in ports) {
+      final url = 'http://$address:$port/description.xml';
+      try {
+        final response = await http.get(Uri.parse(url)).timeout(const Duration(seconds: 5));
+        if (response.statusCode == 200 && response.body.contains('MediaRenderer')) {
+          final device = _parseDeviceDescription(response.body, url, address, port);
+          if (device != null) {
+            _logger.info("Found DLNA device via mDNS: ${device.name} at $address:$port");
+            return device;
+          }
+        }
+      } catch (_) {
+        // Port not open or not a DLNA device — try next port
+      }
+    }
+    return null;
+  }
+
+  /// Parse a device description XML and extract the friendly name and UDN.
+  DlnaOutputDevice? _parseDeviceDescription(String xmlBody, String locationUrl, String address, int port) {
+    try {
+      final doc = xml.XmlDocument.parse(xmlBody);
+      final root = doc.rootElement;
+      final deviceEl = root.getElement('device');
+      if (deviceEl == null) return null;
+
+      final friendlyName = deviceEl.getElement('friendlyName')?.innerText ?? 'Unknown';
+      final udn = deviceEl.getElement('UDN')?.innerText ?? locationUrl;
+      final id = udn.startsWith('uuid:') ? udn.substring(5) : udn;
+
+      return DlnaOutputDevice(name: friendlyName, id: id, address: address, port: port, locationUrl: locationUrl);
+    } catch (e) {
+      _logger.warning("Failed to parse device description: $e");
+      return null;
+    }
+  }
+
+  // ── Connection ──────────────────────────────────────────────────
+
+  /// Connect to a DLNA device and prepare it for playback.
+  ///
+  /// Fetches the device description XML from the device's location URL,
+  /// parses it into an [upnp.Device], and extracts the AVTransport and
+  /// RenderingControl services.
+  ///
+  /// Returns true on success, false on failure.
+  Future<bool> connect(DlnaOutputDevice device) async {
+    try {
+      _logger.info("Connecting to DLNA device: ${device.name}");
+
+      // Disconnect any existing session first
+      if (_device != null) {
+        await disconnect();
+      }
+
+      // Fetch and parse the device description XML
+      final response = await http.get(Uri.parse(device.locationUrl)).timeout(const Duration(seconds: 10));
+      if (response.statusCode != 200) {
+        _logger.severe("Failed to fetch device description: ${response.statusCode}");
+        return false;
+      }
+
+      final doc = xml.XmlDocument.parse(response.body);
+      final deviceEl = doc.rootElement.getElement('device');
+      if (deviceEl == null) {
+        _logger.severe("No <device> element in description XML");
+        return false;
+      }
+
+      final upnpDevice = upnp.Device.fromXml(deviceEl, device.locationUrl);
+
+      // Verify it has the services we need
+      final avTransport = upnpDevice.avTransportService();
+      if (avTransport == null) {
+        _logger.severe("Device has no AVTransport service");
+        return false;
+      }
+      final renderingControl = upnpDevice.renderingControlService();
+
+      _device = upnpDevice;
+      _avTransport = avTransport;
+      _renderingControl = renderingControl;
+      _connectedDevice = device;
+      _playbackState = DlnaPlaybackState.stopped;
+      _position = Duration.zero;
+      _duration = Duration.zero;
+
+      _deviceController.add(_connectedDevice);
+      _logger.info("Connected to DLNA device: ${device.name}");
+      return true;
+    } catch (e) {
+      _logger.severe("Failed to connect to DLNA device: $e");
+      _device = null;
+      _avTransport = null;
+      _renderingControl = null;
+      _connectedDevice = null;
+      _deviceController.add(null);
+      return false;
+    }
+  }
+
+  /// Discover a DLNA device by its IP address, bypassing SSDP/mDNS discovery.
+  ///
+  /// Fetches the device description XML from `http://{address}:{port}/description.xml`
+  /// and parses it to extract the device info.
+  ///
+  /// [port] defaults to 49152, the most common UPnP port. Common ports
+  /// (49152, 49153, 49154, 80, 8080, 8200) are tried if the default fails.
+  Future<DlnaOutputDevice?> discoverDeviceByAddress(String address, {int port = 49152}) async {
+    final ports = [port, 49152, 49153, 49154, 80, 8080, 8200];
+    for (final p in ports.toSet()) {
+      final descriptionUrl = 'http://$address:$p/description.xml';
+      try {
+        _logger.info("Fetching DLNA device description from $descriptionUrl");
+        final response = await http.get(Uri.parse(descriptionUrl)).timeout(const Duration(seconds: 5));
+        if (response.statusCode == 200 && response.body.contains('MediaRenderer')) {
+          final device = _parseDeviceDescription(response.body, descriptionUrl, address, p);
+          if (device != null) {
+            _logger.info("Found DLNA device: ${device.name} at $address:$p");
+            return device;
+          }
+        }
+      } catch (e) {
+        _logger.fine("No DLNA device at $address:$p: $e");
+      }
+    }
+    _logger.warning("No DLNA device found at $address");
+    return null;
+  }
+
+  // ── Media loading ───────────────────────────────────────────────
+
+  /// Load media onto the connected DLNA device and start playback.
+  ///
+  /// If [filePath] is provided, the file is served via the HTTP proxy so the
+  /// DLNA device can access it. Otherwise, [url] must be provided — the URL
+  /// is proxied through the app so the DLNA device fetches from the phone.
+  ///
+  /// [mimeType] is the MIME type of the audio (e.g. "audio/mpeg", "audio/flac").
+  /// If not provided, it is inferred from the file extension or defaults to
+  /// "audio/mpeg".
+  Future<bool> loadMedia({
+    String? url,
+    String? filePath,
+    String? title,
+    String? imageUrl,
+    Duration? startPosition,
+    String? mimeType,
+  }) async {
+    final avTransport = _avTransport;
+    if (avTransport == null) {
+      _logger.warning("Cannot load media: no DLNA connection");
+      return false;
+    }
+
+    try {
+      _logger.info("Loading media on DLNA device: ${filePath ?? url}");
+
+      final String mediaUrl;
+      final String effectiveMime;
+
+      // Always start the proxy — even for remote URLs, we proxy through
+      // the app so the DLNA device doesn't need to reach the Jellyfin
+      // server directly.
+      await _mediaProxy.start(targetDeviceIp: _connectedDevice?.address);
+
+      if (filePath != null) {
+        effectiveMime = mimeType ?? _mimeTypeFromFilePath(filePath);
+        mediaUrl = _mediaProxy.registerFile(filePath, mimeType: effectiveMime);
+      } else {
+        effectiveMime = mimeType ?? "audio/mpeg";
+        mediaUrl = _mediaProxy.registerUrl(url!, mimeType: effectiveMime);
+      }
+
+      // Build DIDL-Lite metadata with correct audio protocolInfo.
+      final protocolInfo = _audioProtocolInfo(effectiveMime);
+      final didlLite = _buildDidlLite(url: mediaUrl, title: title ?? "Finamp", protocolInfo: protocolInfo);
+
+      _logger.info("DLNA: SetAVTransportURI protocolInfo=$protocolInfo");
+
+      _playbackState = DlnaPlaybackState.transitioning;
+      _emitStatus();
+
+      // Send SetAVTransportURI
+      await avTransport.setAVTransportURI(mediaUrl, metadata: didlLite);
+
+      // Wait briefly for the device to process the URI before sending Play.
+      await Future<void>.delayed(const Duration(milliseconds: 500));
+
+      // Send Play
+      await avTransport.play();
+
+      _playbackState = DlnaPlaybackState.playing;
+      _playbackStartTime = DateTime.now();
+      _startPolling();
+
+      // Handle start position via seek if provided.
+      if (startPosition != null && startPosition > Duration.zero) {
+        await Future<void>.delayed(const Duration(seconds: 1));
+        await seek(startPosition);
+      }
+
+      _emitStatus();
+      return true;
+    } catch (e) {
+      _logger.severe("Failed to load media on DLNA device: $e");
+      return false;
+    }
+  }
+
+  /// Build DLNA protocolInfo string for an audio MIME type.
+  ///
+  /// Example: "audio/mpeg" → "http-get:*:audio/mpeg:DLNA.ORG_PN=MP3;DLNA.ORG_OP=01;DLNA.ORG_FLAGS=01700000000000000000000000000000"
+  static const _dlnaFlags = '01700000000000000000000000000000';
+
+  String _audioProtocolInfo(String mimeType) {
+    final pn = switch (mimeType) {
+      'audio/mpeg' => 'DLNA.ORG_PN=MP3',
+      'audio/x-ms-wma' => 'DLNA.ORG_PN=WMABASE',
+      'audio/vnd.dlna.adts' => 'DLNA.ORG_PN=AAC_ADTS',
+      'audio/mp4' || 'audio/m4a' || 'audio/aac' => 'DLNA.ORG_PN=AAC_ISO',
+      'audio/wav' || 'audio/x-wav' => 'DLNA.ORG_PN=LPCM',
+      'audio/flac' ||
+      'audio/ogg' ||
+      'audio/ape' ||
+      'audio/x-ape' ||
+      'audio/ac3' => null, // No standard DLNA PN, use generic
+      _ => null,
+    };
+
+    if (pn != null) {
+      return 'http-get:*:$mimeType:$pn;DLNA.ORG_OP=01;DLNA.ORG_FLAGS=$_dlnaFlags';
+    }
+    return 'http-get:*:$mimeType:DLNA.ORG_OP=01;DLNA.ORG_FLAGS=$_dlnaFlags';
+  }
+
+  /// Build DIDL-Lite metadata for an audio music track with protocolInfo.
+  String _buildDidlLite({required String url, required String title, required String protocolInfo}) {
+    final escapedTitle = _escapeXml(title);
+    final escapedUrl = _escapeXml(url);
+
+    final didlLite =
+        '<DIDL-Lite xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/"'
+        ' xmlns:dc="http://purl.org/dc/elements/1.1/"'
+        ' xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/">'
+        '<item id="0" parentID="0" restricted="1">'
+        '<dc:title>$escapedTitle</dc:title>'
+        '<upnp:class>object.item.audioItem.musicTrack</upnp:class>'
+        '<res protocolInfo="$protocolInfo">$escapedUrl</res>'
+        '</item>'
+        '</DIDL-Lite>';
+
+    return _escapeXml(didlLite);
+  }
+
+  /// Infer MIME type from a file path/extension.
+  String _mimeTypeFromFilePath(String filePath) {
+    final ext = filePath.split('.').last.toLowerCase();
+    return switch (ext) {
+      'mp3' => 'audio/mpeg',
+      'flac' => 'audio/flac',
+      'wav' => 'audio/wav',
+      'm4a' => 'audio/m4a',
+      'aac' => 'audio/aac',
+      'ogg' => 'audio/ogg',
+      'wma' => 'audio/x-ms-wma',
+      'ape' => 'audio/ape',
+      'ac3' => 'audio/ac3',
+      _ => 'audio/mpeg',
+    };
+  }
+
+  static String _escapeXml(String input) {
+    return input
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+        .replaceAll('"', '&quot;')
+        .replaceAll("'", '&apos;');
+  }
+
+  // ── Playback control ───────────────────────────────────────────
+
+  /// Resume playback on the DLNA device.
+  Future<void> play() async {
+    final avTransport = _avTransport;
+    if (avTransport == null) return;
+    try {
+      await avTransport.play();
+      _playbackState = DlnaPlaybackState.playing;
+      _startPolling();
+      _emitStatus();
+    } catch (e) {
+      _logger.severe("DLNA play failed: $e");
+    }
+  }
+
+  /// Pause playback on the DLNA device.
+  Future<void> pause() async {
+    final avTransport = _avTransport;
+    if (avTransport == null) {
+      _logger.warning("DLNA pause failed: no AVTransport service");
+      return;
+    }
+    try {
+      await avTransport.pause();
+      _playbackState = DlnaPlaybackState.paused;
+      _stopPolling();
+      _emitStatus();
+    } catch (e) {
+      _logger.severe("DLNA pause failed: $e (type: ${e.runtimeType})");
+      rethrow;
+    }
+  }
+
+  /// Stop playback on the DLNA device.
+  Future<void> stop() async {
+    final avTransport = _avTransport;
+    if (avTransport == null) return;
+    try {
+      await avTransport.stop();
+      _playbackState = DlnaPlaybackState.stopped;
+      _stopPolling();
+      _emitStatus();
+    } catch (e) {
+      _logger.severe("DLNA stop failed: $e");
+    }
+  }
+
+  /// Seek to a position on the DLNA device.
+  Future<void> seek(Duration position) async {
+    final avTransport = _avTransport;
+    if (avTransport == null) return;
+    try {
+      final target = _formatDuration(position);
+      await avTransport.seek(upnp.SeekMode.relTime, target);
+      _position = position;
+      _emitStatus();
+    } catch (e) {
+      _logger.severe("DLNA seek failed: $e");
+    }
+  }
+
+  /// Set the volume on the DLNA device (0.0 to 1.0).
+  Future<void> setVolume(double volume) async {
+    final renderingControl = _renderingControl;
+    if (renderingControl == null) return;
+    try {
+      final intVolume = (volume * 100).round().clamp(0, 100);
+      await renderingControl.setVolume(volume: intVolume);
+    } catch (e) {
+      _logger.fine("DLNA setVolume failed: $e");
+    }
+  }
+
+  /// Get the current volume from the DLNA device (0.0 to 1.0).
+  Future<double> getVolume() async {
+    final renderingControl = _renderingControl;
+    if (renderingControl == null) return 0.0;
+    try {
+      final intVolume = await renderingControl.getVolume();
+      return intVolume / 100.0;
+    } catch (e) {
+      _logger.fine("DLNA getVolume failed: $e");
+      return 0.0;
+    }
+  }
+
+  // ── Disconnect ─────────────────────────────────────────────────
+
+  /// Disconnect from the DLNA device and clean up resources.
+  Future<void> disconnect() async {
+    _stopPolling();
+
+    final avTransport = _avTransport;
+    if (avTransport != null) {
+      try {
+        await avTransport.stop();
+      } catch (e) {
+        _logger.warning("Error stopping DLNA during disconnect: $e");
+      }
+    }
+
+    _device = null;
+    _avTransport = null;
+    _renderingControl = null;
+    _connectedDevice = null;
+    _playbackState = DlnaPlaybackState.stopped;
+    _position = Duration.zero;
+    _duration = Duration.zero;
+    await _mediaProxy.stop();
+    _deviceController.add(null);
+    _statusController.add(
+      DlnaPlaybackStatus(state: DlnaPlaybackState.stopped, position: Duration.zero, duration: Duration.zero),
+    );
+    _logger.info("Disconnected from DLNA device");
+  }
+
+  // ── Polling ─────────────────────────────────────────────────────
+
+  /// Start periodic polling of DLNA playback status.
+  void _startPolling() {
+    _pollTimer?.cancel();
+    _pollTimer = Timer.periodic(const Duration(seconds: 2), (_) async {
+      await _pollDevice();
+    });
+  }
+
+  /// Stop polling.
+  void _stopPolling() {
+    _pollTimer?.cancel();
+    _pollTimer = null;
+  }
+
+  Future<void> _pollDevice() async {
+    final avTransport = _avTransport;
+    if (avTransport == null) return;
+
+    try {
+      // Get position info
+      final posInfo = await avTransport.getPositionInfo();
+      _position = _parseDuration(posInfo.relTime);
+      if (posInfo.trackDuration != null) {
+        final parsed = _parseDuration(posInfo.trackDuration);
+        if (parsed > Duration.zero) {
+          _duration = parsed;
+        }
+      }
+
+      // Get transport info to detect state changes
+      final transportInfo = await avTransport.getTransportInfo();
+      final state = transportInfo.currentTransportState;
+
+      if (state == upnp.TransportState.playing) {
+        _playbackState = DlnaPlaybackState.playing;
+      } else if (state == upnp.TransportState.pausedPlayback) {
+        _playbackState = DlnaPlaybackState.paused;
+      } else if (state == upnp.TransportState.stopped) {
+        // If device reports STOPPED while we think we're playing, the track
+        // ended. But don't do this during the first few seconds after loading
+        // — the device may briefly report STOPPED before transitioning to
+        // PLAYING.
+        if (_playbackState == DlnaPlaybackState.playing &&
+            _playbackStartTime != null &&
+            DateTime.now().difference(_playbackStartTime!) > const Duration(seconds: 5)) {
+          _playbackState = DlnaPlaybackState.stopped;
+          _stopPolling();
+        }
+      }
+    } catch (e) {
+      _logger.fine("DLNA polling failed: $e");
+    }
+
+    _emitStatus();
+  }
+
+  /// Emit a status update to listeners.
+  void _emitStatus() {
+    _statusController.add(DlnaPlaybackStatus(state: _playbackState, position: _position, duration: _duration));
+  }
+
+  // ── Duration helpers ────────────────────────────────────────────
+
+  /// Format a [Duration] as 'HH:MM:SS' for DLNA Seek commands.
+  static String _formatDuration(Duration duration) {
+    final h = duration.inHours.toString().padLeft(2, '0');
+    final m = (duration.inMinutes % 60).toString().padLeft(2, '0');
+    final s = (duration.inSeconds % 60).toString().padLeft(2, '0');
+    return '$h:$m:$s';
+  }
+
+  /// Parse a 'HH:MM:SS' string into a [Duration].
+  static Duration _parseDuration(String? formatted) {
+    if (formatted == null || formatted.isEmpty || formatted == 'NOT_IMPLEMENTED') {
+      return Duration.zero;
+    }
+    final parts = formatted.split(':');
+    if (parts.length != 3) return Duration.zero;
+    return Duration(
+      hours: int.tryParse(parts[0]) ?? 0,
+      minutes: int.tryParse(parts[1]) ?? 0,
+      seconds: int.tryParse(parts[2]) ?? 0,
+    );
+  }
+
+  // ── Dispose ─────────────────────────────────────────────────────
+
+  /// Dispose all resources. Call this when the service is no longer needed.
+  void dispose() {
+    _stopPolling();
+    for (final sub in _discoverySubs) {
+      unawaited(sub.cancel());
+    }
+    _discoverySubs.clear();
+    unawaited(_mediaProxy.stop());
+    _statusController.close();
+    _deviceController.close();
+  }
+}

--- a/lib/services/music_player_background_task.dart
+++ b/lib/services/music_player_background_task.dart
@@ -26,6 +26,7 @@ import 'package:logging/logging.dart';
 import 'package:rxdart/rxdart.dart';
 
 import 'android_auto_helper.dart';
+import 'dlna_service.dart';
 import 'finamp_settings_helper.dart';
 import 'ios_helpers.dart';
 import 'metadata_provider.dart';
@@ -170,6 +171,37 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler with SeekHandler, Queue
   late final BehaviorSubject<FadeState> fadeState;
 
   final outputSwitcherChannel = MethodChannel('com.unicornsonlsd.finamp/output_switcher');
+
+  /// When true, audio output is routed to a DLNA device instead of the local
+  /// [AudioPlayer]. All play/pause/seek/skip operations are sent to the DLNA
+  /// device via [_dlnaService].
+  bool _isDlnaMode = false;
+
+  /// The DLNA service used for device discovery and playback control.
+  DlnaService? _dlnaService;
+
+  /// Subscription to DLNA playback status (position, state, duration).
+  StreamSubscription<DlnaPlaybackStatus>? _dlnaStatusSub;
+
+  /// The last known DLNA playback status. Used for progress reporting and UI.
+  DlnaPlaybackStatus _dlnaStatus = DlnaPlaybackStatus(
+    state: DlnaPlaybackState.stopped,
+    position: Duration.zero,
+    duration: Duration.zero,
+  );
+
+  /// Whether we are currently loading a new track onto the DLNA device.
+  /// Prevents auto-advance from firing during track transitions.
+  bool _isDlnaLoadingTrack = false;
+
+  /// Whether audio is currently being routed to a DLNA device.
+  bool get isDlnaMode => _isDlnaMode;
+
+  /// The currently connected DLNA device name, or null if not casting.
+  String? get dlnaDeviceName => _dlnaService?.connectedDevice?.name;
+
+  /// The current DLNA playback status. Used by UI when casting.
+  DlnaPlaybackStatus get dlnaStatus => _dlnaStatus;
 
   /// Some Bluetooth headsets send skip and pause/play media button events in
   /// very quick succession for a double-tap skip gesture. This guard ignores a
@@ -551,13 +583,20 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler with SeekHandler, Queue
       for (final queueItem in queueItems) {
         audioSources.add(await _queueItemToAudioSource(queueItem));
       }
-      return await _player.setAudioSources(
+      final result = await _player.setAudioSources(
         audioSources,
         preload: preload,
         initialIndex: initialIndex,
         initialPosition: initialPosition,
         shuffleOrder: shuffleOrder,
       );
+
+      // If in DLNA mode, load the first track onto the DLNA device
+      if (_isDlnaMode && _dlnaService != null) {
+        await _loadCurrentTrackToDlna();
+      }
+
+      return result;
     } on PlayerException catch (e) {
       _audioServiceBackgroundTaskLogger.severe("Player error code ${e.code}: ${e.message}");
       GlobalSnackbar.error(e);
@@ -611,6 +650,15 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler with SeekHandler, Queue
     _audioServiceBackgroundTaskLogger.fine(
       "play() start: disableFade=$disableFade, playing=${_player.playing}, fadeDirection=${fadeState.value.fadeDirection}, currentIndex=${_player.currentIndex}, position=${_player.position}",
     );
+    if (_isDlnaMode && _dlnaService != null) {
+      try {
+        await _dlnaService!.play();
+      } catch (e) {
+        _audioServiceBackgroundTaskLogger.warning("DLNA play failed: $e");
+      }
+      _broadcastDlnaPlaybackState(playing: true);
+      return;
+    }
     if (_shouldIgnorePlayPauseAfterRecentSkip) {
       return;
     }
@@ -634,6 +682,10 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler with SeekHandler, Queue
   }
 
   void setVolume(final double volume) async {
+    if (_isDlnaMode && _dlnaService != null) {
+      _dlnaService!.setVolume(volume);
+      return;
+    }
     return _volume.setInternalVolume(volume);
   }
 
@@ -642,6 +694,15 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler with SeekHandler, Queue
     _audioServiceBackgroundTaskLogger.fine(
       "pause() start: disableFade=$disableFade, playing=${_player.playing}, fadeDirection=${fadeState.value.fadeDirection}, currentIndex=${_player.currentIndex}, position=${_player.position}",
     );
+    if (_isDlnaMode && _dlnaService != null) {
+      try {
+        await _dlnaService!.pause();
+      } catch (e) {
+        _audioServiceBackgroundTaskLogger.warning("DLNA pause failed: $e");
+      }
+      _broadcastDlnaPlaybackState(playing: false);
+      return;
+    }
     if (_shouldIgnorePlayPauseAfterRecentSkip) {
       return;
     }
@@ -756,6 +817,11 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler with SeekHandler, Queue
     try {
       _audioServiceBackgroundTaskLogger.info("Audio service received stop command");
 
+      if (_isDlnaMode && _dlnaService != null) {
+        await _dlnaService!.stop();
+        _broadcastDlnaPlaybackState(playing: false);
+      }
+
       if (FinampSettingsHelper.finampSettings.clearQueueOnStopEvent) {
         await GetIt.instance<QueueService>().stopAndClearQueue();
       } else {
@@ -812,6 +878,19 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler with SeekHandler, Queue
       "skipToPrevious() start: forceSkip=$forceSkip, playing=${_player.playing}, fadeDirection=${fadeState.value.fadeDirection}, hasPrevious=${_player.hasPrevious}, loopMode=${_player.loopMode}, currentIndex=${_player.currentIndex}, position=${_player.position}",
     );
     _lastSkipCommandAt = DateTime.now();
+    if (_isDlnaMode && _dlnaService != null) {
+      if (_dlnaStatus.position.inSeconds >= 5) {
+        // Restart current track
+        await _loadCurrentTrackToDlna();
+      } else if (_player.hasPrevious) {
+        await _player.seekToPrevious();
+        await _loadCurrentTrackToDlna();
+      } else {
+        // No previous track — restart from beginning
+        await _loadCurrentTrackToDlna();
+      }
+      return;
+    }
     bool doSkip = true;
 
     try {
@@ -848,6 +927,16 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler with SeekHandler, Queue
       "skipToNext() start: playing=${_player.playing}, fadeDirection=${fadeState.value.fadeDirection}, hasNext=${_player.hasNext}, loopMode=${_player.loopMode}, currentIndex=${_player.currentIndex}, position=${_player.position}",
     );
     _lastSkipCommandAt = DateTime.now();
+    if (_isDlnaMode && _dlnaService != null) {
+      if (_player.loopMode == LoopMode.one || !_player.hasNext) {
+        // Use skipByOffset to handle loop mode wrapping properly
+        await skipByOffset(1);
+      } else {
+        await _player.seekToNext();
+      }
+      await _loadCurrentTrackToDlna();
+      return;
+    }
     try {
       if (_player.loopMode == LoopMode.one || !_player.hasNext) {
         // if the user manually skips to the next track, they probably want to actually skip to the next track
@@ -895,6 +984,12 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler with SeekHandler, Queue
   Future<void> skipToIndex(int index) async {
     _audioServiceBackgroundTaskLogger.fine("skipping to index: $index");
 
+    if (_isDlnaMode && _dlnaService != null) {
+      await _player.seek(Duration.zero, index: _player.shuffleModeEnabled ? shuffleIndices[index] : index);
+      await _loadCurrentTrackToDlna();
+      return;
+    }
+
     try {
       await _player.seek(Duration.zero, index: _player.shuffleModeEnabled ? shuffleIndices[index] : index);
     } catch (e) {
@@ -905,6 +1000,10 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler with SeekHandler, Queue
 
   @override
   Future<void> seek(Duration position) async {
+    if (_isDlnaMode && _dlnaService != null) {
+      await _dlnaService!.seek(position);
+      return;
+    }
     try {
       await _player.seek(position);
     } catch (e) {
@@ -1214,6 +1313,251 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler with SeekHandler, Queue
   //   return sleepTimer.getRemaining();
   // }
 
+  // ─── DLNA / Cast output methods ───────────────────────────────────────────
+
+  /// Connect to a DLNA device and switch audio output to it.
+  ///
+  /// Pauses the local player, connects to the DLNA device, and loads the
+  /// current track onto it. The local [AudioPlayer] is kept in a paused state
+  /// so the queue state stays consistent.
+  Future<bool> connectToDlna(DlnaService dlnaService) async {
+    try {
+      _audioServiceBackgroundTaskLogger.info("Switching output to DLNA device");
+
+      _dlnaService = dlnaService;
+      _isDlnaMode = true;
+
+      // Listen to DLNA status updates for position, state, and auto-advance
+      _dlnaStatusSub?.cancel();
+      _dlnaStatusSub = dlnaService.statusStream.listen((status) {
+        _dlnaStatus = status;
+
+        // Broadcast the DLNA position/state as a PlaybackState so the UI
+        // (progress slider, player buttons) updates correctly.
+        _broadcastDlnaPlaybackState(playing: status.state == DlnaPlaybackState.playing);
+
+        // Auto-advance when the DLNA device reports playback has stopped
+        // after playing (track finished). We check !_isDlnaLoadingTrack to
+        // avoid advancing during track transitions.
+        if (status.state == DlnaPlaybackState.stopped && !_isDlnaLoadingTrack) {
+          // Only auto-advance if we were actually playing (position > 0)
+          // and the track reached near the end (position close to duration).
+          // This prevents false auto-advance when the device reports STOPPED
+          // during connection/startup (before playback starts).
+          if (status.duration > Duration.zero &&
+              status.position > const Duration(seconds: 3) &&
+              (status.duration - status.position).abs() < const Duration(seconds: 5)) {
+            _audioServiceBackgroundTaskLogger.info("DLNA track finished, auto-advancing");
+            skipToNext();
+          }
+        }
+      });
+
+      // Pause the local player — we keep the queue state but don't play locally
+      if (_player.playing) {
+        await _player.pause();
+      }
+
+      // Load the current track onto the DLNA device, if we have a queue
+      if (_player.sequence.isNotEmpty && _player.currentIndex != null) {
+        await _loadCurrentTrackToDlna();
+      }
+
+      return true;
+    } catch (e) {
+      _audioServiceBackgroundTaskLogger.severe("Failed to connect DLNA: $e");
+      _isDlnaMode = false;
+      _dlnaService = null;
+      return false;
+    }
+  }
+
+  /// Disconnect from the DLNA device and resume local playback.
+  ///
+  /// Stops the DLNA device, resumes the local [AudioPlayer] from the DLNA's
+  /// last known position.
+  Future<void> disconnectFromDlna() async {
+    _audioServiceBackgroundTaskLogger.info("Disconnecting DLNA output");
+
+    _dlnaStatusSub?.cancel();
+    _dlnaStatusSub = null;
+
+    // Seek the local player to the DLNA's last position before switching back
+    if (_dlnaStatus.position > Duration.zero && _player.currentIndex != null) {
+      try {
+        await _player.seek(_dlnaStatus.position);
+      } catch (e) {
+        _audioServiceBackgroundTaskLogger.warning("Could not seek local player to DLNA position: $e");
+      }
+    }
+
+    if (_dlnaService != null) {
+      await _dlnaService!.stop();
+    }
+
+    _isDlnaMode = false;
+    _dlnaService = null;
+    _dlnaStatus = DlnaPlaybackStatus(
+      state: DlnaPlaybackState.stopped,
+      position: Duration.zero,
+      duration: Duration.zero,
+    );
+
+    // Resume local playback
+    if (_player.processingState != ProcessingState.completed) {
+      await _player.play();
+    }
+  }
+
+  /// Load the current track (based on _player.currentIndex) onto the DLNA
+  /// device. Used on track changes and initial connection.
+  Future<void> _loadCurrentTrackToDlna() async {
+    final dlnaService = _dlnaService;
+    if (dlnaService == null || !dlnaService.isConnected) return;
+
+    final currentIndex = _player.currentIndex;
+    if (currentIndex == null || _player.sequence.isEmpty) return;
+
+    _isDlnaLoadingTrack = true;
+
+    try {
+      final queueItem = _player.sequence[currentIndex].tag as FinampQueueItem?;
+      if (queueItem == null) return;
+
+      final item = queueItem.item;
+      final title = item.title;
+      final imageUrl = item.artUri?.toString();
+
+      final isDownloaded = item.extras?["downloadedTrackPath"] != null;
+
+      // Determine the MIME type from the Jellyfin container field so the
+      // DLNA device gets the correct protocolInfo (e.g. audio/mpeg for MP3,
+      // audio/flac for FLAC). Falls back to "audio/mpeg" if unknown.
+      final itemJson = item.extras?["itemJson"] as Map<String, dynamic>?;
+      final container = itemJson?["Container"] as String?;
+      final mimeType = _dlnaMimeTypeFromContainer(container);
+
+      // Pass the current local playback position so the DLNA device
+      // resumes from where the user left off.
+      final startPosition = _player.position;
+
+      if (isDownloaded) {
+        // Serve the downloaded file via the HTTP proxy
+        final downloadedPath = item.extras!["downloadedTrackPath"] as String;
+        final success = await dlnaService.loadMedia(
+          filePath: downloadedPath,
+          title: title,
+          imageUrl: imageUrl,
+          mimeType: mimeType,
+          startPosition: startPosition,
+        );
+        if (!success) {
+          _audioServiceBackgroundTaskLogger.warning("Failed to load downloaded song on DLNA");
+        }
+      } else {
+        // Build the direct-play URL (no transcode for DLNA — most devices
+        // can't handle HLS)
+        final uri = await _trackUriForDlna(item);
+        final success = await dlnaService.loadMedia(
+          url: uri.toString(),
+          title: title,
+          imageUrl: imageUrl,
+          mimeType: mimeType,
+          startPosition: startPosition,
+        );
+        if (!success) {
+          _audioServiceBackgroundTaskLogger.warning("Failed to load streaming song on DLNA");
+        }
+      }
+
+      // Update mediaItem so the UI reflects the current track
+      mediaItem.add(item);
+    } catch (e) {
+      _audioServiceBackgroundTaskLogger.severe("Error loading track to DLNA: $e");
+    } finally {
+      _isDlnaLoadingTrack = false;
+    }
+  }
+
+  /// Build the media URL for a [MediaItem] to send to a DLNA device.
+  ///
+  /// Unlike [_trackUri], this always uses direct play (no HLS/transcode) since
+  /// most DLNA devices don't support HLS. The DLNA device fetches the URL
+  /// itself, so we don't need to be on Android/iOS.
+  Future<Uri> _trackUriForDlna(MediaItem mediaItem) async {
+    final finampUserHelper = GetIt.instance<FinampUserHelper>();
+
+    final parsedBaseUrl = Uri.parse(finampUserHelper.currentUser!.baseURL);
+
+    List<String> builtPath = List.from(parsedBaseUrl.pathSegments);
+    Map<String, String> queryParameters = Map.from(parsedBaseUrl.queryParameters);
+
+    // Include the API key so the DLNA device can authenticate
+    queryParameters["ApiKey"] = finampUserHelper.currentUser!.accessToken;
+
+    // Always use direct play for DLNA — most devices can't handle HLS
+    builtPath.addAll(["Items", mediaItem.extras!["itemJson"]["Id"] as String, "File"]);
+
+    return Uri(
+      host: parsedBaseUrl.host,
+      port: parsedBaseUrl.port,
+      scheme: parsedBaseUrl.scheme,
+      userInfo: parsedBaseUrl.userInfo,
+      pathSegments: builtPath,
+      queryParameters: queryParameters,
+    );
+  }
+
+  /// Map a Jellyfin container string to a MIME type for DLNA protocolInfo.
+  ///
+  /// Jellyfin container values include: "mp3", "flac", "wav", "m4a", "aac",
+  /// "ogg", "wma", "ape", "ac3", "opus", "webm", "mp4", etc.
+  /// Returns null if the container is unknown or null — the caller should
+  /// default to "audio/mpeg" in that case.
+  String? _dlnaMimeTypeFromContainer(String? container) {
+    if (container == null) return null;
+    return switch (container.toLowerCase()) {
+      'mp3' => 'audio/mpeg',
+      'flac' => 'audio/flac',
+      'wav' || 'wave' => 'audio/wav',
+      'm4a' => 'audio/m4a',
+      'aac' => 'audio/aac',
+      'ogg' || 'oggpag' || 'opus' => 'audio/ogg',
+      'wma' => 'audio/x-ms-wma',
+      'ape' => 'audio/ape',
+      'ac3' => 'audio/ac3',
+      'adts' => 'audio/vnd.dlna.adts',
+      _ => null, // unknown — caller defaults to audio/mpeg
+    };
+  }
+
+  /// Broadcast a PlaybackState to AudioService clients reflecting DLNA state.
+  void _broadcastDlnaPlaybackState({required bool playing}) {
+    final currentIndex = _player.currentIndex;
+    playbackState.add(
+      PlaybackState(
+        controls: [
+          MediaControl.skipToPrevious,
+          if (playing) MediaControl.pause else MediaControl.play,
+          MediaControl.stop,
+          MediaControl.skipToNext,
+        ],
+        systemActions: const {MediaAction.seek, MediaAction.seekForward, MediaAction.seekBackward},
+        androidCompactActionIndices: const [0, 1, 3],
+        processingState: AudioProcessingState.ready,
+        playing: playing,
+        updatePosition: _dlnaStatus.position,
+        bufferedPosition: _dlnaStatus.position,
+        speed: 1.0,
+        queueIndex: currentIndex,
+        shuffleMode: _player.shuffleModeEnabled ? AudioServiceShuffleMode.all : AudioServiceShuffleMode.none,
+        repeatMode: _audioServiceRepeatMode(_player.loopMode),
+      ),
+    );
+  }
+
+  // ─── End DLNA methods ──────────────────────────────────────────────────────
+
   /// Transform a just_audio event into an audio_service state.
   ///
   /// This method is used from the constructor. Every event received from the
@@ -1303,7 +1647,7 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler with SeekHandler, Queue
   SequenceState get sequenceState => _player.sequenceState;
   double get volume => (_volume._internalVolume * 100).roundToDouble() / 100;
   bool get paused => !_player.playing;
-  Duration get playbackPosition => _player.position;
+  Duration get playbackPosition => _isDlnaMode ? _dlnaStatus.position : _player.position;
 
   void onQueueServiceAvailable() {
     // Moved here because currentTrackMetadataProvider depends on queueService

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1128,10 +1128,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1169,10 +1169,10 @@ packages:
     dependency: "direct main"
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1189,6 +1189,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.16.12"
+  multicast_dns:
+    dependency: "direct main"
+    description:
+      name: multicast_dns
+      sha256: "134668a9605c747322d8c3eb0e89a4c0cbdedb29f8d2d5ae29d14daef724987b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.3+1"
   nested:
     dependency: transitive
     description:
@@ -1825,10 +1833,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "19a78f63e83d3a61f00826d09bc2f60e191bf3504183c001262be6ac75589fb8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.8"
   threshold:
     dependency: transitive
     description:
@@ -1877,6 +1885,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  upnp_client:
+    dependency: "direct main"
+    description:
+      name: upnp_client
+      sha256: "5821602de59f31d50d19447490994d876fba951fa98dcc7924cddfdbab21dca2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   upower:
     dependency: transitive
     description:
@@ -2110,7 +2126,7 @@ packages:
     source: hosted
     version: "1.1.0"
   xml:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: xml
       sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -77,6 +77,9 @@ dependencies:
   file_picker: ^11.0.2
   file: ^7.0.1
   permission_handler: ^12.0.0
+  upnp_client: ^1.0.4
+  multicast_dns: ^0.3.3
+  xml: ^6.6.1
   provider: ^6.0.5
   uuid: ^4.5.1
   infinite_scroll_pagination: ^5.0.0


### PR DESCRIPTION
## Summary

Adds DLNA/UPnP audio casting support, allowing users to play music on DLNA-compatible speakers and receivers on their local network.

The device selector is integrated into the existing **Output** menu (the "Sortie" button on the player screen), alongside the system output routes (speaker, Bluetooth, etc.).

## How it works

- **Discovery**: Combined SSDP (via `dart_cast`'s `DlnaDiscoveryProvider`) + mDNS (`_raop._tcp.local` via `multicast_dns`) for devices that don't respond to SSDP multicast. Manual IP entry is also available for devices not found via discovery.
- **Playback**: Audio is **proxied through the phone** — the DLNA device fetches from the app's local HTTP proxy, not directly from Jellyfin. This means the DLNA device only needs to reach the phone, not the Jellyfin server.
- **Protocol info**: Sends correct audio `protocolInfo` (e.g. `audio/mpeg:DLNA.ORG_PN=MP3`) and `object.item.audioItem.musicTrack` DIDL-Lite class, instead of the video-oriented metadata that `dart_cast` defaults to.
- **Format detection**: Maps Jellyfin container strings (mp3, flac, wav, m4a, etc.) to MIME types for correct DLNA protocol info.
- **Resume position**: When switching to DLNA output, the current playback position is passed to the DLNA device so playback resumes from where the user left off.
- **Auto-advance**: When the DLNA device reports a track has finished, the queue automatically advances to the next track.

## Files changed

- `lib/services/dlna_service.dart` (new) — DLNA service: device discovery (SSDP + mDNS), connect/disconnect, `loadMedia()` with audio protocolInfo, media proxy, position polling
- `lib/services/music_player_background_task.dart` — DLNA mode integration: `connectToDlna()`/`disconnectFromDlna()`, DLNA-delegated play/pause/stop/seek/skip, auto-advance, Jellyfin URL + MIME type helpers
- `lib/menus/output_menu.dart` — `DlnaDeviceList` widget in the existing output menu bottom sheet
- `lib/main.dart` — Register `DlnaService` in GetIt
- `lib/components/now_playing_bar.dart` — Cast indicator when DLNA mode is active
- `lib/l10n/app_en.arb` — New l10n strings
- `android/app/src/main/AndroidManifest.xml` — WiFi/network/multicast permissions
- `pubspec.yaml` — Add `dart_cast: ^0.6.0` and `multicast_dns: ^0.3.3`

## Tested against

A DLNA renderer that does not respond to SSDP multicast but advertises via mDNS as `_raop._tcp.local`. Both streaming from Jellyfin and playing downloaded files verified working.