### PR TITLE
Add multi-select and batch actions to song lists

### DIFF
--- a/lib/components/AddToPlaylistScreen/add_to_playlist_list.dart
+++ b/lib/components/AddToPlaylistScreen/add_to_playlist_list.dart
@@ -9,10 +9,10 @@ import '../error_snackbar.dart';
 class AddToPlaylistList extends StatefulWidget {
   const AddToPlaylistList({
     Key? key,
-    required this.itemToAddId,
+    required this.itemsToAdd,
   }) : super(key: key);
 
-  final String itemToAddId;
+  final List<String> itemsToAdd;
 
   @override
   State<AddToPlaylistList> createState() => _AddToPlaylistListState();
@@ -49,7 +49,7 @@ class _AddToPlaylistListState extends State<AddToPlaylistList> {
                     try {
                       await jellyfinApiHelper.addItemstoPlaylist(
                         playlistId: snapshot.data![index].id,
-                        ids: [widget.itemToAddId],
+                        ids: widget.itemsToAdd,
                       );
 
                       if (!mounted) return;

--- a/lib/components/AddToPlaylistScreen/new_playlist_dialog.dart
+++ b/lib/components/AddToPlaylistScreen/new_playlist_dialog.dart
@@ -10,10 +10,10 @@ import '../error_snackbar.dart';
 class NewPlaylistDialog extends StatefulWidget {
   const NewPlaylistDialog({
     Key? key,
-    required this.itemToAdd,
+    required this.itemsToAdd,
   }) : super(key: key);
 
-  final String itemToAdd;
+  final List<String> itemsToAdd;
 
   @override
   State<NewPlaylistDialog> createState() => _NewPlaylistDialogState();
@@ -71,7 +71,7 @@ class _NewPlaylistDialogState extends State<NewPlaylistDialog> {
       try {
         await _jellyfinApiHelper.createNewPlaylist(NewPlaylist(
           name: _name,
-          ids: [widget.itemToAdd],
+          ids: widget.itemsToAdd,
           userId: _finampUserHelper.currentUser!.id,
         ));
 

--- a/lib/components/AlbumScreen/album_screen_content.dart
+++ b/lib/components/AlbumScreen/album_screen_content.dart
@@ -5,10 +5,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_sticky_header/flutter_sticky_header.dart';
 import 'package:get_it/get_it.dart';
+import 'package:provider/provider.dart';
 
 import '../../models/jellyfin_models.dart';
 import '../../services/finamp_settings_helper.dart';
 import '../../components/favourite_button.dart';
+import '../selection_app_bar.dart';
+import '../song_selection_controller.dart';
 import 'album_screen_content_flexible_space_bar.dart';
 import 'delete_button.dart';
 import 'song_list_tile.dart';
@@ -43,6 +46,21 @@ class _AlbumScreenContentState extends State<AlbumScreenContent> {
       });
     }
 
+    // Multi-select support. The controller is provided above the AlbumScreen's
+    // Scaffold, so the batch action bar and this app bar share it.
+    final selectionController = context.watch<SongSelectionController?>();
+    final isSelecting = selectionController?.isSelecting ?? false;
+    if (selectionController != null) {
+      selectionController.parent = widget.parent;
+      selectionController.setSelectableItems(widget.children);
+      selectionController.onItemsRemoved = (removed) {
+        setState(() {
+          final removedIds = removed.map((e) => e.id).toSet();
+          widget.children.removeWhere((e) => removedIds.contains(e.id));
+        });
+      };
+    }
+
     List<List<BaseItemDto>> childrenPerDisc = [];
     // if not in playlist, try splitting up tracks by disc numbers
     // if first track has a disc number, let's assume the rest has it too
@@ -62,30 +80,40 @@ class _AlbumScreenContentState extends State<AlbumScreenContent> {
     return Scrollbar(
       child: CustomScrollView(
         slivers: [
-          SliverAppBar(
-            title: Text(widget.parent.name ??
-                AppLocalizations.of(context)!.unknownName),
-            // 125 + 64 is the total height of the widget we use as a
-            // FlexibleSpaceBar. We add the toolbar height since the widget
-            // should appear below the appbar.
-            // TODO: This height is affected by platform density.
-            expandedHeight: kToolbarHeight + 125 + 64,
-            pinned: true,
-            flexibleSpace: AlbumScreenContentFlexibleSpaceBar(
-              album: widget.parent,
-              items: widget.children,
+          if (isSelecting)
+            SliverAppBar(
+              pinned: true,
+              leading: selectionCloseButton(context, selectionController!),
+              title: selectionTitle(context, selectionController),
+              actions: selectionAppBarActions(context, selectionController),
+            )
+          else
+            SliverAppBar(
+              title: Text(widget.parent.name ??
+                  AppLocalizations.of(context)!.unknownName),
+              // 125 + 64 is the total height of the widget we use as a
+              // FlexibleSpaceBar. We add the toolbar height since the widget
+              // should appear below the appbar.
+              // TODO: This height is affected by platform density.
+              expandedHeight: kToolbarHeight + 125 + 64,
+              pinned: true,
+              flexibleSpace: AlbumScreenContentFlexibleSpaceBar(
+                album: widget.parent,
+                items: widget.children,
+              ),
+              actions: [
+                if (widget.parent.type == "Playlist" &&
+                    !FinampSettingsHelper.finampSettings.isOffline)
+                  PlaylistNameEditButton(playlist: widget.parent),
+                FavoriteButton(item: widget.parent),
+                if (GetIt.instance<DownloadsHelper>()
+                    .isAlbumDownloaded(widget.parent.id))
+                  DeleteButton(parent: widget.parent, items: widget.children),
+                if (!FinampSettingsHelper.finampSettings.isOffline)
+                  SyncAlbumOrPlaylistButton(
+                      parent: widget.parent, items: widget.children)
+              ],
             ),
-            actions: [
-              if (widget.parent.type == "Playlist" &&
-                  !FinampSettingsHelper.finampSettings.isOffline)
-                PlaylistNameEditButton(playlist: widget.parent),
-              FavoriteButton(item: widget.parent),
-              if (GetIt.instance<DownloadsHelper>().isAlbumDownloaded(widget.parent.id))
-                DeleteButton(parent: widget.parent, items: widget.children),
-              if (!FinampSettingsHelper.finampSettings.isOffline)
-                SyncAlbumOrPlaylistButton(parent: widget.parent, items: widget.children)
-            ],
-          ),
           if (widget.children.length > 1 &&
               childrenPerDisc.length >
                   1) // show headers only for multi disc albums

--- a/lib/components/AlbumScreen/song_list_tile.dart
+++ b/lib/components/AlbumScreen/song_list_tile.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:get_it/get_it.dart';
 import 'package:mini_music_visualizer/mini_music_visualizer.dart';
+import 'package:provider/provider.dart';
 
 import '../../models/jellyfin_models.dart';
 import '../../screens/add_to_playlist_screen.dart';
@@ -16,6 +17,7 @@ import '../album_image.dart';
 import '../error_snackbar.dart';
 import '../favourite_button.dart';
 import '../print_duration.dart';
+import '../song_selection_controller.dart';
 import 'downloaded_indicator.dart';
 
 enum SongListTileMenuItems {
@@ -75,6 +77,13 @@ class _SongListTileState extends State<SongListTile> {
   Widget build(BuildContext context) {
     final screenSize = MediaQuery.of(context).size;
 
+    // Screens that support multi-select provide a [SongSelectionController]
+    // above this widget. The lookup is nullable so that every other call site
+    // keeps its original (non-selecting) behaviour with no changes.
+    final selectionController = context.watch<SongSelectionController?>();
+    final isSelecting = selectionController?.isSelecting ?? false;
+    final isSelected = selectionController?.isSelected(widget.item) ?? false;
+
     /// Sets the item's favourite on the Jellyfin server.
     Future<void> setFavourite() async {
       try {
@@ -117,7 +126,10 @@ class _SongListTileState extends State<SongListTile> {
                       widget.parentId;
 
           return ListTile(
-            leading: AlbumImage(item: widget.item),
+            selected: isSelected,
+            leading: isSelecting
+                ? _SelectableAlbumImage(item: widget.item, selected: isSelected)
+                : AlbumImage(item: widget.item),
             title: RichText(
               text: TextSpan(
                 children: [
@@ -200,6 +212,10 @@ class _SongListTileState extends State<SongListTile> {
               ],
             ),
             onTap: () {
+              if (isSelecting) {
+                selectionController!.toggle(widget.item);
+                return;
+              }
               _audioServiceHelper.replaceQueueWithItem(
                 itemList: widget.children ?? [widget.item],
                 initialIndex: widget.index ?? 0,
@@ -210,6 +226,18 @@ class _SongListTileState extends State<SongListTile> {
 
     return GestureDetector(
       onLongPressStart: (details) async {
+        // On surfaces that support multi-select, a long press enters selection
+        // mode directly (like QQ Music) instead of opening the context menu.
+        if (selectionController != null) {
+          Feedback.forLongPress(context);
+          if (selectionController.isSelecting) {
+            selectionController.toggle(widget.item);
+          } else {
+            selectionController.startSelection(widget.item);
+          }
+          return;
+        }
+
         Feedback.forLongPress(context);
 
         // This horrible check does 2 things:
@@ -365,7 +393,7 @@ class _SongListTileState extends State<SongListTile> {
 
           case SongListTileMenuItems.addToPlaylist:
             Navigator.of(context).pushNamed(AddToPlaylistScreen.routeName,
-                arguments: widget.item.id);
+                arguments: [widget.item.id]);
             break;
 
           case SongListTileMenuItems.removeFromPlaylist:
@@ -445,7 +473,8 @@ class _SongListTileState extends State<SongListTile> {
           ? listTile
           : Dismissible(
               key: Key(widget.index.toString()),
-              direction: FinampSettingsHelper.finampSettings.disableGesture
+              direction: isSelecting ||
+                      FinampSettingsHelper.finampSettings.disableGesture
                   ? DismissDirection.none
                   : DismissDirection.horizontal,
               background: Container(
@@ -494,6 +523,48 @@ class _SongListTileState extends State<SongListTile> {
               },
               child: listTile,
             ),
+    );
+  }
+}
+
+/// The album image with a selection overlay, shown in place of [AlbumImage]
+/// while the tile is in selection mode. [AlbumImage] remains the sizing child
+/// so the artwork keeps its normal size.
+class _SelectableAlbumImage extends StatelessWidget {
+  const _SelectableAlbumImage({
+    Key? key,
+    required this.item,
+    required this.selected,
+  }) : super(key: key);
+
+  final BaseItemDto item;
+  final bool selected;
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        AlbumImage(item: item),
+        Positioned.fill(
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              color: selected
+                  ? Colors.black.withOpacity(0.45)
+                  : Colors.transparent,
+              borderRadius: AlbumImage.borderRadius,
+            ),
+            child: Center(
+              child: Icon(
+                selected ? Icons.check_circle : Icons.radio_button_unchecked,
+                color: selected
+                    ? Theme.of(context).colorScheme.primary
+                    : Colors.white,
+                size: 28.0,
+              ),
+            ),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/components/MusicScreen/music_screen_tab_view.dart
+++ b/lib/components/MusicScreen/music_screen_tab_view.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 import 'package:hive/hive.dart';
 import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
+import 'package:provider/provider.dart';
 
 import '../../models/finamp_models.dart';
 import '../../models/jellyfin_models.dart';
@@ -14,6 +15,7 @@ import '../../services/finamp_settings_helper.dart';
 import '../../services/finamp_user_helper.dart';
 import '../../services/jellyfin_api_helper.dart';
 import '../AlbumScreen/song_list_tile.dart';
+import '../song_selection_controller.dart';
 import '../error_snackbar.dart';
 import '../first_page_progress_indicator.dart';
 import '../new_page_progress_indicator.dart';
@@ -74,6 +76,18 @@ class _MusicScreenTabViewState extends State<MusicScreenTabView>
   String? letterToSearch;
   String lastSortOrder = SortOrder.ascending.toString();
   Timer? timer;
+
+  // On the Songs tab, the multi-select controller is fed the currently loaded
+  // items (for "select all"). Cached from build so the paging listener can push
+  // updates as more pages load, without relying on incidental rebuilds.
+  SongSelectionController? _songSelectionController;
+
+  void _updateSelectableItems() {
+    if (widget.tabContentType == TabContentType.songs) {
+      _songSelectionController
+          ?.setSelectableItems(_pagingController.itemList ?? []);
+    }
+  }
 
   // This function just lets us easily set stuff to the getItems call we want.
   Future<void> _getPage(int pageKey) async {
@@ -142,6 +156,8 @@ class _MusicScreenTabViewState extends State<MusicScreenTabView>
     _pagingController.addPageRequestListener((pageKey) {
       _getPage(pageKey);
     });
+    // Keep the "select all" candidate list current as pages load.
+    _pagingController.addListener(_updateSelectableItems);
     lastSortOrder =
         widget.sortOrder?.toString() ?? SortOrder.ascending.toString();
     controller = ScrollController();
@@ -240,6 +256,15 @@ class _MusicScreenTabViewState extends State<MusicScreenTabView>
       valueListenable: FinampSettingsHelper.finampSettingsListener,
       builder: (context, box, _) {
         final isOffline = box.get("FinampSettings")?.isOffline ?? false;
+
+        // Multi-select is only offered on the Songs tab, and only when a
+        // [SongSelectionController] is provided above this view (i.e. the Music
+        // screen, not the artist detail view). We use `read` so that toggling a
+        // selection doesn't rebuild the whole paginated list.
+        final selectionController = _songSelectionController =
+            widget.tabContentType == TabContentType.songs
+                ? context.read<SongSelectionController?>()
+                : null;
 
         if (isOffline) {
           // We do the same checks we do when online to ensure that the list is
@@ -394,6 +419,8 @@ class _MusicScreenTabViewState extends State<MusicScreenTabView>
             }
           }
 
+          selectionController?.setSelectableItems(offlineSortedItems ?? []);
+
           return Scrollbar(
             controller: controller,
             child: Stack(
@@ -476,6 +503,9 @@ class _MusicScreenTabViewState extends State<MusicScreenTabView>
             _oldView = widget.view;
             _pagingController.refresh();
           }
+
+          selectionController
+              ?.setSelectableItems(_pagingController.itemList ?? []);
 
           return RefreshIndicator(
             // RefreshIndicator wants an async function, so we use Future.sync()

--- a/lib/components/PlayerScreen/add_to_playlist_button.dart
+++ b/lib/components/PlayerScreen/add_to_playlist_button.dart
@@ -21,9 +21,9 @@ class AddToPlaylistButton extends StatelessWidget {
           return IconButton(
             onPressed: () => Navigator.of(context).pushReplacementNamed(
                 AddToPlaylistScreen.routeName,
-                arguments:
-                    BaseItemDto.fromJson(snapshot.data!.extras!["itemJson"])
-                        .id),
+                arguments: [
+                  BaseItemDto.fromJson(snapshot.data!.extras!["itemJson"]).id
+                ]),
             icon: const Icon(Icons.playlist_add),
             tooltip: AppLocalizations.of(context)!.addToPlaylistTooltip,
           );

--- a/lib/components/batch_operations_helper.dart
+++ b/lib/components/batch_operations_helper.dart
@@ -1,0 +1,257 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:get_it/get_it.dart';
+
+import '../models/finamp_models.dart';
+import '../models/jellyfin_models.dart';
+import '../services/audio_service_helper.dart';
+import '../services/downloads_helper.dart';
+import '../services/finamp_settings_helper.dart';
+import '../services/finamp_user_helper.dart';
+import '../services/jellyfin_api_helper.dart';
+import 'AlbumScreen/download_dialog.dart';
+import 'confirmation_prompt_dialog.dart';
+import 'error_snackbar.dart';
+import 'song_selection_controller.dart';
+
+/// Performs the batch equivalents of the per-song actions in [SongListTile]'s
+/// context menu, over a list of selected songs.
+///
+/// The underlying helpers are already list-native for queue and playlist
+/// operations, so those are a single call. Favourites are single-id at the API
+/// layer, so they fan out with [Future.wait]. Downloads are grouped by their
+/// parent album because [DownloadsHelper.addDownloads] is parent-centric.
+class BatchOperationsHelper {
+  static AudioServiceHelper get _audioServiceHelper =>
+      GetIt.instance<AudioServiceHelper>();
+  static JellyfinApiHelper get _jellyfinApiHelper =>
+      GetIt.instance<JellyfinApiHelper>();
+  static DownloadsHelper get _downloadsHelper =>
+      GetIt.instance<DownloadsHelper>();
+  static FinampUserHelper get _finampUserHelper =>
+      GetIt.instance<FinampUserHelper>();
+
+  static void _snackbar(BuildContext context, String message) {
+    ScaffoldMessenger.of(context)
+        .showSnackBar(SnackBar(content: Text(message)));
+  }
+
+  static Future<void> addToQueue(
+      BuildContext context, List<BaseItemDto> items) async {
+    if (items.isEmpty) return;
+    try {
+      await _audioServiceHelper.addQueueItems(items);
+      if (!context.mounted) return;
+      _snackbar(context, AppLocalizations.of(context)!.addedToQueue);
+    } catch (e) {
+      errorSnackbar(e, context);
+    }
+  }
+
+  static Future<void> playNext(
+      BuildContext context, List<BaseItemDto> items) async {
+    if (items.isEmpty) return;
+    try {
+      await _audioServiceHelper.insertQueueItemsNext(items);
+      if (!context.mounted) return;
+      _snackbar(context, AppLocalizations.of(context)!.insertedIntoQueue);
+    } catch (e) {
+      errorSnackbar(e, context);
+    }
+  }
+
+  static Future<void> playNow(
+      BuildContext context, List<BaseItemDto> items) async {
+    if (items.isEmpty) return;
+    try {
+      await _audioServiceHelper.replaceQueueWithItem(itemList: items);
+      if (!context.mounted) return;
+      _snackbar(context, AppLocalizations.of(context)!.queueReplaced);
+    } catch (e) {
+      errorSnackbar(e, context);
+    }
+  }
+
+  /// Adds or removes favourites for [items]. The [BaseItemDto.userData] of each
+  /// item is updated in place so the tiles reflect the new state after the
+  /// controller notifies.
+  static Future<void> setFavourites(
+    BuildContext context,
+    List<BaseItemDto> items, {
+    required bool addToFavourites,
+  }) async {
+    if (items.isEmpty) return;
+    try {
+      await Future.wait(items.map((item) async {
+        final newUserData = addToFavourites
+            ? await _jellyfinApiHelper.addFavourite(item.id)
+            : await _jellyfinApiHelper.removeFavourite(item.id);
+        item.userData = newUserData;
+      }));
+
+      if (!context.mounted) return;
+      _snackbar(
+        context,
+        addToFavourites
+            ? AppLocalizations.of(context)!.addedItemsToFavourites(items.length)
+            : AppLocalizations.of(context)!
+                .removedItemsFromFavourites(items.length),
+      );
+    } catch (e) {
+      errorSnackbar(e, context);
+    }
+  }
+
+  static Future<void> instantMix(BuildContext context, BaseItemDto item) async {
+    try {
+      await _audioServiceHelper.startInstantMixForItem(item);
+      if (!context.mounted) return;
+      _snackbar(context, AppLocalizations.of(context)!.startingInstantMix);
+    } catch (e) {
+      errorSnackbar(e, context);
+    }
+  }
+
+  /// Removes [controller]'s selected songs from the playlist they belong to.
+  /// Only valid when [SongSelectionController.isPlaylist] is true.
+  static Future<void> removeFromPlaylist(
+    BuildContext context,
+    SongSelectionController controller,
+  ) async {
+    final parent = controller.parent;
+    if (parent == null) return;
+
+    final items = controller.selectedItems
+        .where((e) => e.playlistItemId != null)
+        .toList();
+    if (items.isEmpty) return;
+
+    try {
+      await _jellyfinApiHelper.removeItemsFromPlaylist(
+        playlistId: parent.id,
+        entryIds: items.map((e) => e.playlistItemId!).toList(),
+      );
+
+      if (!context.mounted) return;
+      controller.onItemsRemoved?.call(items);
+      controller.removeFromSelection(items);
+      _snackbar(context, AppLocalizations.of(context)!.removedFromPlaylist);
+    } catch (e) {
+      errorSnackbar(e, context);
+    }
+  }
+
+  /// Downloads [items]. When a single [parent] (album/playlist) is supplied
+  /// (album/playlist screen) it is used directly; otherwise the songs are
+  /// grouped by their album, which is resolved from the server, since
+  /// [DownloadsHelper.addDownloads] downloads under a single parent.
+  /// Returns true if a download was started (so the caller can leave selection
+  /// mode), false if it was cancelled or nothing could be downloaded.
+  static Future<bool> download(
+    BuildContext context,
+    List<BaseItemDto> items, {
+    BaseItemDto? parent,
+  }) async {
+    if (items.isEmpty) return false;
+    if (FinampSettingsHelper.finampSettings.isOffline) return false;
+
+    final viewId = _finampUserHelper.currentUser?.currentViewId;
+    if (viewId == null) return false;
+
+    late final List<BaseItemDto> parents;
+    late final List<List<BaseItemDto>> groupedItems;
+
+    if (parent != null) {
+      parents = [parent];
+      groupedItems = [items];
+    } else {
+      final Map<String, List<BaseItemDto>> byAlbum = {};
+      for (final item in items) {
+        final albumId = item.albumId ?? item.parentId;
+        if (albumId == null) continue;
+        byAlbum.putIfAbsent(albumId, () => []).add(item);
+      }
+
+      final resolvedParents = <BaseItemDto>[];
+      final resolvedItems = <List<BaseItemDto>>[];
+      var failedAlbums = 0;
+      for (final entry in byAlbum.entries) {
+        try {
+          resolvedParents.add(await _jellyfinApiHelper.getItemById(entry.key));
+          resolvedItems.add(entry.value);
+        } catch (_) {
+          failedAlbums++;
+        }
+      }
+      // Report all resolution failures once instead of one snackbar per album.
+      if (failedAlbums > 0 && context.mounted) {
+        errorSnackbar(
+            "Could not load $failedAlbums album(s) to download.", context);
+      }
+      parents = resolvedParents;
+      groupedItems = resolvedItems;
+    }
+
+    if (parents.isEmpty || !context.mounted) return false;
+
+    final downloadLocation = await showDialog<DownloadLocation>(
+      context: context,
+      builder: (context) => DownloadDialog(
+        parents: parents,
+        items: groupedItems,
+        viewId: viewId,
+      ),
+    );
+
+    if (downloadLocation == null || !context.mounted) return false;
+
+    await checkedAddDownloads(
+      context,
+      downloadLocation: downloadLocation,
+      parents: parents,
+      items: groupedItems,
+      viewId: viewId,
+    );
+    return true;
+  }
+
+  /// Deletes the downloads for [items] after a confirmation prompt. Passes
+  /// `deletedFor: null` so only the songs' downloads are removed, not any
+  /// parent album. [onDeleted] is called after a successful deletion (used to
+  /// leave selection mode).
+  static void deleteDownloads(
+    BuildContext context,
+    List<BaseItemDto> items, {
+    VoidCallback? onDeleted,
+  }) {
+    if (items.isEmpty) return;
+
+    // Capture messenger/strings from the (persistent) caller context, since the
+    // dialog's own context is deactivated once it pops.
+    final messenger = ScaffoldMessenger.of(context);
+    final localisations = AppLocalizations.of(context)!;
+
+    showDialog(
+      context: context,
+      builder: (dialogContext) => ConfirmationPromptDialog(
+        promptText: localisations.deleteSelectedDownloadsPrompt(items.length),
+        confirmButtonText: localisations.deleteDownloadsConfirmButtonText,
+        abortButtonText: localisations.deleteDownloadsAbortButtonText,
+        onConfirmed: () async {
+          try {
+            await _downloadsHelper.deleteParentAndChildDownloads(
+              jellyfinItemIds: items.map((e) => e.id).toList(),
+              deletedFor: null,
+            );
+            messenger.showSnackBar(
+                SnackBar(content: Text(localisations.downloadsDeleted)));
+            onDeleted?.call();
+          } catch (e) {
+            if (context.mounted) errorSnackbar(e, context);
+          }
+        },
+        onAborted: () {},
+      ),
+    );
+  }
+}

--- a/lib/components/selection_action_bar.dart
+++ b/lib/components/selection_action_bar.dart
@@ -1,0 +1,258 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:get_it/get_it.dart';
+import 'package:provider/provider.dart';
+
+import '../models/jellyfin_models.dart';
+import '../screens/add_to_playlist_screen.dart';
+import '../screens/album_screen.dart';
+import '../services/downloads_helper.dart';
+import '../services/finamp_settings_helper.dart';
+import '../services/jellyfin_api_helper.dart';
+import 'batch_operations_helper.dart';
+import 'error_snackbar.dart';
+import 'song_selection_controller.dart';
+
+enum _BatchMenuItem {
+  playNext,
+  download,
+  deleteDownload,
+  removeFromPlaylist,
+  instantMix,
+  goToAlbum,
+}
+
+/// A contextual bottom bar shown while in selection mode, offering the batch
+/// equivalents of the per-song actions. Reads the [SongSelectionController]
+/// from the surrounding subtree; renders nothing when not selecting.
+class SelectionActionBar extends StatelessWidget {
+  const SelectionActionBar({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = context.watch<SongSelectionController?>();
+    if (controller == null || !controller.isSelecting) {
+      return const SizedBox.shrink();
+    }
+
+    final items = controller.selectedItems;
+    final hasSelection = items.isNotEmpty;
+    final isOffline = FinampSettingsHelper.finampSettings.isOffline;
+    final allFavourite =
+        hasSelection && items.every((e) => e.userData?.isFavorite ?? false);
+
+    return Material(
+      color: Theme.of(context).colorScheme.surfaceVariant,
+      elevation: 8.0,
+      child: SafeArea(
+        top: false,
+        child: SizedBox(
+          height: 56.0,
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceAround,
+            children: [
+              IconButton(
+                icon: const Icon(Icons.play_arrow),
+                tooltip: AppLocalizations.of(context)!.replaceQueue,
+                onPressed: hasSelection
+                    ? () async {
+                        await BatchOperationsHelper.playNow(context, items);
+                        controller.endSelection();
+                      }
+                    : null,
+              ),
+              IconButton(
+                icon: const Icon(Icons.queue_music),
+                tooltip: AppLocalizations.of(context)!.addToQueue,
+                onPressed: hasSelection
+                    ? () async {
+                        await BatchOperationsHelper.addToQueue(context, items);
+                        controller.endSelection();
+                      }
+                    : null,
+              ),
+              IconButton(
+                icon: const Icon(Icons.playlist_add),
+                tooltip: AppLocalizations.of(context)!.addToPlaylistTitle,
+                onPressed: hasSelection && !isOffline
+                    ? () => _addToPlaylist(context, controller, items)
+                    : null,
+              ),
+              IconButton(
+                icon:
+                    Icon(allFavourite ? Icons.favorite : Icons.favorite_border),
+                tooltip: allFavourite
+                    ? AppLocalizations.of(context)!.removeFavourite
+                    : AppLocalizations.of(context)!.addFavourite,
+                onPressed: hasSelection
+                    ? () async {
+                        await BatchOperationsHelper.setFavourites(
+                          context,
+                          items,
+                          addToFavourites: !allFavourite,
+                        );
+                        controller.endSelection();
+                      }
+                    : null,
+              ),
+              PopupMenuButton<_BatchMenuItem>(
+                enabled: hasSelection,
+                icon: const Icon(Icons.more_vert),
+                onSelected: (value) =>
+                    _onMenuSelected(context, controller, items, value),
+                itemBuilder: (context) => [
+                  PopupMenuItem(
+                    value: _BatchMenuItem.playNext,
+                    child: ListTile(
+                      leading: const Icon(Icons.queue_music),
+                      title: Text(AppLocalizations.of(context)!.playNext),
+                    ),
+                  ),
+                  PopupMenuItem(
+                    value: _BatchMenuItem.download,
+                    enabled: !isOffline,
+                    child: ListTile(
+                      leading: const Icon(Icons.file_download),
+                      title: Text(AppLocalizations.of(context)!.download),
+                      enabled: !isOffline,
+                    ),
+                  ),
+                  PopupMenuItem(
+                    value: _BatchMenuItem.deleteDownload,
+                    child: ListTile(
+                      leading: const Icon(Icons.delete),
+                      title:
+                          Text(AppLocalizations.of(context)!.deleteFromDevice),
+                    ),
+                  ),
+                  if (controller.isPlaylist)
+                    PopupMenuItem(
+                      value: _BatchMenuItem.removeFromPlaylist,
+                      enabled: !isOffline,
+                      child: ListTile(
+                        leading: const Icon(Icons.playlist_remove),
+                        title: Text(AppLocalizations.of(context)!
+                            .removeFromPlaylistTitle),
+                        enabled: !isOffline,
+                      ),
+                    ),
+                  if (items.length == 1) ...[
+                    PopupMenuItem(
+                      value: _BatchMenuItem.instantMix,
+                      enabled: !isOffline,
+                      child: ListTile(
+                        leading: const Icon(Icons.explore),
+                        title: Text(AppLocalizations.of(context)!.instantMix),
+                        enabled: !isOffline,
+                      ),
+                    ),
+                    PopupMenuItem(
+                      value: _BatchMenuItem.goToAlbum,
+                      child: ListTile(
+                        leading: const Icon(Icons.album),
+                        title: Text(AppLocalizations.of(context)!.goToAlbum),
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _addToPlaylist(
+    BuildContext context,
+    SongSelectionController controller,
+    List<BaseItemDto> items,
+  ) async {
+    await Navigator.of(context).pushNamed(
+      AddToPlaylistScreen.routeName,
+      arguments: items.map((e) => e.id).toList(),
+    );
+    controller.endSelection();
+  }
+
+  Future<void> _onMenuSelected(
+    BuildContext context,
+    SongSelectionController controller,
+    List<BaseItemDto> items,
+    _BatchMenuItem value,
+  ) async {
+    switch (value) {
+      case _BatchMenuItem.playNext:
+        await BatchOperationsHelper.playNext(context, items);
+        controller.endSelection();
+        break;
+      case _BatchMenuItem.download:
+        // Keeps the selection if the download-location dialog is cancelled.
+        if (await BatchOperationsHelper.download(context, items,
+            parent: controller.parent)) {
+          controller.endSelection();
+        }
+        break;
+      case _BatchMenuItem.deleteDownload:
+        // The confirmation dialog exits selection itself on confirm.
+        BatchOperationsHelper.deleteDownloads(context, items,
+            onDeleted: controller.endSelection);
+        break;
+      case _BatchMenuItem.removeFromPlaylist:
+        await BatchOperationsHelper.removeFromPlaylist(context, controller);
+        controller.endSelection();
+        break;
+      case _BatchMenuItem.instantMix:
+        await BatchOperationsHelper.instantMix(context, items.first);
+        controller.endSelection();
+        break;
+      case _BatchMenuItem.goToAlbum:
+        await _goToAlbum(context, items.first);
+        controller.endSelection();
+        break;
+    }
+  }
+
+  Future<void> _goToAlbum(BuildContext context, BaseItemDto item) async {
+    if (item.parentId == null) return;
+    late BaseItemDto album;
+    if (FinampSettingsHelper.finampSettings.isOffline) {
+      final downloadsHelper = GetIt.instance<DownloadsHelper>();
+      final downloadedParent =
+          downloadsHelper.getDownloadedParent(item.parentId!);
+      if (downloadedParent == null) return;
+      album = downloadedParent.item;
+    } else {
+      try {
+        album = await GetIt.instance<JellyfinApiHelper>()
+            .getItemById(item.parentId!);
+      } catch (e) {
+        if (context.mounted) errorSnackbar(e, context);
+        return;
+      }
+    }
+
+    if (!context.mounted) return;
+    Navigator.of(context).pushNamed(AlbumScreen.routeName, arguments: album);
+  }
+}
+
+/// Stacks the [SelectionActionBar] above [child] (typically the now playing
+/// bar) so both can live in a Scaffold's `bottomNavigationBar`.
+class SelectionAwareBottomBar extends StatelessWidget {
+  const SelectionAwareBottomBar({Key? key, required this.child})
+      : super(key: key);
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        const SelectionActionBar(),
+        child,
+      ],
+    );
+  }
+}

--- a/lib/components/selection_app_bar.dart
+++ b/lib/components/selection_app_bar.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+import 'song_selection_controller.dart';
+
+/// Close (X) button that leaves selection mode.
+Widget selectionCloseButton(
+    BuildContext context, SongSelectionController controller) {
+  return IconButton(
+    icon: const Icon(Icons.close),
+    tooltip: MaterialLocalizations.of(context).closeButtonTooltip,
+    onPressed: controller.endSelection,
+  );
+}
+
+/// "N selected" title for the selection app bar.
+Widget selectionTitle(
+    BuildContext context, SongSelectionController controller) {
+  return Text(
+    AppLocalizations.of(context)!.itemsSelected(controller.selectedCount),
+  );
+}
+
+/// Select-all / deselect-all toggle for the selection app bar. Only shown when
+/// the surface exposes a list of selectable items.
+List<Widget> selectionAppBarActions(
+    BuildContext context, SongSelectionController controller) {
+  if (!controller.hasSelectableItems) return const [];
+  final allSelected = controller.allSelectableSelected;
+  return [
+    IconButton(
+      icon: Icon(allSelected ? Icons.deselect : Icons.select_all),
+      tooltip: allSelected
+          ? AppLocalizations.of(context)!.deselectAll
+          : AppLocalizations.of(context)!.selectAll,
+      onPressed: allSelected ? controller.deselectAll : controller.selectAll,
+    ),
+  ];
+}
+
+/// A regular [AppBar] shown while in selection mode (used by screens whose app
+/// bar is a plain [AppBar], e.g. the Music screen). Screens whose app bar is a
+/// [SliverAppBar] build one inline using the helpers above.
+class SelectionAppBar extends StatelessWidget implements PreferredSizeWidget {
+  const SelectionAppBar({
+    Key? key,
+    required this.controller,
+    this.bottom,
+  }) : super(key: key);
+
+  final SongSelectionController controller;
+  final PreferredSizeWidget? bottom;
+
+  @override
+  Size get preferredSize =>
+      Size.fromHeight(kToolbarHeight + (bottom?.preferredSize.height ?? 0.0));
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBar(
+      leading: selectionCloseButton(context, controller),
+      title: selectionTitle(context, controller),
+      actions: selectionAppBarActions(context, controller),
+      bottom: bottom,
+    );
+  }
+}

--- a/lib/components/song_selection_controller.dart
+++ b/lib/components/song_selection_controller.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/foundation.dart';
+
+import '../models/jellyfin_models.dart';
+
+/// Ephemeral, screen-scoped controller that tracks the multi-select state of a
+/// list of songs.
+///
+/// It is provided to a screen subtree via a `ChangeNotifierProvider`.
+/// [SongListTile] looks it up with a *nullable* `context.watch` so that screens
+/// which don't provide one keep their original (non-selecting) behaviour, and
+/// no existing call site needs to change.
+class SongSelectionController extends ChangeNotifier {
+  bool _isSelecting = false;
+
+  // Insertion-ordered so that batch actions (e.g. adding to the queue) preserve
+  // the order in which songs were selected. Keyed by [BaseItemDto.id].
+  final Map<String, BaseItemDto> _selected = <String, BaseItemDto>{};
+
+  List<BaseItemDto> _selectable = const [];
+
+  /// The parent the current surface belongs to, when it is a single album or
+  /// playlist. Used as the download parent and to enable the
+  /// "remove from playlist" action. Null on surfaces without a single parent
+  /// (e.g. the Songs tab).
+  BaseItemDto? parent;
+
+  /// Called after items have been removed from the underlying list by a batch
+  /// action (currently "remove from playlist") so the surface can drop them
+  /// from its in-memory list and rebuild.
+  void Function(List<BaseItemDto> removed)? onItemsRemoved;
+
+  bool get isSelecting => _isSelecting;
+
+  int get selectedCount => _selected.length;
+
+  bool get hasSelection => _selected.isNotEmpty;
+
+  /// Selected items, in selection order.
+  List<BaseItemDto> get selectedItems => _selected.values.toList();
+
+  bool isSelected(BaseItemDto item) => _selected.containsKey(item.id);
+
+  /// True when the current surface is a playlist, enabling the
+  /// "remove from playlist" batch action.
+  bool get isPlaylist => parent?.type == "Playlist";
+
+  /// The set of items the current surface can select, used for "select all".
+  /// The list widget updates this as its data changes (including as more pages
+  /// load on paginated surfaces). Does not notify, since it is called from
+  /// build.
+  void setSelectableItems(List<BaseItemDto> items) {
+    _selectable = items;
+  }
+
+  bool get hasSelectableItems => _selectable.isNotEmpty;
+
+  bool get allSelectableSelected =>
+      _selectable.isNotEmpty &&
+      _selectable.every((e) => _selected.containsKey(e.id));
+
+  /// Enters selection mode with [item] selected.
+  void startSelection(BaseItemDto item) {
+    _isSelecting = true;
+    _selected[item.id] = item;
+    notifyListeners();
+  }
+
+  /// Toggles whether [item] is selected. Does nothing to the mode itself, so
+  /// deselecting the last item keeps the user in selection mode (matching apps
+  /// like QQ Music, where you exit explicitly).
+  void toggle(BaseItemDto item) {
+    if (_selected.containsKey(item.id)) {
+      _selected.remove(item.id);
+    } else {
+      _selected[item.id] = item;
+    }
+    notifyListeners();
+  }
+
+  void selectAll() {
+    for (final item in _selectable) {
+      _selected[item.id] = item;
+    }
+    notifyListeners();
+  }
+
+  void deselectAll() {
+    _selected.clear();
+    notifyListeners();
+  }
+
+  /// Removes [items] from the current selection (e.g. after they were removed
+  /// from a playlist).
+  void removeFromSelection(List<BaseItemDto> items) {
+    for (final item in items) {
+      _selected.remove(item.id);
+    }
+    notifyListeners();
+  }
+
+  /// Exits selection mode and clears the selection.
+  void endSelection() {
+    _isSelecting = false;
+    _selected.clear();
+    notifyListeners();
+  }
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -583,5 +583,45 @@
   "sync": "Synchronize with Server",
   "@sync": {},
   "about": "About Finamp",
-  "@about": {}
+  "@about": {},
+  "selectAll": "Select All",
+  "@selectAll": {},
+  "deselectAll": "Deselect All",
+  "@deselectAll": {},
+  "itemsSelected": "{count,plural, =0{No items selected} =1{{count} selected} other{{count} selected}}",
+  "@itemsSelected": {
+    "description": "Title shown in the selection app bar with the number of selected songs.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "addedItemsToFavourites": "{count,plural, =1{Added {count} song to favourites} other{Added {count} songs to favourites}}",
+  "@addedItemsToFavourites": {
+    "description": "Snackbar shown after adding the selected songs to favourites.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "removedItemsFromFavourites": "{count,plural, =1{Removed {count} song from favourites} other{Removed {count} songs from favourites}}",
+  "@removedItemsFromFavourites": {
+    "description": "Snackbar shown after removing the selected songs from favourites.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "deleteSelectedDownloadsPrompt": "{count,plural, =1{Are you sure you want to delete {count} downloaded song?} other{Are you sure you want to delete {count} downloaded songs?}}",
+  "@deleteSelectedDownloadsPrompt": {
+    "description": "Confirmation prompt shown before deleting the downloads of the selected songs.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/screens/add_to_playlist_screen.dart
+++ b/lib/screens/add_to_playlist_screen.dart
@@ -16,14 +16,18 @@ class AddToPlaylistScreen extends StatefulWidget {
 class _AddToPlaylistScreenState extends State<AddToPlaylistScreen> {
   @override
   Widget build(BuildContext context) {
-    final itemId = ModalRoute.of(context)!.settings.arguments as String;
+    // Accepts either a single item id or a list of them (multi-select), so all
+    // existing callers keep working.
+    final arguments = ModalRoute.of(context)!.settings.arguments;
+    final itemIds =
+        arguments is List<String> ? arguments : [arguments as String];
 
     return Scaffold(
       appBar: AppBar(
         title: Text(AppLocalizations.of(context)!.addToPlaylistTitle),
       ),
       body: AddToPlaylistList(
-        itemToAddId: itemId,
+        itemsToAdd: itemIds,
       ),
       floatingActionButton: FloatingActionButton(
         child: const Icon(Icons.add),
@@ -33,7 +37,7 @@ class _AddToPlaylistScreenState extends State<AddToPlaylistScreen> {
           // cancels the dialog.
           final result = await showDialog<bool>(
             context: context,
-            builder: (context) => NewPlaylistDialog(itemToAdd: itemId),
+            builder: (context) => NewPlaylistDialog(itemsToAdd: itemIds),
           );
 
           if (!mounted) return;

--- a/lib/screens/album_screen.dart
+++ b/lib/screens/album_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:get_it/get_it.dart';
 import 'package:hive/hive.dart';
+import 'package:provider/provider.dart';
 
 import '../models/jellyfin_models.dart';
 import '../models/finamp_models.dart';
@@ -9,6 +10,8 @@ import '../services/jellyfin_api_helper.dart';
 import '../services/finamp_settings_helper.dart';
 import '../services/downloads_helper.dart';
 import '../components/now_playing_bar.dart';
+import '../components/selection_action_bar.dart';
+import '../components/song_selection_controller.dart';
 import '../components/AlbumScreen/album_screen_content.dart';
 import '../services/music_player_background_task.dart';
 
@@ -37,75 +40,79 @@ class _AlbumScreenState extends State<AlbumScreen> {
     final BaseItemDto parent = widget.parent ??
         ModalRoute.of(context)!.settings.arguments as BaseItemDto;
 
-    return Scaffold(
-      body: ValueListenableBuilder<Box<FinampSettings>>(
-        valueListenable: FinampSettingsHelper.finampSettingsListener,
-        builder: (context, box, widget) {
-          bool isOffline = box.get("FinampSettings")?.isOffline ?? false;
+    return ChangeNotifierProvider(
+      create: (_) => SongSelectionController(),
+      child: Scaffold(
+        body: ValueListenableBuilder<Box<FinampSettings>>(
+          valueListenable: FinampSettingsHelper.finampSettingsListener,
+          builder: (context, box, widget) {
+            bool isOffline = box.get("FinampSettings")?.isOffline ?? false;
 
-          if (isOffline) {
-            final downloadsHelper = GetIt.instance<DownloadsHelper>();
+            if (isOffline) {
+              final downloadsHelper = GetIt.instance<DownloadsHelper>();
 
-            // The downloadedParent won't be null here if we've already
-            // navigated to it in offline mode
-            final downloadedParent =
-                downloadsHelper.getDownloadedParent(parent.id)!;
+              // The downloadedParent won't be null here if we've already
+              // navigated to it in offline mode
+              final downloadedParent =
+                  downloadsHelper.getDownloadedParent(parent.id)!;
 
-            return AlbumScreenContent(
-              parent: downloadedParent.item,
-              children: downloadedParent.downloadedChildren.values.toList(),
-            );
-          } else {
-            albumScreenContentFuture ??= jellyfinApiHelper.getItems(
-              parentItem: parent,
-              sortBy: "ParentIndexNumber,IndexNumber,SortName",
-              includeItemTypes: "Audio",
-              isGenres: false,
-            );
+              return AlbumScreenContent(
+                parent: downloadedParent.item,
+                children: downloadedParent.downloadedChildren.values.toList(),
+              );
+            } else {
+              albumScreenContentFuture ??= jellyfinApiHelper.getItems(
+                parentItem: parent,
+                sortBy: "ParentIndexNumber,IndexNumber,SortName",
+                includeItemTypes: "Audio",
+                isGenres: false,
+              );
 
-            return FutureBuilder<List<BaseItemDto>?>(
-              future: albumScreenContentFuture,
-              builder: (context, snapshot) {
-                if (snapshot.hasData) {
-                  final List<BaseItemDto> items = snapshot.data!;
+              return FutureBuilder<List<BaseItemDto>?>(
+                future: albumScreenContentFuture,
+                builder: (context, snapshot) {
+                  if (snapshot.hasData) {
+                    final List<BaseItemDto> items = snapshot.data!;
 
-                  return AlbumScreenContent(parent: parent, children: items);
-                } else if (snapshot.hasError) {
-                  return CustomScrollView(
-                    physics: const NeverScrollableScrollPhysics(),
-                    slivers: [
-                      SliverAppBar(
-                        title: Text(AppLocalizations.of(context)!.error),
-                      ),
-                      SliverFillRemaining(
-                        child: Center(child: Text(snapshot.error.toString())),
-                      )
-                    ],
-                  );
-                } else {
-                  // We return all of this so that we can have an app bar while loading.
-                  // This is especially important for iOS, where there isn't a hardware back button.
-                  return CustomScrollView(
-                    physics: const NeverScrollableScrollPhysics(),
-                    slivers: [
-                      SliverAppBar(
-                        title: Text(parent.name ??
-                            AppLocalizations.of(context)!.unknownName),
-                      ),
-                      const SliverFillRemaining(
-                        child: Center(
-                          child: CircularProgressIndicator.adaptive(),
+                    return AlbumScreenContent(parent: parent, children: items);
+                  } else if (snapshot.hasError) {
+                    return CustomScrollView(
+                      physics: const NeverScrollableScrollPhysics(),
+                      slivers: [
+                        SliverAppBar(
+                          title: Text(AppLocalizations.of(context)!.error),
                         ),
-                      )
-                    ],
-                  );
-                }
-              },
-            );
-          }
-        },
+                        SliverFillRemaining(
+                          child: Center(child: Text(snapshot.error.toString())),
+                        )
+                      ],
+                    );
+                  } else {
+                    // We return all of this so that we can have an app bar while loading.
+                    // This is especially important for iOS, where there isn't a hardware back button.
+                    return CustomScrollView(
+                      physics: const NeverScrollableScrollPhysics(),
+                      slivers: [
+                        SliverAppBar(
+                          title: Text(parent.name ??
+                              AppLocalizations.of(context)!.unknownName),
+                        ),
+                        const SliverFillRemaining(
+                          child: Center(
+                            child: CircularProgressIndicator.adaptive(),
+                          ),
+                        )
+                      ],
+                    );
+                  }
+                },
+              );
+            }
+          },
+        ),
+        bottomNavigationBar:
+            const SelectionAwareBottomBar(child: NowPlayingBar()),
       ),
-      bottomNavigationBar: const NowPlayingBar(),
     );
   }
 }

--- a/lib/screens/music_screen.dart
+++ b/lib/screens/music_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:get_it/get_it.dart';
 import 'package:hive/hive.dart';
 import 'package:logging/logging.dart';
+import 'package:provider/provider.dart';
 
 import '../models/finamp_models.dart';
 import '../services/finamp_settings_helper.dart';
@@ -13,6 +14,9 @@ import '../components/MusicScreen/music_screen_drawer.dart';
 import '../components/MusicScreen/sort_by_menu_button.dart';
 import '../components/MusicScreen/sort_order_button.dart';
 import '../components/now_playing_bar.dart';
+import '../components/selection_action_bar.dart';
+import '../components/selection_app_bar.dart';
+import '../components/song_selection_controller.dart';
 import '../components/error_snackbar.dart';
 import '../services/jellyfin_api_helper.dart';
 
@@ -158,132 +162,154 @@ class _MusicScreenState extends State<MusicScreen>
 
   @override
   Widget build(BuildContext context) {
-    return ValueListenableBuilder<Box<FinampUser>>(
-      valueListenable: _finampUserHelper.finampUsersListenable,
-      builder: (context, value, _) {
-        return ValueListenableBuilder<Box<FinampSettings>>(
-          valueListenable: FinampSettingsHelper.finampSettingsListener,
-          builder: (context, value, _) {
-            final finampSettings = value.get("FinampSettings");
+    return ChangeNotifierProvider(
+      create: (_) => SongSelectionController(),
+      child: ValueListenableBuilder<Box<FinampUser>>(
+        valueListenable: _finampUserHelper.finampUsersListenable,
+        builder: (context, value, _) {
+          return ValueListenableBuilder<Box<FinampSettings>>(
+            valueListenable: FinampSettingsHelper.finampSettingsListener,
+            builder: (context, value, _) {
+              final finampSettings = value.get("FinampSettings");
+              final selection = context.watch<SongSelectionController>();
 
-            // Get the tabs from the user's tab order, and filter them to only
-            // include enabled tabs
-            final tabs = finampSettings!.tabOrder.where((e) =>
-                FinampSettingsHelper.finampSettings.showTabs[e] ?? false);
+              // Get the tabs from the user's tab order, and filter them to only
+              // include enabled tabs
+              final tabs = finampSettings!.tabOrder.where((e) =>
+                  FinampSettingsHelper.finampSettings.showTabs[e] ?? false);
 
-            if (tabs.length != _tabController?.length) {
-              _musicScreenLogger.info(
-                  "Rebuilding MusicScreen tab controller (${tabs.length} != ${_tabController?.length})");
-              _buildTabController();
-            }
+              if (tabs.length != _tabController?.length) {
+                _musicScreenLogger.info(
+                    "Rebuilding MusicScreen tab controller (${tabs.length} != ${_tabController?.length})");
+                _buildTabController();
+              }
 
-            return WillPopScope(
-              onWillPop: () async {
-                if (isSearching) {
-                  _stopSearching();
-                  return false;
-                }
-                return true;
-              },
-              child: Scaffold(
-                appBar: AppBar(
-                  title: isSearching
-                      ? TextField(
-                          controller: textEditingController,
-                          autofocus: true,
-                          onChanged: (value) => setState(() {
-                            searchQuery = value;
-                          }),
-                          decoration: InputDecoration(
-                            border: InputBorder.none,
-                            hintText: MaterialLocalizations.of(context)
-                                .searchFieldLabel,
+              return WillPopScope(
+                onWillPop: () async {
+                  if (selection.isSelecting) {
+                    selection.endSelection();
+                    return false;
+                  }
+                  if (isSearching) {
+                    _stopSearching();
+                    return false;
+                  }
+                  return true;
+                },
+                child: Scaffold(
+                  appBar: selection.isSelecting
+                      ? SelectionAppBar(controller: selection)
+                      : AppBar(
+                          title: isSearching
+                              ? TextField(
+                                  controller: textEditingController,
+                                  autofocus: true,
+                                  onChanged: (value) => setState(() {
+                                    searchQuery = value;
+                                  }),
+                                  decoration: InputDecoration(
+                                    border: InputBorder.none,
+                                    hintText: MaterialLocalizations.of(context)
+                                        .searchFieldLabel,
+                                  ),
+                                )
+                              : Text(_finampUserHelper
+                                      .currentUser?.currentView?.name ??
+                                  AppLocalizations.of(context)!.music),
+                          bottom: TabBar(
+                            controller: _tabController,
+                            tabs: tabs
+                                .map((tabType) => Tab(
+                                      text: tabType
+                                          .toLocalisedString(context)
+                                          .toUpperCase(),
+                                    ))
+                                .toList(),
+                            isScrollable: true,
+                            tabAlignment: TabAlignment.start,
                           ),
-                        )
-                      : Text(_finampUserHelper.currentUser?.currentView?.name ??
-                          AppLocalizations.of(context)!.music),
-                  bottom: TabBar(
+                          leading: isSearching
+                              ? BackButton(
+                                  onPressed: () => _stopSearching(),
+                                )
+                              : null,
+                          actions: isSearching
+                              ? [
+                                  IconButton(
+                                    icon: Icon(
+                                      Icons.cancel,
+                                      color: Theme.of(context)
+                                          .colorScheme
+                                          .onSurface,
+                                    ),
+                                    onPressed: () => setState(() {
+                                      textEditingController.clear();
+                                      searchQuery = null;
+                                    }),
+                                    tooltip:
+                                        AppLocalizations.of(context)!.clear,
+                                  )
+                                ]
+                              : [
+                                  SortOrderButton(
+                                    tabs.elementAt(_tabController!.index),
+                                  ),
+                                  SortByMenuButton(
+                                    tabs.elementAt(_tabController!.index),
+                                  ),
+                                  IconButton(
+                                    icon: finampSettings.isFavourite
+                                        ? const Icon(Icons.favorite)
+                                        : const Icon(Icons.favorite_outline),
+                                    onPressed: finampSettings.isOffline
+                                        ? null
+                                        : () =>
+                                            FinampSettingsHelper.setIsFavourite(
+                                                !finampSettings.isFavourite),
+                                    tooltip: AppLocalizations.of(context)!
+                                        .favourites,
+                                  ),
+                                  IconButton(
+                                    icon: const Icon(Icons.search),
+                                    onPressed: () => setState(() {
+                                      isSearching = true;
+                                    }),
+                                    tooltip: MaterialLocalizations.of(context)
+                                        .searchFieldLabel,
+                                  ),
+                                ],
+                        ),
+                  bottomNavigationBar:
+                      const SelectionAwareBottomBar(child: NowPlayingBar()),
+                  drawer: const MusicScreenDrawer(),
+                  floatingActionButton: selection.isSelecting
+                      ? null
+                      : Padding(
+                          padding: const EdgeInsets.only(right: 8.0),
+                          child: getFloatingActionButton(),
+                        ),
+                  body: TabBarView(
                     controller: _tabController,
-                    tabs: tabs
-                        .map((tabType) => Tab(
-                              text: tabType
-                                  .toLocalisedString(context)
-                                  .toUpperCase(),
+                    physics: selection.isSelecting
+                        ? const NeverScrollableScrollPhysics()
+                        : null,
+                    children: tabs
+                        .map((tabType) => MusicScreenTabView(
+                              tabContentType: tabType,
+                              searchTerm: searchQuery,
+                              isFavourite: finampSettings.isFavourite,
+                              sortBy: finampSettings.getTabSortBy(tabType),
+                              sortOrder: finampSettings.getSortOrder(tabType),
+                              view: _finampUserHelper.currentUser?.currentView,
                             ))
                         .toList(),
-                    isScrollable: true,
-                    tabAlignment: TabAlignment.start,
                   ),
-                  leading: isSearching
-                      ? BackButton(
-                          onPressed: () => _stopSearching(),
-                        )
-                      : null,
-                  actions: isSearching
-                      ? [
-                          IconButton(
-                            icon: Icon(
-                              Icons.cancel,
-                              color: Theme.of(context).colorScheme.onSurface,
-                            ),
-                            onPressed: () => setState(() {
-                              textEditingController.clear();
-                              searchQuery = null;
-                            }),
-                            tooltip: AppLocalizations.of(context)!.clear,
-                          )
-                        ]
-                      : [
-                          SortOrderButton(
-                            tabs.elementAt(_tabController!.index),
-                          ),
-                          SortByMenuButton(
-                            tabs.elementAt(_tabController!.index),
-                          ),
-                          IconButton(
-                            icon: finampSettings.isFavourite
-                                ? const Icon(Icons.favorite)
-                                : const Icon(Icons.favorite_outline),
-                            onPressed: finampSettings.isOffline
-                                ? null
-                                : () => FinampSettingsHelper.setIsFavourite(
-                                    !finampSettings.isFavourite),
-                            tooltip: AppLocalizations.of(context)!.favourites,
-                          ),
-                          IconButton(
-                            icon: const Icon(Icons.search),
-                            onPressed: () => setState(() {
-                              isSearching = true;
-                            }),
-                            tooltip: MaterialLocalizations.of(context)
-                                .searchFieldLabel,
-                          ),
-                        ],
                 ),
-                bottomNavigationBar: const NowPlayingBar(),
-                drawer: const MusicScreenDrawer(),
-                floatingActionButton: Padding(
-                  padding: const EdgeInsets.only(right: 8.0),
-                  child: getFloatingActionButton(),
-                ),
-                body: TabBarView(
-                  controller: _tabController,
-                  children: tabs
-                      .map((tabType) => MusicScreenTabView(
-                            tabContentType: tabType,
-                            searchTerm: searchQuery,
-                            isFavourite: finampSettings.isFavourite,
-                            sortBy: finampSettings.getTabSortBy(tabType),
-                            sortOrder: finampSettings.getSortOrder(tabType),
-                            view: _finampUserHelper.currentUser?.currentView,
-                          ))
-                      .toList(),
-                ),
-              ),
-            );
-          },
-        );
-      },
+              );
+            },
+          );
+        },
+      ),
     );
   }
 }


### PR DESCRIPTION
## What

Adds QQ Music-style multi-select to the album/playlist detail screen and the Songs tab. Long-press a song to enter selection mode; tap to toggle. A contextual app bar shows the selected count + select-all, and a bottom action bar performs the batch equivalents of the existing per-song actions:

- Play (replace queue), add to queue, play next
- Add to playlist (all selected songs in a single request)
- Add / remove favourite
- Download / delete download
- Remove from playlist (inside playlists)
- Instant mix / go to album (single selection only)

## How

- New screen-scoped `SongSelectionController` (`ChangeNotifier`) provided via `provider`. `SongListTile` reads it through a **nullable** lookup, so existing call sites are unchanged when no controller is present.
- Batch ops reuse existing helpers: queue and playlist operations are list-native (single call); favourites fan out with `Future.wait`; downloads are grouped by album parent (since `addDownloads` is parent-centric).
- The add-to-playlist route now accepts a `List<String>` of ids (still accepts a single id for existing callers).
- New localized strings are added to `app_en.arb` only; other locales come through Weblate.

## Notes

- **Known limitation:** on the online Songs tab, "select all" covers the currently loaded (paginated) songs; album/playlist and offline lists are complete, so select-all there is exhaustive.
- No database/model changes, so no code generation is required.

## Testing

- `flutter analyze` passes with no new errors.
- Builds and launches on the iOS simulator; the flow was exercised end-to-end against a real Jellyfin server: long-press to enter selection, tap to toggle, select-all, the selection app bar and batch action bar, the overflow menu's dynamic items, and a batch action showing a snackbar and exiting selection mode.

