### PR TITLE
Add multi-select and batch actions to the album/playlist screen

### DIFF
--- a/lib/components/AlbumScreen/album_screen_content.dart
+++ b/lib/components/AlbumScreen/album_screen_content.dart
@@ -4,6 +4,7 @@ import 'package:finamp/components/AlbumScreen/album_screen_content_flexible_spac
 import 'package:finamp/components/AlbumScreen/download_button.dart';
 import 'package:finamp/components/AlbumScreen/playlist_edit_button.dart';
 import 'package:finamp/components/AlbumScreen/track_list_tile.dart';
+import 'package:finamp/components/AlbumScreen/track_selection_bar.dart';
 import 'package:finamp/components/MusicScreen/item_wrapper.dart';
 import 'package:finamp/components/MusicScreen/music_screen_tab_view.dart';
 import 'package:finamp/components/favorite_button.dart';
@@ -20,6 +21,7 @@ import 'package:finamp/services/album_screen_provider.dart';
 import 'package:finamp/services/finamp_settings_helper.dart';
 import 'package:finamp/services/permission_providers.dart';
 import 'package:finamp/services/queue_service.dart';
+import 'package:finamp/services/track_selection_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
@@ -82,6 +84,10 @@ class _AlbumScreenContentState extends ConsumerState<AlbumScreenContent> {
     final displayChildren = allTracks ?? [];
     final queueChildren = playableTracks ?? [];
 
+    // Multi-select is scoped to this album/playlist.
+    final selectionScope = widget.parent.id.toString();
+    final isSelecting = ref.watch(trackSelectionProvider(selectionScope).select((s) => s.isSelecting));
+
     void onDelete(BaseItemDto item) {
       // This is pretty inefficient (has to search through whole list) but
       // TracksSliverList gets passed some weird split version of children to
@@ -135,6 +141,15 @@ class _AlbumScreenContentState extends ConsumerState<AlbumScreenContent> {
                 },
               ),
             ];
+
+            if (isSelecting) {
+              return SliverAppBar(
+                pinned: true,
+                leading: trackSelectionCloseButton(selectionScope),
+                title: trackSelectionTitle(selectionScope),
+                actions: trackSelectionAppBarActions(selectionScope, queueChildren),
+              );
+            }
 
             return SliverAppBar(
               title: (!parentIsPlaylist) ? Text(widget.parent.name ?? AppLocalizations.of(context)!.unknownName) : null,
@@ -202,6 +217,7 @@ class _AlbumScreenContentState extends ConsumerState<AlbumScreenContent> {
                 onRemoveFromList: onDelete,
                 adaptiveAdditionalInfoSortBy: (parentIsPlaylist) ? sortSetting.sortBy : null,
                 forceAlbumArtists: (parentIsPlaylist && sortSetting.sortBy == SortBy.albumArtist),
+                selectionScope: selectionScope,
               ),
             ),
             SliverToBoxAdapter(child: SizedBox(height: 16.0)),
@@ -214,6 +230,7 @@ class _AlbumScreenContentState extends ConsumerState<AlbumScreenContent> {
             onRemoveFromList: onDelete,
             adaptiveAdditionalInfoSortBy: (parentIsPlaylist) ? sortSetting.sortBy : null,
             forceAlbumArtists: (parentIsPlaylist && sortSetting.sortBy == SortBy.albumArtist),
+            selectionScope: selectionScope,
           )
         else
           SliverFillRemaining(child: Center(child: CircularProgressIndicator.adaptive())),
@@ -231,6 +248,7 @@ class TracksSliverList extends ConsumerStatefulWidget {
     this.onRemoveFromList,
     this.forceAlbumArtists = false,
     this.adaptiveAdditionalInfoSortBy,
+    this.selectionScope,
   });
 
   final List<BaseItemDto> childrenForList;
@@ -240,6 +258,7 @@ class TracksSliverList extends ConsumerStatefulWidget {
   final BaseItemDtoCallback? onRemoveFromList;
   final bool forceAlbumArtists;
   final SortBy? adaptiveAdditionalInfoSortBy;
+  final String? selectionScope;
 
   @override
   ConsumerState<TracksSliverList> createState() => _TracksSliverListState();
@@ -307,6 +326,7 @@ class _TracksSliverListState extends ConsumerState<TracksSliverList> {
           },
           forceAlbumArtists: widget.forceAlbumArtists,
           adaptiveAdditionalInfoSortBy: widget.adaptiveAdditionalInfoSortBy,
+          selectionScope: widget.selectionScope,
           // TODO should we be passing and leveraging a proper parent playable?
           parentPlayable: PrecalculatedPlayable(
             source: QueueItemSource.fromBaseItem(widget.parent),

--- a/lib/components/AlbumScreen/track_list_tile.dart
+++ b/lib/components/AlbumScreen/track_list_tile.dart
@@ -28,6 +28,7 @@ import '../../services/finamp_settings_helper.dart';
 import '../../services/music_providers.dart';
 import '../../services/queue_service.dart';
 import '../../services/theme_provider.dart';
+import '../../services/track_selection_provider.dart';
 import '../album_image.dart';
 import '../print_duration.dart';
 import 'downloaded_indicator.dart';
@@ -74,6 +75,13 @@ class TrackListTile extends ConsumerWidget {
     this.allowDismiss = true,
     this.highlightCurrentTrack = true,
     this.playbackProgress,
+
+    /// When set, this tile participates in multi-select for the given scope
+    /// (usually the parent album/playlist id). Tapping toggles selection and
+    /// long-pressing enters selection mode instead of opening the track menu.
+    /// Left null everywhere multi-select is not offered, so those uses are
+    /// unaffected.
+    this.selectionScope,
   });
 
   final BaseItemDto item;
@@ -88,6 +96,7 @@ class TrackListTile extends ConsumerWidget {
   final bool allowDismiss;
   final bool highlightCurrentTrack;
   final double? playbackProgress;
+  final String? selectionScope;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -133,6 +142,7 @@ class TrackListTile extends ConsumerWidget {
       highlightCurrentTrack: highlightCurrentTrack,
       onRemoveFromList: onRemoveFromList,
       onTap: trackListTileOnTap,
+      selectionScope: selectionScope,
       confirmDismiss: (direction) async {
         var followUpAction = (direction == DismissDirection.startToEnd)
             ? FinampSettingsHelper.finampSettings.itemSwipeActionLeftToRight
@@ -371,6 +381,7 @@ class TrackListItem extends ConsumerWidget {
   final Future<bool> Function(DismissDirection direction) confirmDismiss;
   final VoidCallback? onRemoveFromList;
   final double? playbackProgress;
+  final String? selectionScope;
 
   const TrackListItem({
     super.key,
@@ -390,6 +401,7 @@ class TrackListItem extends ConsumerWidget {
     this.leftSwipeBackground = const SizedBox.shrink(),
     this.rightSwipeBackground = const SizedBox.shrink(),
     this.playbackProgress,
+    this.selectionScope,
   });
 
   @override
@@ -411,6 +423,19 @@ class TrackListItem extends ConsumerWidget {
       currentTrackProvider.select((queueItem) => queueItem.valueOrNull?.baseItemId == baseItem.id),
     );
 
+    // Multi-select support: only active when a selectionScope is provided.
+    final scope = selectionScope;
+    final selection = scope != null ? ref.watch(trackSelectionProvider(scope)) : null;
+    final isSelecting = selection?.isSelecting ?? false;
+    final isSelected = selection?.isSelected(baseItem) ?? false;
+    void toggleSelection() {
+      if (scope != null) ref.read(trackSelectionProvider(scope).notifier).toggle(baseItem);
+    }
+
+    void enterSelection() {
+      if (scope != null) ref.read(trackSelectionProvider(scope).notifier).startSelection(baseItem);
+    }
+
     var listCard = Padding(
       padding: const EdgeInsets.only(left: 8.0, right: 8.0, top: 6.0),
       child: TrackListItemTile(
@@ -424,14 +449,41 @@ class TrackListItem extends ConsumerWidget {
         adaptiveAdditionalInfoSortBy: adaptiveAdditionalInfoSortBy,
         isCurrentTrack: isCurrentlyPlaying,
         highlightCurrentTrack: highlightCurrentTrack,
-        onTap: () => onTap(playable),
+        onTap: isSelecting ? () => toggleSelection() : () => onTap(playable),
         playbackProgress: playbackProgress,
         onRemoveFromList: onRemoveFromList,
         features: features,
       ),
     );
 
-    var listItem = playable ? listCard : Opacity(opacity: 0.5, child: listCard);
+    Widget listItem = playable ? listCard : Opacity(opacity: 0.5, child: listCard);
+
+    // Overlay a selection indicator when in selection mode.
+    if (isSelecting) {
+      listItem = Stack(
+        children: [
+          listItem,
+          if (isSelected)
+            Positioned.fill(
+              child: IgnorePointer(child: Container(color: Theme.of(context).colorScheme.primary.withOpacity(0.15))),
+            ),
+          Positioned(
+            left: 16,
+            top: 0,
+            bottom: 0,
+            child: Center(
+              child: Icon(
+                isSelected ? TablerIcons.circle_check_filled : TablerIcons.circle,
+                color: isSelected
+                    ? Theme.of(context).colorScheme.primary
+                    : Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
+                size: 26.0,
+              ),
+            ),
+          ),
+        ],
+      );
+    }
 
     var unthemedItem = Builder(
       builder: (context) {
@@ -455,13 +507,23 @@ class TrackListItem extends ConsumerWidget {
             // Begin precalculating theme for song menu
             ref.listenManual(finampThemeProvider(ThemeInfo(baseItem)), (_, __) {});
           },
-          onLongPressStart: features.contains(TrackListItemFeatures.fullyDraggable)
-              ? null
-              : (details) => menuCallback(),
+          onLongPressStart: scope != null
+              ? (details) {
+                  FeedbackHelper.feedback(FeedbackType.selection);
+                  if (isSelecting) {
+                    toggleSelection();
+                  } else {
+                    enterSelection();
+                  }
+                }
+              : (features.contains(TrackListItemFeatures.fullyDraggable) ? null : (details) => menuCallback()),
           onSecondaryTapDown: features.contains(TrackListItemFeatures.fullyDraggable)
               ? null
               : (details) => menuCallback(),
-          child: features.contains(TrackListItemFeatures.swipeable) && !ref.watch(finampSettingsProvider.disableGesture)
+          child:
+              features.contains(TrackListItemFeatures.swipeable) &&
+                  !isSelecting &&
+                  !ref.watch(finampSettingsProvider.disableGesture)
               ? Dismissible(
                   key: Key(listIndex.toString()),
                   direction: getAllowedDismissDirection(

--- a/lib/components/AlbumScreen/track_selection_bar.dart
+++ b/lib/components/AlbumScreen/track_selection_bar.dart
@@ -1,0 +1,222 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:get_it/get_it.dart';
+
+import '../../l10n/app_localizations.dart';
+import '../../menus/playlist_actions_menu.dart';
+import '../../models/finamp_models.dart';
+import '../../models/jellyfin_models.dart';
+import '../../models/music_slices.dart';
+import '../../services/favorite_provider.dart';
+import '../../services/finamp_settings_helper.dart';
+import '../../services/queue_service.dart';
+import '../../services/track_selection_provider.dart';
+import '../global_snackbar.dart';
+
+/// Close (X) button that leaves selection mode.
+Widget trackSelectionCloseButton(String scope) {
+  return Consumer(
+    builder: (context, ref, _) => IconButton(
+      icon: const Icon(Icons.close),
+      tooltip: MaterialLocalizations.of(context).closeButtonTooltip,
+      onPressed: () => ref.read(trackSelectionProvider(scope).notifier).endSelection(),
+    ),
+  );
+}
+
+/// "N selected" title.
+Widget trackSelectionTitle(String scope) {
+  return Consumer(
+    builder: (context, ref, _) {
+      final count = ref.watch(trackSelectionProvider(scope).select((s) => s.count));
+      return Text(AppLocalizations.of(context)!.itemsSelected(count));
+    },
+  );
+}
+
+/// Select-all / deselect-all action for the selection app bar, evaluated against
+/// [allTracks] (the surface's full list).
+List<Widget> trackSelectionAppBarActions(String scope, List<BaseItemDto> allTracks) {
+  return [
+    Consumer(
+      builder: (context, ref, _) {
+        final allSelected = ref.watch(trackSelectionProvider(scope).select((s) => s.allSelected(allTracks)));
+        return IconButton(
+          icon: Icon(allSelected ? Icons.deselect : Icons.select_all),
+          tooltip: allSelected ? AppLocalizations.of(context)!.deselectAll : AppLocalizations.of(context)!.selectAll,
+          onPressed: allTracks.isEmpty
+              ? null
+              : () {
+                  final notifier = ref.read(trackSelectionProvider(scope).notifier);
+                  if (allSelected) {
+                    notifier.deselectAll();
+                  } else {
+                    notifier.selectAll(allTracks);
+                  }
+                },
+        );
+      },
+    ),
+  ];
+}
+
+enum _BatchAction { addToNextUp }
+
+/// A contextual bottom bar shown while a track list is in selection mode,
+/// offering the batch equivalents of the per-track actions. Renders nothing
+/// when not selecting. Meant to sit above the now playing bar.
+class TrackSelectionActionBar extends ConsumerWidget {
+  const TrackSelectionActionBar({super.key, required this.scope, required this.parent});
+
+  final String scope;
+  final BaseItemDto parent;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(trackSelectionProvider(scope));
+    if (!state.isSelecting) return const SizedBox.shrink();
+
+    final items = state.selectedItems;
+    final hasSelection = items.isNotEmpty;
+    final isOffline = ref.watch(finampSettingsProvider.isOffline);
+    final isPlaylist = BaseItemDtoType.fromItem(parent) == BaseItemDtoType.playlist;
+    final allFavourite = hasSelection && items.every((e) => e.userData?.isFavorite ?? false);
+
+    final source = QueueItemSource.fromBaseItem(parent);
+    final queueService = GetIt.instance<QueueService>();
+
+    void exitSelection() => ref.read(trackSelectionProvider(scope).notifier).endSelection();
+
+    return Material(
+      color: Theme.of(context).colorScheme.surfaceContainer,
+      elevation: 8.0,
+      child: SafeArea(
+        top: false,
+        child: SizedBox(
+          height: 56.0,
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceAround,
+            children: [
+              IconButton(
+                icon: const Icon(Icons.play_arrow),
+                tooltip: AppLocalizations.of(context)!.playButtonLabel,
+                onPressed: hasSelection
+                    ? () async {
+                        await queueService.startPlayback(
+                          items: items,
+                          source: source,
+                          order: FinampPlaybackOrder.linear,
+                        );
+                        exitSelection();
+                      }
+                    : null,
+              ),
+              IconButton(
+                icon: const Icon(Icons.queue_music),
+                tooltip: AppLocalizations.of(context)!.addToQueue,
+                onPressed: hasSelection
+                    ? () async {
+                        await queueService.addToQueue(PlayableSlice.simple(items, source));
+                        GlobalSnackbar.message(
+                          (scaffold) => AppLocalizations.of(scaffold)!.confirmAddToQueue("track"),
+                          isConfirmation: true,
+                        );
+                        exitSelection();
+                      }
+                    : null,
+              ),
+              IconButton(
+                icon: const Icon(Icons.playlist_play),
+                tooltip: AppLocalizations.of(context)!.playNext,
+                onPressed: hasSelection
+                    ? () async {
+                        await queueService.addNext(PlayableSlice.simple(items, source));
+                        GlobalSnackbar.message(
+                          (scaffold) => AppLocalizations.of(scaffold)!.confirmPlayNext("track"),
+                          isConfirmation: true,
+                        );
+                        exitSelection();
+                      }
+                    : null,
+              ),
+              IconButton(
+                icon: const Icon(Icons.playlist_add),
+                tooltip: AppLocalizations.of(context)!.addToPlaylistTooltip,
+                onPressed: hasSelection && !isOffline
+                    ? () async {
+                        await showPlaylistActionsMenu(
+                          context: context,
+                          items: items,
+                          parentPlaylist: isPlaylist ? parent : null,
+                        );
+                        exitSelection();
+                      }
+                    : null,
+              ),
+              IconButton(
+                icon: Icon(allFavourite ? Icons.favorite : Icons.favorite_border),
+                tooltip: allFavourite
+                    ? AppLocalizations.of(context)!.removeFavorite
+                    : AppLocalizations.of(context)!.addFavorite,
+                onPressed: hasSelection
+                    ? () {
+                        final target = !allFavourite;
+                        for (final item in items) {
+                          ref.read(isFavoriteProvider(item).notifier).updateFavorite(target);
+                        }
+                        exitSelection();
+                      }
+                    : null,
+              ),
+              PopupMenuButton<_BatchAction>(
+                enabled: hasSelection,
+                icon: const Icon(Icons.more_vert),
+                onSelected: (value) async {
+                  switch (value) {
+                    case _BatchAction.addToNextUp:
+                      await queueService.addToNextUp(PlayableSlice.simple(items, source));
+                      GlobalSnackbar.message(
+                        (scaffold) => AppLocalizations.of(scaffold)!.confirmAddToNextUp("track"),
+                        isConfirmation: true,
+                      );
+                      exitSelection();
+                      break;
+                  }
+                },
+                itemBuilder: (context) => [
+                  PopupMenuItem(
+                    value: _BatchAction.addToNextUp,
+                    child: ListTile(
+                      leading: const Icon(Icons.playlist_play),
+                      title: Text(AppLocalizations.of(context)!.addToNextUp),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Stacks the [TrackSelectionActionBar] above [child] (the now playing bar).
+class TrackSelectionAwareBottomBar extends StatelessWidget {
+  const TrackSelectionAwareBottomBar({super.key, required this.scope, required this.parent, required this.child});
+
+  final String scope;
+  final BaseItemDto parent;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        TrackSelectionActionBar(scope: scope, parent: parent),
+        child,
+      ],
+    );
+  }
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3576,5 +3576,18 @@
     "clientCertificateRequired": "Client certificate required",
     "@clientCertificateRequired": {
         "description": "Message shown on the server selection screen when the server requires a client certificate to be provided."
+    },
+    "selectAll": "Select All",
+    "@selectAll": {},
+    "deselectAll": "Deselect All",
+    "@deselectAll": {},
+    "itemsSelected": "{count, plural, =0{No items selected} =1{{count} selected} other{{count} selected}}",
+    "@itemsSelected": {
+        "description": "Title shown in the selection app bar with the number of selected tracks.",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
     }
 }

--- a/lib/screens/album_screen.dart
+++ b/lib/screens/album_screen.dart
@@ -1,4 +1,5 @@
 import 'package:finamp/components/AlbumScreen/album_screen_content.dart';
+import 'package:finamp/components/AlbumScreen/track_selection_bar.dart';
 import 'package:finamp/components/now_playing_bar.dart';
 import 'package:finamp/models/jellyfin_models.dart';
 import 'package:flutter/material.dart';
@@ -22,7 +23,11 @@ class AlbumScreen extends ConsumerWidget {
     return Scaffold(
       extendBody: true,
       body: AlbumScreenContent(parent: resolvedParent, genreFilter: genreFilter),
-      bottomNavigationBar: const NowPlayingBar(),
+      bottomNavigationBar: TrackSelectionAwareBottomBar(
+        scope: resolvedParent.id.toString(),
+        parent: resolvedParent,
+        child: const NowPlayingBar(),
+      ),
     );
   }
 }

--- a/lib/services/track_selection_provider.dart
+++ b/lib/services/track_selection_provider.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/jellyfin_models.dart';
+
+/// Ephemeral, per-surface multi-select state for track lists.
+///
+/// Keyed by a scope string (e.g. the album/playlist id) via [trackSelectionProvider]
+/// so that different track lists don't share a selection. A [TrackListTile] only
+/// participates when it is given a `selectionScope`, so every other use of the
+/// tile (e.g. playback history) keeps its original behaviour.
+@immutable
+class TrackSelectionState {
+  const TrackSelectionState({this.isSelecting = false, this.selected = const {}});
+
+  final bool isSelecting;
+
+  /// Selected tracks, insertion-ordered so batch actions preserve selection order.
+  final Map<BaseItemId, BaseItemDto> selected;
+
+  int get count => selected.length;
+
+  bool get hasSelection => selected.isNotEmpty;
+
+  List<BaseItemDto> get selectedItems => selected.values.toList();
+
+  bool isSelected(BaseItemDto item) => selected.containsKey(item.id);
+
+  /// Whether every item in [candidates] is currently selected (used to drive the
+  /// select-all / deselect-all toggle against the surface's full list).
+  bool allSelected(List<BaseItemDto> candidates) =>
+      candidates.isNotEmpty && candidates.every((e) => selected.containsKey(e.id));
+
+  TrackSelectionState copyWith({bool? isSelecting, Map<BaseItemId, BaseItemDto>? selected}) =>
+      TrackSelectionState(isSelecting: isSelecting ?? this.isSelecting, selected: selected ?? this.selected);
+}
+
+class TrackSelectionNotifier extends FamilyNotifier<TrackSelectionState, String> {
+  @override
+  TrackSelectionState build(String arg) => const TrackSelectionState();
+
+  /// Enters selection mode with [item] selected.
+  void startSelection(BaseItemDto item) {
+    state = state.copyWith(isSelecting: true, selected: {...state.selected, item.id: item});
+  }
+
+  void toggle(BaseItemDto item) {
+    final next = Map<BaseItemId, BaseItemDto>.of(state.selected);
+    if (next.containsKey(item.id)) {
+      next.remove(item.id);
+    } else {
+      next[item.id] = item;
+    }
+    state = state.copyWith(selected: next);
+  }
+
+  /// Adds all of [items] to the selection (used for "select all").
+  void selectAll(List<BaseItemDto> items) {
+    final next = Map<BaseItemId, BaseItemDto>.of(state.selected);
+    for (final item in items) {
+      next[item.id] = item;
+    }
+    state = state.copyWith(selected: next);
+  }
+
+  void deselectAll() => state = state.copyWith(selected: const {});
+
+  void removeFromSelection(Iterable<BaseItemDto> items) {
+    final next = Map<BaseItemId, BaseItemDto>.of(state.selected);
+    for (final item in items) {
+      next.remove(item.id);
+    }
+    state = state.copyWith(selected: next);
+  }
+
+  /// Exits selection mode and clears the selection.
+  void endSelection() => state = const TrackSelectionState();
+}
+
+final trackSelectionProvider = NotifierProvider.family<TrackSelectionNotifier, TrackSelectionState, String>(
+  TrackSelectionNotifier.new,
+);


### PR DESCRIPTION
## What

Adds QQ Music-style multi-select to the album and playlist detail screen. Long-press a track to enter selection mode; tap to toggle. A contextual app bar shows the selected count with select-all, and a bottom action bar performs the batch equivalents of the per-track actions:

- Play, add to queue, play next, add to next up
- Add to playlist (and remove from playlist inside playlists)
- Add / remove favourite

## How

- Selection state is a screen-scoped Riverpod `NotifierProvider.family` (`trackSelectionProvider`, keyed by the album/playlist id). It's a plain manual provider, so no code generation is required.
- `TrackListTile` gains an opt-in `selectionScope` param. When set, tapping toggles selection and long-pressing enters selection mode (instead of opening the track menu), a selection indicator is drawn, and swipe is disabled. When null — every other use of the tile, e.g. playback history — the tile is unchanged.
- Batch queue actions build a `PlayableSlice.simple(selectedTracks, source)` and go through `QueueService`. Favourites reuse `isFavoriteProvider(...).updateFavorite(...)`. Add / remove to playlist reuses `showPlaylistActionsMenu(items:, parentPlaylist:)`.
- New English strings (`selectAll`, `deselectAll`, `itemsSelected`) are added to `app_en.arb`; everything else reuses existing keys.

## Notes

- Scoped to the album/playlist detail screen for a focused first PR. The shared `TrackListTile` change makes extending this to the Songs tab a small follow-up.
- Download / delete batch actions are intentionally left for a follow-up.
- Passes `flutter analyze` with no new errors.
