### PR TITLE
Add a "Now Playing" link to the main menu

### DIFF
--- a/lib/menus/music_screen_drawer.dart
+++ b/lib/menus/music_screen_drawer.dart
@@ -12,6 +12,7 @@ import 'package:finamp/models/finamp_models.dart';
 import 'package:finamp/screens/downloads_screen.dart';
 import 'package:finamp/screens/logs_screen.dart';
 import 'package:finamp/screens/playback_history_screen.dart';
+import 'package:finamp/screens/player_screen.dart';
 import 'package:finamp/screens/queue_restore_screen.dart';
 import 'package:finamp/screens/settings_screen.dart';
 import 'package:finamp/services/downloads_service.dart';
@@ -284,6 +285,11 @@ class MusicScreenDrawer extends ConsumerWidget {
                         leading: const Padding(padding: EdgeInsets.only(right: 16), child: Icon(Icons.auto_delete)),
                         title: Text(AppLocalizations.of(context)!.queuesScreen),
                         onTap: () => Navigator.of(context).pushNamed(QueueRestoreScreen.routeName),
+                      ),
+                      ListTile(
+                        leading: const Padding(padding: EdgeInsets.only(right: 16), child: Icon(TablerIcons.player_play)),
+                        title: Text(AppLocalizations.of(context)!.playerScreen),
+                        onTap: () => Navigator.of(context).pushNamed(PlayerScreen.routeName),
                       ),
                       const Divider(),
                     ]),


### PR DESCRIPTION
<!-- Just a reminder that text in these brackets is not visible in the rendered output.
You also do **not** need to use this template. You can remove and modify anything however you like!
Its just a suggestion :)
-->

## Changes
<!-- Please describe what this Pull request adds or changes. Possibly with images -->
Currently, non-touchscreen devices like dumbphones can't actually see/affect the currently playing track (at least, not through any combination of direction button presses that I can figure out). This just adds a link to the player screen to the main menu, nothing more :)

<img width="108" height="240" alt="Screenshot_1784493951" src="https://github.com/user-attachments/assets/09b4b55b-77f8-45be-9aed-75717a876b63" />

Happy to make any changes needed!