### PR TITLE
Add split screen toggle for widescreen devices

### DIFF
--- a/lib/components/PlayerScreen/player_screen_appbar_title.dart
+++ b/lib/components/PlayerScreen/player_screen_appbar_title.dart
@@ -1,23 +1,28 @@
 import 'package:balanced_text/balanced_text.dart';
 import 'package:finamp/components/PlayerScreen/queue_source_helper.dart';
+import 'package:finamp/components/global_snackbar.dart';
 import 'package:finamp/l10n/app_localizations.dart';
 import 'package:finamp/models/finamp_models.dart';
+import 'package:finamp/screens/player_screen.dart';
+import 'package:finamp/services/finamp_settings_helper.dart';
 import 'package:finamp/services/queue_service.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:get_it/get_it.dart';
+import 'package:material_symbols_icons/symbols.dart';
 
 import '../../extensions/localizations.dart';
 
-class PlayerScreenAppBarTitle extends StatefulWidget {
+class PlayerScreenAppBarTitle extends ConsumerStatefulWidget {
   const PlayerScreenAppBarTitle({super.key, required this.maxLines});
 
   final int maxLines;
 
   @override
-  State<PlayerScreenAppBarTitle> createState() => _PlayerScreenAppBarTitleState();
+  ConsumerState<PlayerScreenAppBarTitle> createState() => _PlayerScreenAppBarTitleState();
 }
 
-class _PlayerScreenAppBarTitleState extends State<PlayerScreenAppBarTitle> {
+class _PlayerScreenAppBarTitleState extends ConsumerState<PlayerScreenAppBarTitle> {
   final QueueService _queueService = GetIt.instance<QueueService>();
 
   @override
@@ -25,6 +30,8 @@ class _PlayerScreenAppBarTitleState extends State<PlayerScreenAppBarTitle> {
     final currentTrackStream = _queueService.getCurrentTrackStream();
 
     final screenWidth = MediaQuery.widthOf(context);
+
+    final splitScreenState = ref.watch(finampSettingsProvider.allowSplitScreen);
 
     return StreamBuilder<FinampQueueItem?>(
       stream: currentTrackStream,
@@ -35,39 +42,59 @@ class _PlayerScreenAppBarTitleState extends State<PlayerScreenAppBarTitle> {
         }
         final queueItem = snapshot.data!;
 
-        return ConstrainedBox(
-          constraints: BoxConstraints(maxWidth: screenWidth * 0.62),
-          child: GestureDetector(
-            onTap: () => navigateToSource(context, queueItem.source),
-            child: Column(
-              children: [
-                Text(
-                  AppLocalizations.of(context)!.playingFromType(queueItem.source.type.name),
-                  style: TextStyle(
-                    fontSize: 12,
-                    fontWeight: FontWeight.w300,
-                    color: Theme.brightnessOf(context) == Brightness.dark
-                        ? Colors.white.withValues(alpha: 0.7)
-                        : Colors.black.withValues(alpha: 0.8),
-                  ),
-                  overflow: TextOverflow.ellipsis,
-                  textAlign: TextAlign.center,
+        return Stack(
+          alignment: Alignment.center,
+          children: [
+            ConstrainedBox(
+              constraints: BoxConstraints(maxWidth: screenWidth * 0.62),
+              child: GestureDetector(
+                onTap: () => navigateToSource(context, queueItem.source),
+                child: Column(
+                  children: [
+                    Text(
+                      AppLocalizations.of(context)!.playingFromType(queueItem.source.type.name),
+                      style: TextStyle(
+                        fontSize: 12,
+                        fontWeight: FontWeight.w300,
+                        color: Theme.brightnessOf(context) == Brightness.dark
+                            ? Colors.white.withValues(alpha: 0.7)
+                            : Colors.black.withValues(alpha: 0.8),
+                      ),
+                      overflow: TextOverflow.ellipsis,
+                      textAlign: TextAlign.center,
+                    ),
+                    const Padding(padding: EdgeInsets.symmetric(vertical: 1)),
+                    BalancedText(
+                      queueItem.source.name.getLocalized(context.l10n),
+                      style: TextStyle(
+                        fontSize: 14,
+                        color: Theme.brightnessOf(context) == Brightness.dark
+                            ? Colors.white
+                            : Colors.black.withValues(alpha: 0.9),
+                      ),
+                      maxLines: widget.maxLines,
+                      textAlign: TextAlign.center,
+                    ),
+                  ],
                 ),
-                const Padding(padding: EdgeInsets.symmetric(vertical: 1)),
-                BalancedText(
-                  queueItem.source.name.getLocalized(context.l10n),
-                  style: TextStyle(
-                    fontSize: 14,
-                    color: Theme.brightnessOf(context) == Brightness.dark
-                        ? Colors.white
-                        : Colors.black.withValues(alpha: 0.9),
-                  ),
-                  maxLines: widget.maxLines,
-                  textAlign: TextAlign.center,
-                ),
-              ],
+              ),
             ),
-          ),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: IconButton(
+                onPressed: () async {
+                  if (splitScreenState) {
+                    GlobalSnackbar.navigatorState!.pushNamed(PlayerScreen.routeName);
+                    await Future.delayed(Duration(milliseconds: 100));
+                    FinampSetters.setAllowSplitScreen(false);
+                  } else {
+                    FinampSetters.setAllowSplitScreen(true);
+                  }
+                },
+                icon: Icon(splitScreenState ? Symbols.right_panel_open : Symbols.left_panel_open),
+              ),
+            ),
+          ],
         );
       },
     );

--- a/lib/components/PlayerScreen/player_screen_appbar_title.dart
+++ b/lib/components/PlayerScreen/player_screen_appbar_title.dart
@@ -1,4 +1,5 @@
 import 'package:balanced_text/balanced_text.dart';
+import 'package:finamp/components/PlayerScreen/player_split_screen_scaffold.dart';
 import 'package:finamp/components/PlayerScreen/queue_source_helper.dart';
 import 'package:finamp/components/global_snackbar.dart';
 import 'package:finamp/l10n/app_localizations.dart';
@@ -6,6 +7,7 @@ import 'package:finamp/models/finamp_models.dart';
 import 'package:finamp/screens/player_screen.dart';
 import 'package:finamp/services/finamp_settings_helper.dart';
 import 'package:finamp/services/queue_service.dart';
+import 'package:finamp/services/split_screen_transition_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:get_it/get_it.dart';
@@ -30,6 +32,9 @@ class _PlayerScreenAppBarTitleState extends ConsumerState<PlayerScreenAppBarTitl
     final currentTrackStream = _queueService.getCurrentTrackStream();
 
     final screenWidth = MediaQuery.widthOf(context);
+    final view = View.of(context);
+    final fullScreenSize = view.physicalSize / view.devicePixelRatio;
+    final allowSplitScreen = SplitScreenHelper.screenSizeAllowsSplitScreen(fullScreenSize);
 
     final splitScreenState = ref.watch(finampSettingsProvider.allowSplitScreen);
 
@@ -79,21 +84,29 @@ class _PlayerScreenAppBarTitleState extends ConsumerState<PlayerScreenAppBarTitl
                 ),
               ),
             ),
-            Align(
-              alignment: Alignment.centerLeft,
-              child: IconButton(
-                onPressed: () async {
-                  if (splitScreenState) {
-                    GlobalSnackbar.navigatorState!.pushNamed(PlayerScreen.routeName);
-                    await Future.delayed(Duration(milliseconds: 100));
-                    FinampSetters.setAllowSplitScreen(false);
-                  } else {
-                    FinampSetters.setAllowSplitScreen(true);
-                  }
-                },
-                icon: Icon(splitScreenState ? Symbols.right_panel_open : Symbols.left_panel_open),
+            if (allowSplitScreen)
+              Align(
+                alignment: Alignment.centerLeft,
+                child: IconButton(
+                  onPressed: () async {
+                    final splitScreenTransitionNotifier = ref.read(splitScreenTransitionProvider.notifier);
+                    if (splitScreenState) {
+                      await splitScreenTransitionNotifier.runTransitionActions(() async {
+                        FinampSetters.setAllowSplitScreen(false);
+                        await Future.delayed(Duration(milliseconds: 100));
+                        await GlobalSnackbar.navigatorState!.pushNamed(PlayerScreen.routeName);
+                      });
+                    } else {
+                      await splitScreenTransitionNotifier.runTransitionActions(() async {
+                        GlobalSnackbar.navigatorState?.pop();
+                        await Future.delayed(Duration(milliseconds: 100));
+                        FinampSetters.setAllowSplitScreen(true);
+                      });
+                    }
+                  },
+                  icon: Icon(splitScreenState ? Symbols.right_panel_open : Symbols.left_panel_open),
+                ),
               ),
-            ),
           ],
         );
       },

--- a/lib/components/PlayerScreen/player_screen_appbar_title.dart
+++ b/lib/components/PlayerScreen/player_screen_appbar_title.dart
@@ -3,6 +3,7 @@ import 'package:finamp/components/PlayerScreen/player_split_screen_scaffold.dart
 import 'package:finamp/components/PlayerScreen/queue_source_helper.dart';
 import 'package:finamp/components/global_snackbar.dart';
 import 'package:finamp/l10n/app_localizations.dart';
+import 'package:finamp/menus/components/icon_button_with_semantics.dart';
 import 'package:finamp/models/finamp_models.dart';
 import 'package:finamp/screens/player_screen.dart';
 import 'package:finamp/services/finamp_settings_helper.dart';
@@ -87,7 +88,10 @@ class _PlayerScreenAppBarTitleState extends ConsumerState<PlayerScreenAppBarTitl
             if (allowSplitScreen)
               Align(
                 alignment: Alignment.centerLeft,
-                child: IconButton(
+                child: IconButtonWithSemantics(
+                  label: splitScreenState
+                      ? AppLocalizations.of(context)!.switchToFullscreenViewTooltip
+                      : AppLocalizations.of(context)!.switchToSplitScreenViewTooltip,
                   onPressed: () async {
                     final splitScreenTransitionNotifier = ref.read(splitScreenTransitionProvider.notifier);
                     if (splitScreenState) {
@@ -104,7 +108,7 @@ class _PlayerScreenAppBarTitleState extends ConsumerState<PlayerScreenAppBarTitl
                       });
                     }
                   },
-                  icon: Icon(splitScreenState ? Symbols.right_panel_open : Symbols.left_panel_open),
+                  icon: splitScreenState ? Symbols.right_panel_open : Symbols.left_panel_open,
                 ),
               ),
           ],

--- a/lib/components/PlayerScreen/player_screen_appbar_title.dart
+++ b/lib/components/PlayerScreen/player_screen_appbar_title.dart
@@ -47,8 +47,8 @@ class _PlayerScreenAppBarTitleState extends State<PlayerScreenAppBarTitle> {
                     fontSize: 12,
                     fontWeight: FontWeight.w300,
                     color: Theme.brightnessOf(context) == Brightness.dark
-                        ? Colors.white.withOpacity(0.7)
-                        : Colors.black.withOpacity(0.8),
+                        ? Colors.white.withValues(alpha: 0.7)
+                        : Colors.black.withValues(alpha: 0.8),
                   ),
                   overflow: TextOverflow.ellipsis,
                   textAlign: TextAlign.center,
@@ -60,7 +60,7 @@ class _PlayerScreenAppBarTitleState extends State<PlayerScreenAppBarTitle> {
                     fontSize: 14,
                     color: Theme.brightnessOf(context) == Brightness.dark
                         ? Colors.white
-                        : Colors.black.withOpacity(0.9),
+                        : Colors.black.withValues(alpha: 0.9),
                   ),
                   maxLines: widget.maxLines,
                   textAlign: TextAlign.center,

--- a/lib/components/PlayerScreen/player_split_screen_scaffold.dart
+++ b/lib/components/PlayerScreen/player_split_screen_scaffold.dart
@@ -13,30 +13,59 @@ import '../../models/finamp_models.dart';
 import '../../screens/player_screen.dart';
 import '../../services/queue_service.dart';
 
+const double _kMinScreenWidth = 800;
+const double _kMinScreenHeight = 500;
+const double _kMinPlayerWidth = 275;
+const double _kMinMenuWidth = 400;
+const double _kResizingAreaSize = 20;
+
+class SplitScreenHelper {
+  static bool screenSizeAllowsSplitScreen(Size size) {
+    return size.width >= _kMinScreenWidth && size.height >= _kMinScreenHeight;
+  }
+
+  static bool constraintsAllowsSplitScreen(BoxConstraints constraints) {
+    return screenSizeAllowsSplitScreen(Size(constraints.maxWidth, constraints.maxHeight));
+  }
+
+  static bool get usingPlayerSplitScreen => _inSplitScreen;
+
+  /// Min weighted size of the main screen (ie, not the player)
+  static double get mainScreenMinWeight => _splitScreenController.limits[0]!.min!;
+
+  /// Max weighted size of the main screen (ie, not the player)
+  static double get mainScreenMaxWeight => _splitScreenController.limits[0]!.max!;
+}
+
+/// Takes the actual width in double and converts into a weighted size by width
+double _getWeightedValue({required double pixelSize, required BoxConstraints constraints}) {
+  return pixelSize / constraints.maxWidth;
+}
+
 bool _inSplitScreen = false;
-
-bool get usingPlayerSplitScreen => _inSplitScreen;
-
 double _weight = 0.0;
-
-SplitViewController _controller = SplitViewController();
-
 Timer? _timer;
 double? _playerWidth;
+SplitViewController _splitScreenController = SplitViewController();
 
 Widget buildPlayerSplitScreenScaffold(BuildContext context, Widget? widget) {
   return LayoutBuilder(
     builder: (context, constraints) {
       // Only use split screen if wide enough to easily show both views and tall enough
       // that a landscape full-screen player is not preferred instead
-      if (constraints.maxWidth < 800 || constraints.maxHeight < 500) {
+      if (!SplitScreenHelper.constraintsAllowsSplitScreen(constraints)) {
         _inSplitScreen = false;
         return widget!;
       }
       final queueService = GetIt.instance<QueueService>();
-      // Minimum player width is 275.  Minimum menu width is 400.
-      _controller = SplitViewController(
-        limits: [WeightLimit(min: 400 / constraints.maxWidth, max: 1.0 - (275 / constraints.maxWidth))],
+
+      _splitScreenController = SplitViewController(
+        limits: [
+          WeightLimit(
+            min: _getWeightedValue(pixelSize: _kMinMenuWidth, constraints: constraints),
+            max: 1.0 - (_getWeightedValue(pixelSize: _kMinPlayerWidth, constraints: constraints)),
+          ),
+        ],
       );
 
       return Consumer(
@@ -47,84 +76,30 @@ Widget buildPlayerSplitScreenScaffold(BuildContext context, Widget? widget) {
             stream: queueService.getQueueStream(),
             initialData: queueService.getQueue(),
             builder: (context, snapshot) {
-              if (snapshot.hasData &&
+              final shouldShowSplitScreen =
+                  (snapshot.hasData &&
                   (snapshot.data!.saveState == SavedQueueState.loading ||
                       snapshot.data!.saveState == SavedQueueState.failed ||
                       snapshot.data!.currentTrack != null) &&
-                  allowSplitScreen) {
-                _inSplitScreen = true;
-                SplitScreenNavigatorObserver.queuePop();
-                var size = MediaQuery.sizeOf(context);
-                var padding = MediaQuery.paddingOf(context);
-                // When resizing window, update weights to keep player width consistent
-                _weight =
-                    (1.0 -
-                            (_playerWidth ?? FinampSettingsHelper.finampSettings.splitScreenPlayerWidth) /
-                                constraints.maxWidth)
-                        .clamp(_controller.limits[0]!.min!, _controller.limits[0]!.max!);
-                _controller.weights = [_weight];
-                return SplitView(
-                  key: const ValueKey("PlayerSplitView"),
-                  resizingAreaSize: 20,
-                  gripSize: 0,
-                  viewMode: SplitViewMode.Horizontal,
-                  controller: _controller,
-                  onWeightChanged: (weights) {
-                    if (weights[0]! == _weight) {
-                      // Weight is changing due to window resize, not drag action.
-                      // Do not update setting.
-                      return;
-                    }
-                    _playerWidth = (1.0 - weights[0]!) * constraints.maxWidth;
-                    _timer?.cancel();
-                    // Do not spam settings updates while resizing
-                    _timer = Timer(const Duration(seconds: 1), () {
-                      FinampSetters.setSplitScreenPlayerWidth(_playerWidth!);
-                    });
-                  },
-                  children: [
-                    ListenableBuilder(
-                      listenable: _controller,
-                      builder: (context, child) => MediaQuery(
-                        data: MediaQuery.of(context).copyWith(
-                          size: Size(size.width * (_controller.weights[0] ?? 1.0), size.height),
-                          padding: padding.copyWith(right: padding.right + 10),
-                        ),
-                        child: child!,
-                      ),
-                      child: widget,
-                    ),
-                    ListenableBuilder(
-                      listenable: _controller,
-                      builder: (context, child) {
-                        return MediaQuery(
-                          data: MediaQuery.of(
-                            context,
-                          ).copyWith(size: Size(size.width * (1.0 - (_controller.weights[0] ?? 1.0)), size.height)),
-                          child: child!,
-                        );
-                      },
-                      child: HeroControllerScope(
-                        controller: HeroController(),
-                        child: ScaffoldMessenger(
-                          child: Navigator(
-                            pages: const [MaterialPage(child: PlayerScreen())],
-                            onPopPage: (_, __) => false,
-                            onGenerateRoute: (x) {
-                              GlobalSnackbar.navigatorState!.pushNamed(x.name!, arguments: x.arguments);
-                              return EmptyRoute();
-                            },
-                            observers: [KeepScreenOnObserver()],
-                          ),
-                        ),
-                      ),
-                    ),
-                  ],
-                );
-              } else {
+                  allowSplitScreen);
+
+              if (!shouldShowSplitScreen) {
                 _inSplitScreen = false;
                 return widget!;
               }
+
+              _inSplitScreen = true;
+              SplitScreenNavigatorObserver.queuePop();
+
+              // When resizing window, update weights to keep player width consistent
+              final currentPlayerWidth = _playerWidth ?? FinampSettingsHelper.finampSettings.splitScreenPlayerWidth;
+              _weight = (1.0 - currentPlayerWidth / constraints.maxWidth).clamp(
+                SplitScreenHelper.mainScreenMinWeight,
+                SplitScreenHelper.mainScreenMaxWeight,
+              );
+              _splitScreenController.weights = [_weight];
+
+              return _SplitScreen(constraints: constraints, widget: widget);
             },
           );
         },
@@ -133,7 +108,110 @@ Widget buildPlayerSplitScreenScaffold(BuildContext context, Widget? widget) {
   );
 }
 
-class EmptyRoute extends Route {
+class _SplitScreen extends StatelessWidget {
+  const _SplitScreen({super.key, required this.constraints, required this.widget});
+
+  final BoxConstraints constraints;
+  final Widget? widget;
+
+  @override
+  Widget build(BuildContext context) {
+    var size = MediaQuery.sizeOf(context);
+
+    return SplitView(
+      key: const ValueKey("PlayerSplitView"),
+      resizingAreaSize: _kResizingAreaSize,
+      gripSize: 0,
+      viewMode: SplitViewMode.Horizontal,
+      controller: _splitScreenController,
+      onWeightChanged: (weights) {
+        final weight = weights[0]!;
+        if (weight == _weight) {
+          // Weight is changing due to window resize, not drag action.
+          // Do not update setting.
+          return;
+        }
+        _playerWidth = (1.0 - weight) * constraints.maxWidth;
+        _timer?.cancel();
+        // Do not spam settings updates while resizing
+        _timer = Timer(const Duration(seconds: 1), () {
+          FinampSetters.setSplitScreenPlayerWidth(_playerWidth!);
+        });
+      },
+      children: [
+        _SplitMainPanel(size: size, widget: widget),
+        _SplitPlayerPanel(size: size),
+      ],
+    );
+  }
+}
+
+class _SplitMainPanel extends StatelessWidget {
+  const _SplitMainPanel({super.key, required this.size, required this.widget});
+
+  final Size size;
+  final Widget? widget;
+
+  @override
+  Widget build(BuildContext context) {
+    var padding = MediaQuery.paddingOf(context);
+
+    return ListenableBuilder(
+      listenable: _splitScreenController,
+      builder: (context, child) {
+        final weight = (_splitScreenController.weights[0] ?? 1.0);
+
+        return MediaQuery(
+          data: MediaQuery.of(context).copyWith(
+            size: Size((size.width * weight).clamp(0.0, double.infinity), size.height),
+            padding: padding.copyWith(right: padding.right + 10),
+          ),
+          child: child!,
+        );
+      },
+      child: widget,
+    );
+  }
+}
+
+class _SplitPlayerPanel extends StatelessWidget {
+  const _SplitPlayerPanel({super.key, required this.size});
+
+  final Size size;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: _splitScreenController,
+      builder: (context, child) {
+        final weight = 1.0 - (_splitScreenController.weights[0] ?? 1.0);
+
+        return MediaQuery(
+          data: MediaQuery.of(
+            context,
+          ).copyWith(size: Size((size.width * weight).clamp(0.0, double.infinity), size.height)),
+          child: child!,
+        );
+      },
+      child: HeroControllerScope(
+        controller: HeroController(),
+        child: ScaffoldMessenger(
+          child: Navigator(
+            pages: const [MaterialPage(child: PlayerScreen())],
+            onDidRemovePage: (page) {},
+            onGenerateRoute: (x) {
+              GlobalSnackbar.navigatorState!.pushNamed(x.name!, arguments: x.arguments);
+              return EmptyRoute();
+            },
+            observers: [KeepScreenOnObserver()],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class EmptyRoute extends Route<dynamic> {
   @override
   List<OverlayEntry> get overlayEntries => [OverlayEntry(builder: (_) => const SizedBox.shrink())];
   @override
@@ -146,7 +224,7 @@ class EmptyRoute extends Route {
 class SplitScreenNavigatorObserver extends NavigatorObserver {
   @override
   void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
-    if (usingPlayerSplitScreen && previousRoute != null && !shouldNotPop(previousRoute)) {
+    if (_inSplitScreen && previousRoute != null && !shouldNotPop(previousRoute)) {
       queuePop();
     }
   }
@@ -160,7 +238,7 @@ class SplitScreenNavigatorObserver extends NavigatorObserver {
     });
   }
 
-  static bool shouldNotPop(Route route) {
+  static bool shouldNotPop(Route<dynamic> route) {
     return !_playerCheck(route) && !_lyricsCheck(route);
   }
 }

--- a/lib/components/now_playing_bar.dart
+++ b/lib/components/now_playing_bar.dart
@@ -509,13 +509,15 @@ class NowPlayingBar extends ConsumerWidget {
                 builder: (context, snapshot) {
                   if (snapshot.hasData &&
                       snapshot.data!.saveState == SavedQueueState.loading &&
-                      !usingPlayerSplitScreen) {
+                      !SplitScreenHelper.usingPlayerSplitScreen) {
                     return buildLoadingQueueBar(ref, null);
                   } else if (snapshot.hasData &&
                       snapshot.data!.saveState == SavedQueueState.failed &&
-                      !usingPlayerSplitScreen) {
+                      !SplitScreenHelper.usingPlayerSplitScreen) {
                     return buildLoadingQueueBar(ref, queueService.retryQueueLoad);
-                  } else if (snapshot.hasData && snapshot.data!.currentTrack != null && !usingPlayerSplitScreen) {
+                  } else if (snapshot.hasData &&
+                      snapshot.data!.currentTrack != null &&
+                      !SplitScreenHelper.usingPlayerSplitScreen) {
                     return buildNowPlayingBar(ref, snapshot.data!.currentTrack!);
                   } else {
                     return const SizedBox.shrink();

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1686,6 +1686,14 @@
     },
     "allowSplitScreenTitle": "Allow SplitScreen Mode",
     "allowSplitScreenSubtitle": "The player will be displayed alongside other views on wider displays.",
+    "switchToFullscreenViewTooltip": "Switch to Full Screen View",
+    "@switchToFullscreenViewTooltip": {
+        "description": "Tooltip for the button that switches from split screen to full screen player view"
+    },
+    "switchToSplitScreenViewTooltip": "Switch to Split Screen View",
+    "@switchToSplitScreenViewTooltip": {
+        "description": "Tooltip for the button that switches from full screen to split screen player view"
+    },
     "enableVibration": "Enable vibration",
     "enableVibrationSubtitle": "Whether to enable vibration.",
     "oneLineMarqueeTextButton": "Auto-scroll Long Titles",

--- a/lib/screens/music_screen.dart
+++ b/lib/screens/music_screen.dart
@@ -5,6 +5,7 @@ import 'package:finamp/components/HomeScreen/home_screen_content.dart';
 import 'package:finamp/components/MusicScreen/artist_type_selection_row.dart';
 import 'package:finamp/components/MusicScreen/music_screen_tab_view.dart';
 import 'package:finamp/components/MusicScreen/sort_and_filter_row.dart';
+import 'package:finamp/components/PlayerScreen/player_screen_appbar_title.dart';
 import 'package:finamp/components/global_snackbar.dart';
 import 'package:finamp/components/now_playing_bar.dart';
 import 'package:finamp/l10n/app_localizations.dart';
@@ -17,6 +18,7 @@ import 'package:finamp/services/finamp_user_helper.dart';
 import 'package:finamp/services/item_by_id_provider.dart';
 import 'package:finamp/services/jellyfin_api_helper.dart';
 import 'package:finamp/services/music_providers.dart';
+import 'package:finamp/services/split_screen_transition_provider.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -256,7 +258,9 @@ class _MusicScreenState extends ConsumerState<MusicScreen> with TickerProviderSt
           textEditingController: textEditingController,
           isSearching: isSearching,
         ),
-        bottomNavigationBar: NowPlayingBar(),
+        // Temporarily block the now playing bar during a split screen transition
+        bottomNavigationBar: ref.watch(splitScreenTransitionProvider) ? null : NowPlayingBar(),
+        // bottomNavigationBar: NowPlayingBar(),
         drawerEnableOpenDragGesture: widget.showHeader,
         drawer: widget.showHeader ? const MusicScreenDrawer() : null,
         floatingActionButton: Padding(

--- a/lib/screens/player_screen.dart
+++ b/lib/screens/player_screen.dart
@@ -199,7 +199,9 @@ class _PlayerScreenContent extends ConsumerWidget {
             centerTitle: true,
             toolbarHeight: toolbarHeight,
             title: PlayerScreenAppBarTitle(maxLines: maxToolbarLines),
-            leading: usingPlayerSplitScreen ? null : FinampAppBarBackButton(dismissDirection: AxisDirection.down),
+            leading: SplitScreenHelper.usingPlayerSplitScreen
+                ? null
+                : FinampAppBarBackButton(dismissDirection: AxisDirection.down),
             actions: [],
           ),
           // Required for sleep timer input

--- a/lib/services/split_screen_transition_provider.dart
+++ b/lib/services/split_screen_transition_provider.dart
@@ -1,0 +1,21 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'split_screen_transition_provider.g.dart';
+
+@riverpod
+class SplitScreenTransition extends _$SplitScreenTransition {
+  @override
+  bool build() {
+    return false;
+  }
+
+  void setTransitioning(bool isTransitioning) {
+    state = isTransitioning;
+  }
+
+  Future<void> runTransitionActions(Future<void> Function() transitionActions) async {
+    setTransitioning(true);
+    await transitionActions();
+    setTransitioning(false);
+  }
+}

--- a/lib/services/split_screen_transition_provider.g.dart
+++ b/lib/services/split_screen_transition_provider.g.dart
@@ -1,0 +1,32 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: deprecated_member_use_from_same_package, strict_raw_type
+
+// dart format off
+
+
+part of 'split_screen_transition_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$splitScreenTransitionHash() =>
+    r'024f24c9fe7a71f7048b4011d77c9518b36a9866';
+
+/// See also [SplitScreenTransition].
+@ProviderFor(SplitScreenTransition)
+final splitScreenTransitionProvider =
+    AutoDisposeNotifierProvider<SplitScreenTransition, bool>.internal(
+      SplitScreenTransition.new,
+      name: r'splitScreenTransitionProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$splitScreenTransitionHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$SplitScreenTransition = AutoDisposeNotifier<bool>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1140,6 +1140,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.13.0"
+  material_symbols_icons:
+    dependency: "direct main"
+    description:
+      name: material_symbols_icons
+      sha256: "49c532dd0b74544e9d8d93ec0f821d52ec532e7c9263c889ebe71b1be4f34ba7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2951.0"
   media_kit:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -158,6 +158,7 @@ dependencies:
       url: https://github.com/oguzhnatly/flutter_carplay.git
       ref: 017ce2e
   diacritic: ^0.1.6
+  material_symbols_icons: ^4.2951.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
<!-- Just a reminder that text in these brackets is not visible in the rendered output.
You also do **not** need to use this template. You can remove and modify anything however you like!
Its just a suggestion :)
-->

## Changes
- Added split screen toggle IconButton to AppBar for widescreen devices
- Refactored player_split_screen_scaffold.dart a bit for better separation and readability
- Added a SplitScreenHelper to more easily access split screen values
- Added the https://pub.dev/packages/material_symbols_icons package for "Spotify accurate" icons on the IconButton.  
(Can definitely remove if we want to avoid adding more packages to the yaml, just wanted it to be as accurate to the request as possible)

<!-- Did you add UI text? 
No? Just check or remove the box
Yes? Make sure you replace hardcoded strings with translations -->
- [x] Translations

<!-- Did you add settings to the settings screen?
No? Just check or remove the box 
Yes? Make sure they are resettable using the button on the respective page! (see finamp_settings_helper.dart)-->
- [x] Reset Settings
(Settings toggles were not directly affected but settings are being manipulated, so it seems relevant)

## Related Issues
<!-- List relevant issues to this PR using a format like this
-->
- addresses feature request #1626 

Notes:
This isn't the _best_ solution for this issue but I explored several other avenues with little success
- Forcing the split screen view to fully expand is the better / cleaner solution, but when the main screen is disposed of, the rebuild of the screen duplicates some widgets.  Couldn't figure out the root cause of this, and it would appear to not like being "squished"
- Pushing a new PlayerScreen widget to the top of the stack would smoothly show the screen as full screen, but there are some issues with .pop() in that pushed PlayerScreen() that could get messy.  This might be a decent long term solution if the above root cause isn't identified.
- The notification bar is blocked very briefly to prevent some of the jank of changing split screen settings.  While this could potentially cause the now player bar to not show, I don't see how without access to the split screen button, and would be fixed on app restart.
- Ended up going with a slightly modified version of what @flloschy suggested, thank you for that
