### PR TITLE
Remove download location truncation

### DIFF
--- a/lib/components/DownloadLocationSettingsScreen/download_location_list_tile.dart
+++ b/lib/components/DownloadLocationSettingsScreen/download_location_list_tile.dart
@@ -19,7 +19,7 @@ class DownloadLocationListTile extends ConsumerWidget {
 
     return ListTile(
       title: Text(downloadLocation.name),
-      subtitle: Text(downloadLocation.currentPath, maxLines: 1, overflow: TextOverflow.ellipsis),
+      subtitle: Text(downloadLocation.currentPath),
       trailing: Row(
         mainAxisSize: MainAxisSize.min,
         children: [


### PR DESCRIPTION
<!-- Just a reminder that text in these brackets is not visible in the rendered output.
You also do **not** need to use this template. You can remove and modify anything however you like!
Its just a suggestion :)
-->

## Changes
<!-- Please describe what this Pull request adds or changes. Possibly with images -->
This is a simple PR to remove the truncation for download location.  Previously, the location was cut off with ellipses, and for 9:16 devices (ie, phones) it unclear what the full path of the downloads location was.

Previous truncation
<img width="270" height="600" alt="Screenshot_1785775731" src="https://github.com/user-attachments/assets/945a9b0c-cbe8-401c-b06c-6ff5c009c964" />


Removed truncation
<img width="270" height="600" alt="Screenshot_1785771494" src="https://github.com/user-attachments/assets/2164e71c-065b-4bc4-a7e3-cc4979cc929b" />



## Related Issues
<!-- List relevant issues to this PR using a format like this
- closes #1708 
-->
