### PR TITLE
Add frosted glass to the now playing bar and drawer

### DIFF
--- a/lib/components/now_playing_bar.dart
+++ b/lib/components/now_playing_bar.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 import 'dart:math';
+import 'dart:ui' show ImageFilter;
 
 import 'package:audio_service/audio_service.dart';
 import 'package:finamp/color_schemes.g.dart';
@@ -176,11 +177,30 @@ class NowPlayingBar extends ConsumerWidget {
 
     final elapsedPartBackgroundColor = getProgressForegroundColor(ref);
     final remainingPartBackgroundColor = getProgressBackgroundColor(ref);
-    final averageBackgroundColor = Color.alphaBlend(
-      elapsedPartBackgroundColor.withOpacity(0.5),
-      remainingPartBackgroundColor,
-    );
-    Color primaryTextColor = AtContrast.getContrastiveTintedTextColor(onBackground: averageBackgroundColor);
+    final colorScheme = ColorScheme.of(context);
+    final isDark = Theme.brightnessOf(context) == Brightness.dark;
+    // Over the vivid blurred artwork we use deterministic light/dark text plus a
+    // soft shadow, so it stays legible no matter how bright or dark (or pure
+    // black) the current cover happens to be.
+    final Color primaryTextColor = isDark ? Colors.white : Colors.black;
+    // In dark mode a soft black halo lifts white text off bright art. In light
+    // mode the black text already has enough contrast, so we keep only a very
+    // tight, faint halo — a wide blur here just makes the text look fuzzy.
+    final List<Shadow> textShadows = [
+      Shadow(color: Colors.black.withOpacity(isDark ? 0.45 : 0.12), blurRadius: isDark ? 6.0 : 1.5),
+    ];
+    // A theme-aware glass base sits *under* the blurred art so the panel always
+    // reads as frosted glass in both modes — and stays a distinct, lit panel
+    // even over an all-black cover, rather than melting into the page. Kept
+    // fairly dense so busy content scrolling *behind* the bar doesn't bleed
+    // through and fight the bar's own text.
+    final Color glassBaseColor = isDark
+        ? Color.alphaBlend(Colors.black.withOpacity(0.72), colorScheme.surface.withOpacity(0.5))
+        : Colors.white.withOpacity(0.74);
+    // The art is glazed at partial opacity so its colour shines through without
+    // dictating luminance; a gentle scrim then settles the text contrast.
+    final double artGlazeOpacity = isDark ? 0.62 : 0.5;
+    final Color glassScrimColor = (isDark ? Colors.black : Colors.white).withOpacity(0.12);
 
     final showPauseButton = ref.watch(
       mediaStateProvider.select((x) => x.playbackState.playing && x.fadeDirection != FadeDirection.fadeOut),
@@ -232,9 +252,9 @@ class NowPlayingBar extends ConsumerWidget {
                   ).primary.withOpacity(Theme.brightnessOf(context) == Brightness.light ? 0.75 : 0.3),
                   borderRadius: BorderRadius.circular(12.0),
                   clipBehavior: Clip.antiAlias,
-                  color: Theme.brightnessOf(context) == Brightness.dark
-                      ? IconTheme.of(context).color!.withOpacity(0.1)
-                      : Theme.of(context).cardColor,
+                  // Kept transparent so the BackdropFilter below can frost the
+                  // content scrolling behind the (extendBody) bar.
+                  color: Colors.transparent,
                   elevation: 8.0,
                   // If we have a media item and the player hasn't finished, show
                   // the now playing bar.
@@ -245,260 +265,302 @@ class NowPlayingBar extends ConsumerWidget {
                     padding: EdgeInsets.zero,
                     clipBehavior: Clip.antiAlias,
                     decoration: ShapeDecoration(
-                      color: remainingPartBackgroundColor,
-                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12.0)),
-                    ),
-                    child: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      mainAxisAlignment: MainAxisAlignment.start,
-                      crossAxisAlignment: CrossAxisAlignment.center,
-                      children: [
-                        Stack(
-                          alignment: Alignment.center,
-                          children: [
-                            if (ref.watch(finampSettingsProvider.showProgressOnNowPlayingBar))
-                              Positioned.fill(child: ColoredBox(color: remainingPartBackgroundColor)),
-                            AlbumImage(
-                              placeholderBuilder: (_) => const SizedBox.shrink(),
-                              imageListenable: currentAlbumImageProvider,
-                              borderRadius: BorderRadius.zero,
-                            ),
-                            if (!showPlayButtonAtEnd)
-                              AudioFadeProgressVisualizerContainer(
-                                key: const Key("AlbumArtAudioFadeProgressVisualizer"),
-                                width: albumImageSize,
-                                height: albumImageSize,
-                                borderRadius: BorderRadius.only(
-                                  topLeft: Radius.circular(12.0),
-                                  bottomLeft: Radius.circular(12.0),
-                                ),
-                                child: IconButton(
-                                  tooltip: AppLocalizations.of(context)!.togglePlaybackButtonTooltip,
-                                  onPressed: () {
-                                    FeedbackHelper.feedback(FeedbackType.light);
-                                    unawaited(audioHandler.togglePlayback());
-                                  },
-                                  color: Colors.white,
-                                  icon: Icon(
-                                    showPauseButton ? TablerIcons.player_pause : TablerIcons.player_play,
-                                    shadows: <Shadow>[Shadow(color: Colors.black, blurRadius: 10.0)],
-                                    size: 32,
-                                  ),
-                                ),
-                              ),
-                          ],
+                      // A faint glass rim defines the panel edge in both modes,
+                      // so the bar reads as a lit pane even over a black cover.
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(12.0),
+                        side: BorderSide(
+                          color: (isDark ? Colors.white : Colors.black).withOpacity(isDark ? 0.12 : 0.06),
+                          width: 1.0,
                         ),
-                        Expanded(
-                          child: Stack(
-                            children: [
-                              if (ref.watch(finampSettingsProvider.showProgressOnNowPlayingBar))
-                                Positioned.fill(
-                                  child: StreamBuilder<Duration>(
-                                    stream: AudioService.position,
-                                    initialData: audioHandler.playbackState.value.position,
-                                    builder: (context, snapshot) {
-                                      if (snapshot.hasData) {
-                                        playbackPosition = snapshot.data;
-                                        var itemLength = currentTrack.item.duration;
-                                        return FractionallySizedBox(
-                                          alignment: AlignmentDirectional.centerStart,
-                                          widthFactor: itemLength == null
-                                              ? 0
-                                              : max(0, playbackPosition!.inMilliseconds / itemLength.inMilliseconds),
-                                          child: DecoratedBox(
-                                            decoration: ShapeDecoration(
-                                              color: elapsedPartBackgroundColor,
-                                              shape: const RoundedRectangleBorder(
-                                                borderRadius: BorderRadius.only(
-                                                  topRight: Radius.circular(12),
-                                                  bottomRight: Radius.circular(12),
-                                                ),
-                                              ),
-                                            ),
-                                          ),
-                                        );
-                                      } else {
-                                        return SizedBox.shrink();
-                                      }
-                                    },
-                                  ),
+                      ),
+                    ),
+                    child: Stack(
+                      fit: StackFit.expand,
+                      children: [
+                        // 1. Theme-aware glass base — keeps the panel frosted and
+                        // distinct in both light and dark, even over black art.
+                        Positioned.fill(child: ColoredBox(color: glassBaseColor)),
+                        // 2. The current track's artwork, blurred and glazed, so
+                        // the real cover colours shine through the glass without
+                        // dictating luminance (a single flat tint reads muddy).
+                        Positioned.fill(
+                          child: Opacity(opacity: artGlazeOpacity, child: const _NowPlayingBarBlurredArt()),
+                        ),
+                        // 3. A frosting BackdropFilter + gentle scrim settles the
+                        // text contrast while keeping the artwork present.
+                        Positioned.fill(
+                          child: BackdropFilter(
+                            filter: ImageFilter.blur(sigmaX: 12.0, sigmaY: 12.0),
+                            child: ColoredBox(color: glassScrimColor),
+                          ),
+                        ),
+                        Row(
+                          mainAxisSize: MainAxisSize.min,
+                          mainAxisAlignment: MainAxisAlignment.start,
+                          crossAxisAlignment: CrossAxisAlignment.center,
+                          children: [
+                            Stack(
+                              alignment: Alignment.center,
+                              children: [
+                                if (ref.watch(finampSettingsProvider.showProgressOnNowPlayingBar))
+                                  Positioned.fill(child: ColoredBox(color: remainingPartBackgroundColor)),
+                                AlbumImage(
+                                  placeholderBuilder: (_) => const SizedBox.shrink(),
+                                  imageListenable: currentAlbumImageProvider,
+                                  borderRadius: BorderRadius.zero,
                                 ),
-                              Row(
-                                mainAxisSize: MainAxisSize.max,
-                                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                                children: [
-                                  Expanded(
-                                    child: Container(
-                                      height: albumImageSize,
-                                      padding: const EdgeInsets.only(left: 12, right: 4),
-                                      child: Column(
-                                        mainAxisSize: MainAxisSize.min,
-                                        mainAxisAlignment: MainAxisAlignment.center,
-                                        crossAxisAlignment: CrossAxisAlignment.start,
-                                        children: [
-                                          OneLineMarqueeHelper(
-                                            key: ValueKey(currentTrack.item.id),
-                                            text: currentTrack.item.title,
-                                            style: TextStyle(
-                                              fontSize: 14.5,
-                                              height: 26 / 20,
-                                              color: primaryTextColor,
-                                              fontWeight: Theme.brightnessOf(context) == Brightness.light
-                                                  ? FontWeight.w500
-                                                  : FontWeight.w600,
-                                            ),
-                                          ),
-                                          const SizedBox(height: 4),
-                                          Row(
-                                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                                            children: [
-                                              Expanded(
-                                                child: Text(
-                                                  processArtist(currentTrack.item.artist, context),
-                                                  style: TextStyle(
-                                                    color: primaryTextColor,
-                                                    fontSize: 13,
-                                                    fontWeight: FontWeight.w400,
-                                                    overflow: TextOverflow.ellipsis,
-                                                  ),
-                                                ),
-                                              ),
-                                              StreamBuilder<Duration>(
-                                                stream: AudioService.position,
-                                                initialData: audioHandler.playbackState.value.position,
-                                                builder: (context, snapshot) {
-                                                  if (snapshot.hasData) {
-                                                    playbackPosition = snapshot.data;
-                                                    final showRemaining = Platform.isIOS || Platform.isMacOS;
-                                                    final positionFullMinutes = (playbackPosition?.inMinutes ?? 0) % 60;
-                                                    final positionFullHours = (playbackPosition?.inHours ?? 0);
-                                                    final positionSeconds = (playbackPosition?.inSeconds ?? 0) % 60;
-                                                    final durationFullHours =
-                                                        (currentTrack.item.duration?.inHours ?? 0);
-                                                    final durationFullMinutes =
-                                                        (currentTrack.item.duration?.inMinutes ?? 0) % 60;
-                                                    final durationSeconds =
-                                                        (currentTrack.item.duration?.inSeconds ?? 0) % 60;
-                                                    return Semantics.fromProperties(
-                                                      properties: SemanticsProperties(
-                                                        label:
-                                                            "${positionFullHours > 0 ? "$positionFullHours hours " : ""}${positionFullMinutes > 0 ? "$positionFullMinutes minutes " : ""}$positionSeconds seconds of ${durationFullHours > 0 ? "$durationFullHours hours " : ""}${durationFullMinutes > 0 ? "$durationFullMinutes minutes " : ""}$durationSeconds seconds",
-                                                      ),
-                                                      excludeSemantics: true,
-                                                      container: true,
-                                                      child: Row(
-                                                        children: [
-                                                          Text(
-                                                            printDuration(
-                                                              showRemaining
-                                                                  ? ((currentTrack.item.duration ?? Duration.zero) -
-                                                                        (playbackPosition ?? Duration.zero))
-                                                                  : playbackPosition,
-                                                              leadingZeroes: false,
-                                                              isRemaining: showRemaining,
-                                                            ),
-                                                            style: TextStyle(
-                                                              fontSize: 14,
-                                                              fontWeight: FontWeight.w400,
-                                                              color: primaryTextColor.withOpacity(0.8),
-                                                              fontFeatures: const [
-                                                                // fixed-width digits
-                                                                FontFeature.tabularFigures(),
-                                                              ],
-                                                            ),
-                                                          ),
-                                                          if (!showRemaining) ...[
-                                                            const SizedBox(width: 2),
-                                                            Text(
-                                                              '/',
-                                                              style: TextStyle(
-                                                                color: primaryTextColor.withOpacity(0.8),
-                                                                fontSize: 14,
-                                                                fontWeight: FontWeight.w400,
-                                                                fontFeatures: const [
-                                                                  // fixed-width digits
-                                                                  FontFeature.tabularFigures(),
-                                                                ],
-                                                              ),
-                                                            ),
-                                                            const SizedBox(width: 2),
-                                                            Text(
-                                                              // '3:44',
-                                                              (currentTrack.item.duration?.inHours ?? 0.0) >= 1.0
-                                                                  ? "${currentTrack.item.duration?.inHours.toString()}:${((currentTrack.item.duration?.inMinutes ?? 0) % 60).toString().padLeft(2, '0')}:${((currentTrack.item.duration?.inSeconds ?? 0) % 60).toString().padLeft(2, '0')}"
-                                                                  : "${currentTrack.item.duration?.inMinutes.toString()}:${((currentTrack.item.duration?.inSeconds ?? 0) % 60).toString().padLeft(2, '0')}",
-                                                              style: TextStyle(
-                                                                color: primaryTextColor.withOpacity(0.8),
-                                                                fontSize: 14,
-                                                                fontWeight: FontWeight.w400,
-                                                                fontFeatures: const [
-                                                                  // fixed-width digits
-                                                                  FontFeature.tabularFigures(),
-                                                                ],
-                                                              ),
-                                                            ),
-                                                          ],
-                                                        ],
-                                                      ),
-                                                    );
-                                                  } else {
-                                                    return const SizedBox.shrink();
-                                                  }
-                                                },
-                                              ),
-                                            ],
-                                          ),
-                                        ],
+                                if (!showPlayButtonAtEnd)
+                                  AudioFadeProgressVisualizerContainer(
+                                    key: const Key("AlbumArtAudioFadeProgressVisualizer"),
+                                    width: albumImageSize,
+                                    height: albumImageSize,
+                                    borderRadius: BorderRadius.only(
+                                      topLeft: Radius.circular(12.0),
+                                      bottomLeft: Radius.circular(12.0),
+                                    ),
+                                    child: IconButton(
+                                      tooltip: AppLocalizations.of(context)!.togglePlaybackButtonTooltip,
+                                      onPressed: () {
+                                        FeedbackHelper.feedback(FeedbackType.light);
+                                        unawaited(audioHandler.togglePlayback());
+                                      },
+                                      color: Colors.white,
+                                      icon: Icon(
+                                        showPauseButton ? TablerIcons.player_pause : TablerIcons.player_play,
+                                        shadows: <Shadow>[Shadow(color: Colors.black, blurRadius: 10.0)],
+                                        size: 32,
                                       ),
                                     ),
                                   ),
-                                  Padding(
-                                    padding: const EdgeInsets.only(right: 5.0),
-                                    child: Row(
-                                      mainAxisAlignment: MainAxisAlignment.end,
-                                      children: [
-                                        AddToPlaylistButton(
-                                          item: currentTrackBaseItem,
-                                          queueItem: currentTrack,
-                                          color: primaryTextColor,
-                                          size: 28,
-                                          visualDensity: const VisualDensity(horizontal: -4),
-                                        ),
-
-                                        if (showPlayButtonAtEnd)
-                                          Stack(
-                                            alignment: Alignment.center,
-                                            children: [
-                                              AudioFadeProgressVisualizerContainer(
-                                                key: const Key("AlbumArtAudioFadeProgressVisualizer"),
-                                                color: primaryTextColor.withOpacity(0.5),
-                                                width: albumImageSize,
-                                                height: albumImageSize,
-                                                borderRadius: BorderRadius.circular(12.0),
-                                                child: SizedBox.shrink(),
-                                              ),
-                                              IconButton(
-                                                tooltip: AppLocalizations.of(context)!.togglePlaybackButtonTooltip,
-                                                onPressed: () {
-                                                  FeedbackHelper.feedback(FeedbackType.light);
-                                                  unawaited(audioHandler.togglePlayback());
-                                                },
-                                                color: primaryTextColor,
-                                                visualDensity: VisualDensity.compact,
-                                                icon: Icon(
-                                                  showPauseButton ? TablerIcons.player_pause : TablerIcons.player_play,
-                                                  size: 28,
+                              ],
+                            ),
+                            Expanded(
+                              child: Stack(
+                                children: [
+                                  if (ref.watch(finampSettingsProvider.showProgressOnNowPlayingBar))
+                                    Positioned.fill(
+                                      child: StreamBuilder<Duration>(
+                                        stream: AudioService.position,
+                                        initialData: audioHandler.playbackState.value.position,
+                                        builder: (context, snapshot) {
+                                          if (snapshot.hasData) {
+                                            playbackPosition = snapshot.data;
+                                            var itemLength = currentTrack.item.duration;
+                                            return FractionallySizedBox(
+                                              alignment: AlignmentDirectional.centerStart,
+                                              widthFactor: itemLength == null
+                                                  ? 0
+                                                  : max(
+                                                      0,
+                                                      playbackPosition!.inMilliseconds / itemLength.inMilliseconds,
+                                                    ),
+                                              child: DecoratedBox(
+                                                decoration: ShapeDecoration(
+                                                  // Translucent so the played tint layers over the
+                                                  // frosted glass instead of an opaque block, keeping
+                                                  // the title/artist legible where progress overlaps.
+                                                  // The blurred art already carries the accent colour,
+                                                  // so this only needs to mark position subtly.
+                                                  color: elapsedPartBackgroundColor.withOpacity(0.3),
+                                                  shape: const RoundedRectangleBorder(
+                                                    borderRadius: BorderRadius.only(
+                                                      topRight: Radius.circular(12),
+                                                      bottomRight: Radius.circular(12),
+                                                    ),
+                                                  ),
                                                 ),
+                                              ),
+                                            );
+                                          } else {
+                                            return SizedBox.shrink();
+                                          }
+                                        },
+                                      ),
+                                    ),
+                                  Row(
+                                    mainAxisSize: MainAxisSize.max,
+                                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                    children: [
+                                      Expanded(
+                                        child: Container(
+                                          height: albumImageSize,
+                                          padding: const EdgeInsets.only(left: 12, right: 4),
+                                          child: Column(
+                                            mainAxisSize: MainAxisSize.min,
+                                            mainAxisAlignment: MainAxisAlignment.center,
+                                            crossAxisAlignment: CrossAxisAlignment.start,
+                                            children: [
+                                              OneLineMarqueeHelper(
+                                                key: ValueKey(currentTrack.item.id),
+                                                text: currentTrack.item.title,
+                                                style: TextStyle(
+                                                  fontSize: 14.5,
+                                                  height: 26 / 20,
+                                                  color: primaryTextColor,
+                                                  shadows: textShadows,
+                                                  fontWeight: Theme.brightnessOf(context) == Brightness.light
+                                                      ? FontWeight.w500
+                                                      : FontWeight.w600,
+                                                ),
+                                              ),
+                                              const SizedBox(height: 4),
+                                              Row(
+                                                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                                children: [
+                                                  Expanded(
+                                                    child: Text(
+                                                      processArtist(currentTrack.item.artist, context),
+                                                      style: TextStyle(
+                                                        color: primaryTextColor,
+                                                        shadows: textShadows,
+                                                        fontSize: 13,
+                                                        fontWeight: FontWeight.w400,
+                                                        overflow: TextOverflow.ellipsis,
+                                                      ),
+                                                    ),
+                                                  ),
+                                                  StreamBuilder<Duration>(
+                                                    stream: AudioService.position,
+                                                    initialData: audioHandler.playbackState.value.position,
+                                                    builder: (context, snapshot) {
+                                                      if (snapshot.hasData) {
+                                                        playbackPosition = snapshot.data;
+                                                        final showRemaining = Platform.isIOS || Platform.isMacOS;
+                                                        final positionFullMinutes =
+                                                            (playbackPosition?.inMinutes ?? 0) % 60;
+                                                        final positionFullHours = (playbackPosition?.inHours ?? 0);
+                                                        final positionSeconds = (playbackPosition?.inSeconds ?? 0) % 60;
+                                                        final durationFullHours =
+                                                            (currentTrack.item.duration?.inHours ?? 0);
+                                                        final durationFullMinutes =
+                                                            (currentTrack.item.duration?.inMinutes ?? 0) % 60;
+                                                        final durationSeconds =
+                                                            (currentTrack.item.duration?.inSeconds ?? 0) % 60;
+                                                        return Semantics.fromProperties(
+                                                          properties: SemanticsProperties(
+                                                            label:
+                                                                "${positionFullHours > 0 ? "$positionFullHours hours " : ""}${positionFullMinutes > 0 ? "$positionFullMinutes minutes " : ""}$positionSeconds seconds of ${durationFullHours > 0 ? "$durationFullHours hours " : ""}${durationFullMinutes > 0 ? "$durationFullMinutes minutes " : ""}$durationSeconds seconds",
+                                                          ),
+                                                          excludeSemantics: true,
+                                                          container: true,
+                                                          child: Row(
+                                                            children: [
+                                                              Text(
+                                                                printDuration(
+                                                                  showRemaining
+                                                                      ? ((currentTrack.item.duration ?? Duration.zero) -
+                                                                            (playbackPosition ?? Duration.zero))
+                                                                      : playbackPosition,
+                                                                  leadingZeroes: false,
+                                                                  isRemaining: showRemaining,
+                                                                ),
+                                                                style: TextStyle(
+                                                                  fontSize: 14,
+                                                                  fontWeight: FontWeight.w400,
+                                                                  color: primaryTextColor.withOpacity(0.8),
+                                                                  fontFeatures: const [
+                                                                    // fixed-width digits
+                                                                    FontFeature.tabularFigures(),
+                                                                  ],
+                                                                ),
+                                                              ),
+                                                              if (!showRemaining) ...[
+                                                                const SizedBox(width: 2),
+                                                                Text(
+                                                                  '/',
+                                                                  style: TextStyle(
+                                                                    color: primaryTextColor.withOpacity(0.8),
+                                                                    fontSize: 14,
+                                                                    fontWeight: FontWeight.w400,
+                                                                    fontFeatures: const [
+                                                                      // fixed-width digits
+                                                                      FontFeature.tabularFigures(),
+                                                                    ],
+                                                                  ),
+                                                                ),
+                                                                const SizedBox(width: 2),
+                                                                Text(
+                                                                  // '3:44',
+                                                                  (currentTrack.item.duration?.inHours ?? 0.0) >= 1.0
+                                                                      ? "${currentTrack.item.duration?.inHours.toString()}:${((currentTrack.item.duration?.inMinutes ?? 0) % 60).toString().padLeft(2, '0')}:${((currentTrack.item.duration?.inSeconds ?? 0) % 60).toString().padLeft(2, '0')}"
+                                                                      : "${currentTrack.item.duration?.inMinutes.toString()}:${((currentTrack.item.duration?.inSeconds ?? 0) % 60).toString().padLeft(2, '0')}",
+                                                                  style: TextStyle(
+                                                                    color: primaryTextColor.withOpacity(0.8),
+                                                                    fontSize: 14,
+                                                                    fontWeight: FontWeight.w400,
+                                                                    fontFeatures: const [
+                                                                      // fixed-width digits
+                                                                      FontFeature.tabularFigures(),
+                                                                    ],
+                                                                  ),
+                                                                ),
+                                                              ],
+                                                            ],
+                                                          ),
+                                                        );
+                                                      } else {
+                                                        return const SizedBox.shrink();
+                                                      }
+                                                    },
+                                                  ),
+                                                ],
                                               ),
                                             ],
                                           ),
-                                      ],
-                                    ),
+                                        ),
+                                      ),
+                                      Padding(
+                                        padding: const EdgeInsets.only(right: 5.0),
+                                        child: Row(
+                                          mainAxisAlignment: MainAxisAlignment.end,
+                                          children: [
+                                            AddToPlaylistButton(
+                                              item: currentTrackBaseItem,
+                                              queueItem: currentTrack,
+                                              color: primaryTextColor,
+                                              size: 28,
+                                              visualDensity: const VisualDensity(horizontal: -4),
+                                            ),
+
+                                            if (showPlayButtonAtEnd)
+                                              Stack(
+                                                alignment: Alignment.center,
+                                                children: [
+                                                  AudioFadeProgressVisualizerContainer(
+                                                    key: const Key("AlbumArtAudioFadeProgressVisualizer"),
+                                                    color: primaryTextColor.withOpacity(0.5),
+                                                    width: albumImageSize,
+                                                    height: albumImageSize,
+                                                    borderRadius: BorderRadius.circular(12.0),
+                                                    child: SizedBox.shrink(),
+                                                  ),
+                                                  IconButton(
+                                                    tooltip: AppLocalizations.of(context)!.togglePlaybackButtonTooltip,
+                                                    onPressed: () {
+                                                      FeedbackHelper.feedback(FeedbackType.light);
+                                                      unawaited(audioHandler.togglePlayback());
+                                                    },
+                                                    color: primaryTextColor,
+                                                    visualDensity: VisualDensity.compact,
+                                                    icon: Icon(
+                                                      showPauseButton
+                                                          ? TablerIcons.player_pause
+                                                          : TablerIcons.player_play,
+                                                      size: 28,
+                                                    ),
+                                                  ),
+                                                ],
+                                              ),
+                                          ],
+                                        ),
+                                      ),
+                                    ],
                                   ),
                                 ],
                               ),
-                            ],
-                          ),
+                            ),
+                          ],
                         ),
                       ],
                     ),
@@ -547,6 +609,45 @@ class NowPlayingBar extends ConsumerWidget {
                 },
               );
             },
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Paints the current track's album art, heavily blurred and scaled up to fill
+/// the now playing bar, so the cover's real colours glow through the frosted
+/// glass above it. This is the "shine the special colour" look — the actual
+/// artwork rather than a single flat averaged tint (which reads muddy).
+class _NowPlayingBarBlurredArt extends ConsumerWidget {
+  const _NowPlayingBarBlurredArt();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // localImageProvider is overridden to the current track's art by the
+    // enclosing PlayerScreenTheme, so this tracks whatever is playing.
+    final image = ref.watch(localImageProvider).image;
+    if (image == null) {
+      return const SizedBox.shrink();
+    }
+    return ClipRect(
+      child: ImageFiltered(
+        imageFilter: ImageFilter.blur(sigmaX: 32.0, sigmaY: 32.0, tileMode: TileMode.mirror),
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            image: DecorationImage(
+              image: image,
+              fit: BoxFit.cover,
+              // A touch of saturation keeps the colour vivid once the frost
+              // scrim lightens it, without darkening the artwork.
+              colorFilter: const ColorFilter.matrix(<double>[
+                1.18, -0.06, -0.06, 0, 0, //
+                -0.06, 1.18, -0.06, 0, 0, //
+                -0.06, -0.06, 1.18, 0, 0, //
+                0, 0, 0, 1, 0, //
+              ]),
+            ),
           ),
         ),
       ),

--- a/lib/menus/music_screen_drawer.dart
+++ b/lib/menus/music_screen_drawer.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 import 'dart:math';
+import 'dart:ui' show ImageFilter;
 
 import 'package:finamp/components/HomeScreen/finamp_music_screen_header.dart';
 import 'package:finamp/components/MusicScreen/offline_mode_status_label.dart';
@@ -44,186 +45,200 @@ class MusicScreenDrawer extends ConsumerWidget {
         final excessWidth = constraints.maxWidth - minWidth;
         final expandedWidth = minWidth + excessWidth * 0.5;
         final targetWidth = min(expandedWidth, 450.0);
+        // Translucent so the BackdropFilter below can frost the content behind
+        // the drawer for a Mica-like glass panel. In light mode a subtle white
+        // lift keeps the frost bright; in dark mode we keep a denser, un-lifted
+        // surface so the glass stays legible rather than washing out.
+        final isDark = colorScheme.brightness == Brightness.dark;
+        final drawerGlassColor = isDark
+            // Lower opacity + a touch of the album-reactive surface tint lets the
+            // blurred content bleed through, so the dark glass reads as glass
+            // rather than a flat grey panel.
+            ? Color.alphaBlend(colorScheme.surfaceTint.withOpacity(0.06), colorScheme.surface.withOpacity(0.62))
+            : Color.alphaBlend(Colors.white.withOpacity(0.12), colorScheme.surface.withOpacity(0.78));
         return Drawer(
           surfaceTintColor: colorScheme.surfaceTint,
-          backgroundColor: colorScheme.surface,
+          backgroundColor: drawerGlassColor,
           width: targetWidth,
-          child: SafeArea(
-            bottom: false,
-            child: ListTileTheme(
-              // Shrink trailing padding from 24 to 8
-              contentPadding: const EdgeInsetsDirectional.only(start: 16.0, end: 8.0),
-              // Manually handle padding in leading/trailing icons
-              horizontalTitleGap: 0,
-              child: CustomScrollView(
-                slivers: [
-                  SliverList(
-                    delegate: SliverChildListDelegate.fixed([
-                      Padding(
-                        padding: EdgeInsetsGeometry.only(left: 16, right: 16, top: 12, bottom: 8),
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.center,
-                          children: [
-                            SizedBox(height: 12),
-                            FinampIcon(
-                              56,
-                              56,
-                              overrideColor: ref.watch(finampSettingsProvider.isOffline)
-                                  ? TextTheme.of(context).bodyMedium?.color?.withOpacity(0.6)
-                                  : null,
-                            ),
-                            SizedBox(height: 8),
-                            Text(
-                              ref.watch(packageNameProvider).valueOrNull ?? AppLocalizations.of(context)!.finamp,
-                              style: const TextStyle(fontSize: 20),
-                            ),
-                            if (settings?.isOffline ?? false)
-                              Text.rich(
-                                TextSpan(
-                                  text: AppLocalizations.of(context)!.offlineMode,
-                                  style: const TextStyle(fontWeight: FontWeight.w600),
-                                ),
-                                maxLines: 1,
-                                overflow: TextOverflow.ellipsis,
-                              )
-                            else
-                              Text.rich(
-                                TextSpan(
-                                  text: context.l10n.connectedTo,
-                                  children: [
-                                    TextSpan(
-                                      text:
-                                          " ${ref.watch(currentServerInfoProvider).value?.publicServerInfo.serverName ?? context.l10n.unknown}",
-                                      style: const TextStyle(fontWeight: FontWeight.w600),
-                                    ),
-                                    if (ref.watch(currentServerInfoProvider).value?.publicServerInfo.version != null)
-                                      TextSpan(
-                                        text:
-                                            " (v${ref.watch(currentServerInfoProvider).value?.publicServerInfo.version})",
-                                      ),
-                                  ],
-                                ),
-                                maxLines: 1,
-                                overflow: TextOverflow.ellipsis,
+          child: BackdropFilter(
+            filter: ImageFilter.blur(sigmaX: 30.0, sigmaY: 30.0),
+            child: SafeArea(
+              bottom: false,
+              child: ListTileTheme(
+                // Shrink trailing padding from 24 to 8
+                contentPadding: const EdgeInsetsDirectional.only(start: 16.0, end: 8.0),
+                // Manually handle padding in leading/trailing icons
+                horizontalTitleGap: 0,
+                child: CustomScrollView(
+                  slivers: [
+                    SliverList(
+                      delegate: SliverChildListDelegate.fixed([
+                        Padding(
+                          padding: EdgeInsetsGeometry.only(left: 16, right: 16, top: 12, bottom: 8),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.center,
+                            children: [
+                              SizedBox(height: 12),
+                              FinampIcon(
+                                56,
+                                56,
+                                overrideColor: ref.watch(finampSettingsProvider.isOffline)
+                                    ? TextTheme.of(context).bodyMedium?.color?.withOpacity(0.6)
+                                    : null,
                               ),
-                            if (ref.watch(isDownloadingOrSyncingPollingProvider)) ...[
                               SizedBox(height: 8),
                               Text(
-                                context.l10n.connectionStateInfoString(
-                                  ((ref.watch(FinampUserHelper.finampCurrentUserProvider)?.isLocal ?? false)
-                                          ? switch (true) {
-                                              _ when downloadsService.syncBuffer.isRunning =>
-                                                ConnectionStateInfo.syncingLocal,
-                                              _ when downloadsService.downloadTaskQueue.isRunning =>
-                                                ConnectionStateInfo.downloadingLocal,
-                                              _ when downloadsService.deleteBuffer.isRunning =>
-                                                ConnectionStateInfo.deleting,
-                                              _ => ConnectionStateInfo.connectedLocal,
-                                            }
-                                          : switch (true) {
-                                              _ when downloadsService.syncBuffer.isRunning =>
-                                                ConnectionStateInfo.syncing,
-                                              _ when downloadsService.downloadTaskQueue.isRunning =>
-                                                ConnectionStateInfo.downloading,
-                                              _ when downloadsService.deleteBuffer.isRunning =>
-                                                ConnectionStateInfo.deleting,
-                                              _ => ConnectionStateInfo.other,
-                                            })
-                                      .name,
+                                ref.watch(packageNameProvider).valueOrNull ?? AppLocalizations.of(context)!.finamp,
+                                style: const TextStyle(fontSize: 20),
+                              ),
+                              if (settings?.isOffline ?? false)
+                                Text.rich(
+                                  TextSpan(
+                                    text: AppLocalizations.of(context)!.offlineMode,
+                                    style: const TextStyle(fontWeight: FontWeight.w600),
+                                  ),
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                )
+                              else
+                                Text.rich(
+                                  TextSpan(
+                                    text: context.l10n.connectedTo,
+                                    children: [
+                                      TextSpan(
+                                        text:
+                                            " ${ref.watch(currentServerInfoProvider).value?.publicServerInfo.serverName ?? context.l10n.unknown}",
+                                        style: const TextStyle(fontWeight: FontWeight.w600),
+                                      ),
+                                      if (ref.watch(currentServerInfoProvider).value?.publicServerInfo.version != null)
+                                        TextSpan(
+                                          text:
+                                              " (v${ref.watch(currentServerInfoProvider).value?.publicServerInfo.version})",
+                                        ),
+                                    ],
+                                  ),
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
                                 ),
-                                style: TextStyle(fontStyle: FontStyle.italic),
+                              if (ref.watch(isDownloadingOrSyncingPollingProvider)) ...[
+                                SizedBox(height: 8),
+                                Text(
+                                  context.l10n.connectionStateInfoString(
+                                    ((ref.watch(FinampUserHelper.finampCurrentUserProvider)?.isLocal ?? false)
+                                            ? switch (true) {
+                                                _ when downloadsService.syncBuffer.isRunning =>
+                                                  ConnectionStateInfo.syncingLocal,
+                                                _ when downloadsService.downloadTaskQueue.isRunning =>
+                                                  ConnectionStateInfo.downloadingLocal,
+                                                _ when downloadsService.deleteBuffer.isRunning =>
+                                                  ConnectionStateInfo.deleting,
+                                                _ => ConnectionStateInfo.connectedLocal,
+                                              }
+                                            : switch (true) {
+                                                _ when downloadsService.syncBuffer.isRunning =>
+                                                  ConnectionStateInfo.syncing,
+                                                _ when downloadsService.downloadTaskQueue.isRunning =>
+                                                  ConnectionStateInfo.downloading,
+                                                _ when downloadsService.deleteBuffer.isRunning =>
+                                                  ConnectionStateInfo.deleting,
+                                                _ => ConnectionStateInfo.other,
+                                              })
+                                        .name,
+                                  ),
+                                  style: TextStyle(fontStyle: FontStyle.italic),
+                                ),
+                              ],
+                            ],
+                          ),
+                        ),
+                        const OfflineModeSwitchListTile(),
+                        const OfflineModeStatusLabel(),
+                        ListTile(
+                          leading: const Padding(
+                            padding: EdgeInsets.only(left: 2.0, right: 12.0),
+                            child: Icon(Icons.file_download, size: 20.0),
+                          ),
+                          title: Text(AppLocalizations.of(context)!.downloads, style: TextStyle(fontSize: 15.0)),
+                          onTap: () => Navigator.of(context).pushNamed(DownloadsScreen.routeName),
+                          dense: true,
+                        ),
+                        ListTile(
+                          leading: const Padding(
+                            padding: EdgeInsets.only(left: 2.0, right: 12.0),
+                            child: Icon(TablerIcons.clock, size: 20.0),
+                          ),
+                          title: Text(AppLocalizations.of(context)!.playbackHistory, style: TextStyle(fontSize: 15.0)),
+                          onTap: () => Navigator.of(context).pushNamed(PlaybackHistoryScreen.routeName),
+                          dense: true,
+                        ),
+                        ListTile(
+                          leading: const Padding(
+                            padding: EdgeInsets.only(left: 2.0, right: 12.0),
+                            child: Icon(Icons.auto_delete, size: 20.0),
+                          ),
+                          title: Text(AppLocalizations.of(context)!.queuesScreen, style: TextStyle(fontSize: 15.0)),
+                          onTap: () => Navigator.of(context).pushNamed(QueueRestoreScreen.routeName),
+                          dense: true,
+                        ),
+                      ]),
+                    ),
+                    // This causes an error when logging out if we show this widget
+                    if (finampUserHelper.currentUser != null) ...[
+                      SliverPadding(
+                        padding: EdgeInsets.only(left: 10.0, right: 10.0, top: 12.0, bottom: 4.0),
+                        sliver: SliverToBoxAdapter(
+                          child: Text.rich(
+                            TextSpan(
+                              text: AppLocalizations.of(context)!.activeLibraries,
+                              style: const TextStyle(fontWeight: FontWeight.w600),
+                            ),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                      ),
+                    ],
+                    SliverList(
+                      delegate: SliverChildBuilderDelegate((context, index) {
+                        return ViewListTile(view: finampUserHelper.currentUser!.views.values.elementAt(index));
+                      }, childCount: finampUserHelper.currentUser!.views.length),
+                    ),
+                    SliverFillRemaining(
+                      hasScrollBody: false,
+                      child: SafeArea(
+                        bottom: true,
+                        top: false,
+                        child: Align(
+                          alignment: Alignment.bottomCenter,
+                          child: Column(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              const Divider(),
+                              ListTile(
+                                leading: const Padding(
+                                  padding: EdgeInsets.only(right: 16),
+                                  child: Icon(Icons.warning, size: 20.0),
+                                ),
+                                title: Text(AppLocalizations.of(context)!.logs, style: TextStyle(fontSize: 15.0)),
+                                onTap: () => Navigator.of(context).pushNamed(LogsScreen.routeName),
+                                dense: true,
+                              ),
+                              ListTile(
+                                leading: const Padding(
+                                  padding: EdgeInsets.only(right: 16),
+                                  child: Icon(Icons.settings, size: 20.0),
+                                ),
+                                title: Text(AppLocalizations.of(context)!.settings, style: TextStyle(fontSize: 15.0)),
+                                onTap: () => Navigator.of(context).pushNamed(SettingsScreen.routeName),
+                                dense: true,
                               ),
                             ],
-                          ],
-                        ),
-                      ),
-                      const OfflineModeSwitchListTile(),
-                      const OfflineModeStatusLabel(),
-                      ListTile(
-                        leading: const Padding(
-                          padding: EdgeInsets.only(left: 2.0, right: 12.0),
-                          child: Icon(Icons.file_download, size: 20.0),
-                        ),
-                        title: Text(AppLocalizations.of(context)!.downloads, style: TextStyle(fontSize: 15.0)),
-                        onTap: () => Navigator.of(context).pushNamed(DownloadsScreen.routeName),
-                        dense: true,
-                      ),
-                      ListTile(
-                        leading: const Padding(
-                          padding: EdgeInsets.only(left: 2.0, right: 12.0),
-                          child: Icon(TablerIcons.clock, size: 20.0),
-                        ),
-                        title: Text(AppLocalizations.of(context)!.playbackHistory, style: TextStyle(fontSize: 15.0)),
-                        onTap: () => Navigator.of(context).pushNamed(PlaybackHistoryScreen.routeName),
-                        dense: true,
-                      ),
-                      ListTile(
-                        leading: const Padding(
-                          padding: EdgeInsets.only(left: 2.0, right: 12.0),
-                          child: Icon(Icons.auto_delete, size: 20.0),
-                        ),
-                        title: Text(AppLocalizations.of(context)!.queuesScreen, style: TextStyle(fontSize: 15.0)),
-                        onTap: () => Navigator.of(context).pushNamed(QueueRestoreScreen.routeName),
-                        dense: true,
-                      ),
-                    ]),
-                  ),
-                  // This causes an error when logging out if we show this widget
-                  if (finampUserHelper.currentUser != null) ...[
-                    SliverPadding(
-                      padding: EdgeInsets.only(left: 10.0, right: 10.0, top: 12.0, bottom: 4.0),
-                      sliver: SliverToBoxAdapter(
-                        child: Text.rich(
-                          TextSpan(
-                            text: AppLocalizations.of(context)!.activeLibraries,
-                            style: const TextStyle(fontWeight: FontWeight.w600),
                           ),
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
                         ),
                       ),
                     ),
                   ],
-                  SliverList(
-                    delegate: SliverChildBuilderDelegate((context, index) {
-                      return ViewListTile(view: finampUserHelper.currentUser!.views.values.elementAt(index));
-                    }, childCount: finampUserHelper.currentUser!.views.length),
-                  ),
-                  SliverFillRemaining(
-                    hasScrollBody: false,
-                    child: SafeArea(
-                      bottom: true,
-                      top: false,
-                      child: Align(
-                        alignment: Alignment.bottomCenter,
-                        child: Column(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            const Divider(),
-                            ListTile(
-                              leading: const Padding(
-                                padding: EdgeInsets.only(right: 16),
-                                child: Icon(Icons.warning, size: 20.0),
-                              ),
-                              title: Text(AppLocalizations.of(context)!.logs, style: TextStyle(fontSize: 15.0)),
-                              onTap: () => Navigator.of(context).pushNamed(LogsScreen.routeName),
-                              dense: true,
-                            ),
-                            ListTile(
-                              leading: const Padding(
-                                padding: EdgeInsets.only(right: 16),
-                                child: Icon(Icons.settings, size: 20.0),
-                              ),
-                              title: Text(AppLocalizations.of(context)!.settings, style: TextStyle(fontSize: 15.0)),
-                              onTap: () => Navigator.of(context).pushNamed(SettingsScreen.routeName),
-                              dense: true,
-                            ),
-                          ],
-                        ),
-                      ),
-                    ),
-                  ),
-                ],
+                ),
               ),
             ),
           ),


### PR DESCRIPTION
**What this does**
  
  Gives the now playing bar and the navigation drawer a frosted glass treatment that fits the redesign.

  The now playing bar now renders the current track's album art, blurred and glazed behind frosted glass, so the cover's own colour shines through the panel. This replaces the previous single averaged accent colour, which tended to read muddy and made text contrast unpredictable. A theme aware glass base sits under the artwork so the bar stays a distinct, legible panel in both light and dark modes, and even over an all black cover it still reads as a lit pane rather than melting into the page.

  Text uses a fixed light or dark colour with a tight shadow so the title and artist stay crisp over any artwork, and the progress fill is now translucent so it layers over the glass as a subtle played tint instead of blocking the text where it overlaps.

  The navigation drawer gets a matching frosted panel that adapts to light and dark, so the two surfaces feel consistent.

  **Notes**

  Built entirely on Flutter's BackdropFilter and ImageFiltered, so it renders the same on Android, iOS, and desktop. There are no platform specific paths. Performance is a single small blur over the bar plus the drawer blur only while the drawer is open, so there is no meaningful battery or frame cost.
  
  **Design**

Built to feel native in both worlds from one code path: on iOS it reads as system glass, a live blur with the album art bleeding through like Apple's own now playing surfaces; on Android it lands as a Material translucent surface, its tint and album derived accent driven by the color scheme the way Material expects. All Flutter BackdropFilter and ImageFiltered, so there is no platform branch and the look stays consistent everywhere Finamp ships.

  Tested live on the iOS simulator across bright, pale, and pure black covers in both light and dark mode.

  **Screenshots**

<img width="441" height="168" alt="Screenshot 2026-08-07 at 10 48 37 AM" src="https://github.com/user-attachments/assets/e84f910f-3bbd-4256-bb9e-e97ace781707" />
<img width="477" height="164" alt="Screenshot 2026-08-07 at 10 50 06 AM" src="https://github.com/user-attachments/assets/c4e0e9dd-4c36-4ef0-b7b2-2d9d949248ed" />
<img width="419" height="139" alt="Screenshot 2026-08-07 at 10 48 18 AM" src="https://github.com/user-attachments/assets/a972d93e-e00e-4720-a4f7-8791a7609452" />
<img width="401" height="825" alt="Screenshot 2026-08-07 at 10 48 13 AM" src="https://github.com/user-attachments/assets/acf0fc15-d130-4b33-924a-3f645d143006" />
<img width="457" height="851" alt="Screenshot 2026-08-07 at 10 49 16 AM" src="https://github.com/user-attachments/assets/a7935b21-59b7-43e6-b067-f702e49f7193" />
