### PR TITLE
Fetch track credits on demand instead of in every item query

### DIFF
--- a/lib/components/PlayerScreen/feature_chips.dart
+++ b/lib/components/PlayerScreen/feature_chips.dart
@@ -120,8 +120,9 @@ class FeatureState {
         );
       }
 
-      if (feature == FinampFeatureChipType.additionalPeople && (currentTrack?.baseItem.people?.isNotEmpty ?? false)) {
-        currentTrack?.baseItem.people?.forEach((person) {
+      final people = metadata?.people ?? currentTrack?.baseItem.people;
+      if (feature == FinampFeatureChipType.additionalPeople && (people?.isNotEmpty ?? false)) {
+        people?.forEach((person) {
           features.add(FeatureProperties(type: feature, text: "${person.role ?? person.type}: ${person.name}"));
         });
       }

--- a/lib/services/downloads_service_backend.dart
+++ b/lib/services/downloads_service_backend.dart
@@ -1244,7 +1244,7 @@ class DownloadsSyncService {
       }
       _metadataCache[id] = itemFetch.future;
       item = await _jellyfinApiData
-          .getItemByIdBatched(id, "${_jellyfinApiData.defaultFields},sortName,MediaSources")
+          .getItemByIdBatched(id, "${_jellyfinApiData.defaultFields},sortName,MediaSources,People")
           .then((value) => value == null ? null : DownloadStub.fromItem(item: value, type: type));
       _downloadsService.resetConnectionErrors();
       itemFetch.complete(item);
@@ -1275,7 +1275,7 @@ class DownloadsSyncService {
       case BaseItemDtoType.playlist || BaseItemDtoType.album:
         childType = DownloadItemType.track;
         childFilter = BaseItemDtoType.track;
-        fields = "${_jellyfinApiData.defaultFields},MediaSources,SortName";
+        fields = "${_jellyfinApiData.defaultFields},MediaSources,SortName,People";
         sortOrder = "ParentIndexNumber,IndexNumber,SortName";
       case BaseItemDtoType.artist || BaseItemDtoType.genre || BaseItemDtoType.library:
         childType = DownloadItemType.collection;
@@ -1317,7 +1317,7 @@ class DownloadsSyncService {
               parentItem: item,
               includeItemTypes: BaseItemDtoType.track.jellyfinName,
               recursive: false,
-              fields: "${_jellyfinApiData.defaultFields},MediaSources,SortName",
+              fields: "${_jellyfinApiData.defaultFields},MediaSources,SortName,People",
             ) ??
             [];
         childItems.addAll(trackChildItems);
@@ -1336,7 +1336,7 @@ class DownloadsSyncService {
               includeItemTypes: BaseItemDtoType.track.jellyfinName,
               filters: "Artist=${parent.name}",
               artistType: ArtistType.artist,
-              fields: "${_jellyfinApiData.defaultFields},MediaSources,SortName",
+              fields: "${_jellyfinApiData.defaultFields},MediaSources,SortName,People",
             ) ??
             [];
         var artistTrackChildStubs = artistTrackChildItems.map(
@@ -1368,7 +1368,7 @@ class DownloadsSyncService {
   Future<List<DownloadStub>> _getFinampCollectionChildren(DownloadStub parent) async {
     assert(parent.type == DownloadItemType.finampCollection);
     FinampCollection collection = parent.finampCollection!;
-    final String fields = "${_jellyfinApiData.defaultFields},MediaSources,SortName";
+    final String fields = "${_jellyfinApiData.defaultFields},MediaSources,SortName,People";
     try {
       List<BaseItemDto> outputItems;
       DownloadItemType? typeOverride;

--- a/lib/services/jellyfin_api.dart
+++ b/lib/services/jellyfin_api.dart
@@ -16,8 +16,7 @@ import 'jellyfin_api_helper.dart';
 
 part 'jellyfin_api.chopper.dart';
 
-const String defaultFields =
-    "ChildCount,DateCreated,DateLastMediaAdded,Etag,Genres,ParentId,ProviderIds,Tags,SortName,People";
+const String defaultFields = "ChildCount,DateCreated,DateLastMediaAdded,Etag,Genres,ParentId,ProviderIds,Tags,SortName";
 
 @ChopperApi()
 abstract class JellyfinApi extends ChopperService {

--- a/lib/services/metadata_provider.dart
+++ b/lib/services/metadata_provider.dart
@@ -25,6 +25,7 @@ class MetadataProvider {
   bool isDownloaded;
   bool qualifiesForPlaybackSpeedControl;
   double? albumNormalizationGain;
+  List<BaseItemPerson>? people;
 
   MetadataProvider({
     required this.item,
@@ -33,6 +34,7 @@ class MetadataProvider {
     this.isDownloaded = false,
     this.qualifiesForPlaybackSpeedControl = false,
     this.albumNormalizationGain,
+    this.people,
   });
 
   MediaSourceInfo get mediaSourceInfo => playbackInfo.mediaSources!.first;
@@ -187,7 +189,20 @@ final AutoDisposeFutureProviderFamily<MetadataProvider?, BaseItemDto> metadataPr
         playbackInfo: playbackInfo,
         isDownloaded: localPlaybackInfo != null,
         albumNormalizationGain: parent?.normalizationGain,
+        people: item.people,
       );
+
+      final chipConfig = ref.watch(finampSettingsProvider.featureChipsConfiguration);
+      if (!ref.watch(finampSettingsProvider.isOffline) &&
+          chipConfig.enabled &&
+          chipConfig.features.contains(FinampFeatureChipType.additionalPeople)) {
+        try {
+          final withPeople = await jellyfinApiHelper.getItems(itemIds: [item.id], fields: "People");
+          metadata.people = withPeople?.firstOrNull?.people;
+        } catch (e) {
+          metadataProviderLogger.warning("Failed to fetch people for '${item.name}' (${item.id})", e);
+        }
+      }
 
       for (final genre in item.genres ?? []) {
         if (MetadataProvider.speedControlGenres.contains(genre.toLowerCase())) {


### PR DESCRIPTION
### Problem

On Jellyfin 12 (reported on RC4 https://github.com/finamp-app/finamp/issues/1707), opening playlists and browsing the library became several times slower than on 0.9.24. Downgrading Finamp restored the speed.

The cause is in the default item fields Finamp requests. `defaultFields` includes `People` (the cast/credits list), which is applied to every bulk item query. On the server, People live in a separate table from the item, so requesting the field forces a per item relational join across the whole result. Jellyfin 12 handles that join much more slowly than earlier servers, so the previously tolerable cost became the bottleneck. 0.9.24 did not request `People` in these queries, which is why the downgrade "fixes" it.

### Measurements

Same query against a live Jellyfin 12.0.0 server, only difference is whether `People` is requested:

| Request | Without People | With People |
| --- | --- | --- |
| 53 track playlist | 41 ms | 258 ms (~6x) |
| 500 track library page | 179 ms | 2361 ms (~13x) |

The cost scales with track count, so large playlists are the worst affected.

### Fix

Stop requesting `People` in bulk queries, and fetch it on demand only for the currently playing track, through the metadata provider. That single item request measured ~18 ms and still returns the credits, so the additional people chip on the player screen is unchanged. Playlists load at 0.9.24 speeds again.

Only the current track (and the few tracks the player precaches) trigger the extra request, and only when the additional people chip is enabled and the app is online.

### Notes

The server returns an empty `People` list rather than omitting the field, so the item alone can't tell us whether credits were loaded; the provider always fetches when online and the chip is enabled.

There is likely also a server side regression worth reporting upstream (RC4 handling this join notably slower than older servers), but the client should not be over fetching credits for a whole playlist to display them for one track regardless, so this change is worthwhile independent of any server fix.
