### PR TITLE
feat: embedded Tailscale (tsnet) for MagicDNS Jellyfin

### DIFF
--- a/docs/EMBEDDED_TAILSCALE.md
+++ b/docs/EMBEDDED_TAILSCALE.md
@@ -1,0 +1,61 @@
+# Embedded Tailscale (tsnet)
+
+Fork-only feature: Finamp can join your tailnet **in-process** via
+[`package:tailscale`](https://pub.dev/packages/tailscale) (upstream Go `tsnet`).
+This is **not** a system VPN, so it can coexist with ExpressVPN on iOS/Android.
+
+## Why
+
+iOS and Android allow only one system VPN profile at a time. The official
+Tailscale app and ExpressVPN cannot both be active. Userspace `tsnet` speaks
+WireGuard-over-UDP from inside Finamp and leaves the OS routing table alone.
+
+## User flow
+
+1. Settings → **Embedded Tailscale**
+2. Enable **Connect via embedded Tailscale**
+3. Paste a Tailscale **auth key** (recommended) or complete interactive login
+4. Set the Jellyfin server URL to a MagicDNS name, e.g.
+   `https://jellyfin.tailnet.ts.net:8096`
+   (the login screen still normalizes the common `jellyfin@tailnet` typo)
+5. Jellyfin API calls (Chopper) go through `Tailscale.instance.http.client`
+
+When the toggle is on, app launch calls `Tailscale.up()` again so MagicDNS
+works without reopening Settings (saved credentials / auth key flow).
+
+Toggle off to use the normal LAN / public HTTP client again.
+
+## Build requirements
+
+- Flutter with **Dart ≥ 3.10.4** (this branch bumps `sdk: ^3.10.4`)
+- **Go 1.25+** on `PATH` (Go 1.26 recommended). The first build compiles the
+  native tsnet asset; later builds are cached.
+- Xcode (iOS/macOS) / Android NDK via Flutter
+
+```bash
+# Dev MacBook — Finamp repo
+go version   # expect go1.25+
+flutter pub get
+flutter run
+```
+
+## Security notes
+
+- Node WireGuard private key lives under application support
+  (`…/embedded_tailscale/`). Do not back this directory up to iCloud.
+- Prefer short-lived or tagged auth keys from the Tailscale admin console.
+- Use **Log out / reset node** before handing a device away.
+
+## Scope / non-goals
+
+- Music Finder / External Search is **not** on this branch (personal fork work).
+- Audio streaming (`just_audio`) may still use the platform HTTP stack; if
+  streams fail over MagicDNS while API works, a follow-up must route media
+  fetches through the same client.
+- Not proposed to upstream until device-tested and package:tailscale reviewed
+  for key storage.
+
+## Related
+
+- Copilot task: https://github.com/itdir/finamp/tasks/5fd20a6a-e3ee-44ab-82d3-8a34c7646131
+- Plan: `~/.cursor/plans/finamp_embedded_tsnet_5fd20a6a.plan.md`

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2318,6 +2318,40 @@
     "@networkSettingsTitle": {
         "description": "Title for the network settings screen"
     },
+    "embeddedTailscaleSettingsTitle": "Embedded Tailscale",
+    "@embeddedTailscaleSettingsTitle": {
+        "description": "Settings screen for in-app Tailscale tsnet"
+    },
+    "embeddedTailscaleEnableTitle": "Connect via embedded Tailscale",
+    "embeddedTailscaleEnableSubtitle": "Route Jellyfin API traffic through userspace Tailscale (tsnet). Works alongside ExpressVPN because it is not a system VPN.",
+    "embeddedTailscaleStatusTitle": "Node status",
+    "embeddedTailscaleStatusDisconnected": "Disconnected",
+    "embeddedTailscaleStatusBusy": "Working…",
+    "embeddedTailscaleStatusRunning": "Running ({ip})",
+    "@embeddedTailscaleStatusRunning": {
+        "placeholders": {
+            "ip": { "type": "String" }
+        }
+    },
+    "embeddedTailscaleStatusNeedsLogin": "Needs login — use an auth key or open the login URL",
+    "embeddedTailscaleStatusNeedsApproval": "Waiting for machine approval in the Tailscale admin console",
+    "embeddedTailscaleStatusOther": "State: {state}",
+    "@embeddedTailscaleStatusOther": {
+        "placeholders": {
+            "state": { "type": "String" }
+        }
+    },
+    "embeddedTailscaleErrorTitle": "Error",
+    "embeddedTailscaleAuthKeyLabel": "Auth key (optional)",
+    "embeddedTailscaleAuthKeyHint": "tskey-auth-…",
+    "embeddedTailscaleConnectButton": "Connect / reconnect",
+    "embeddedTailscaleConnectSubtitle": "Bring the node up with the auth key if provided, otherwise reuse saved credentials",
+    "embeddedTailscaleOpenLogin": "Open login URL",
+    "embeddedTailscaleOpenLoginSubtitle": "Complete interactive Tailscale login in the browser",
+    "embeddedTailscaleLoginClipboardHint": "Complete Tailscale login from the Tailscale admin / auth flow for this node",
+    "embeddedTailscaleLoginCopied": "Login hint copied to clipboard",
+    "embeddedTailscaleLogoutTitle": "Log out / reset node",
+    "embeddedTailscaleLogoutSubtitle": "Revoke this node and wipe the local WireGuard key",
     "downloadPaused": "Downloading paused because device is not connected to WiFi",
     "@downloadPaused": {
         "description": "Gets shown in the snackbar if loosing wifi connection while downloads are running and the 'requireWifiForDownloads' is enabled"

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,6 +19,7 @@ import 'package:finamp/screens/accessibility_settings_screen.dart';
 import 'package:finamp/screens/album_settings_screen.dart';
 import 'package:finamp/screens/artist_settings_screen.dart';
 import 'package:finamp/screens/downloads_settings_screen.dart';
+import 'package:finamp/screens/embedded_tailscale_settings_screen.dart';
 import 'package:finamp/screens/genre_settings_screen.dart';
 import 'package:finamp/screens/home_screen_settings_screen.dart';
 import 'package:finamp/screens/interaction_settings_screen.dart';
@@ -40,6 +41,7 @@ import 'package:finamp/services/dbus_manager.dart';
 import 'package:finamp/services/discord_rpc.dart';
 import 'package:finamp/services/downloads_service.dart';
 import 'package:finamp/services/downloads_service_backend.dart';
+import 'package:finamp/services/embedded_tailscale_service.dart';
 import 'package:finamp/services/finamp_logs_helper.dart';
 import 'package:finamp/services/finamp_settings_helper.dart';
 import 'package:finamp/services/finamp_user_helper.dart';
@@ -151,6 +153,8 @@ Future<void> main(List<String> args, {bool integrationTesting = false, bool logi
     _mainLog.info("Installed client certificate");
     await _setupFinampUserHelper();
     _mainLog.info("Setup user helper");
+    await _setupEmbeddedTailscale();
+    _mainLog.info("Setup embedded Tailscale");
     await _setupJellyfinApiData();
     _mainLog.info("setup jellyfin api");
     _setupOfflineListenLogHelper();
@@ -225,6 +229,21 @@ Future<void> _setupEdgeToEdgeOverlayStyle() async {
     // screen as it does not have an AppBar. To fix this, we set the
     // brightness to dark manually on startup.
     SystemChrome.setSystemUIOverlayStyle(const SystemUiOverlayStyle(statusBarBrightness: Brightness.dark));
+  }
+}
+
+/// Bring up userspace tsnet when the setting is already enabled (e.g. after
+/// app relaunch) so Chopper MagicDNS calls work before opening Settings.
+Future<void> _setupEmbeddedTailscale() async {
+  if (!FinampSettingsHelper.finampSettings.useEmbeddedTailscale) return;
+  try {
+    await EmbeddedTailscaleService.ensureInitialized();
+    final status = await EmbeddedTailscaleService.up();
+    _mainLog.info(
+      'Embedded Tailscale up: state=${status.state} ipv4=${status.ipv4}',
+    );
+  } catch (e, st) {
+    _mainLog.warning('Embedded Tailscale failed to start on launch', e, st);
   }
 }
 
@@ -988,6 +1007,8 @@ class FinampApp extends ConsumerWidget {
         ArtistSettingsScreen.routeName: (context) => const ArtistSettingsScreen(),
         GenreSettingsScreen.routeName: (context) => const GenreSettingsScreen(),
         NetworkSettingsScreen.routeName: (context) => const NetworkSettingsScreen(),
+        EmbeddedTailscaleSettingsScreen.routeName: (context) =>
+            const EmbeddedTailscaleSettingsScreen(),
         AccessibilitySettingsScreen.routeName: (context) => const AccessibilitySettingsScreen(),
         PlaylistEditScreen.routeName: (context) =>
             PlaylistEditScreen(playlist: ModalRoute.settingsOf(context)!.arguments as BaseItemDto),

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -274,6 +274,8 @@ class DefaultSettings {
   static const duckOnAudioInterruption = true;
   static const forceAudioOffloadingOnAndroid = false;
   static const verboseLogging = false;
+  /// Route Jellyfin HTTP through in-process Tailscale tsnet (coexists with ExpressVPN).
+  static const useEmbeddedTailscale = false;
   static const previousTracksPersistenceMode = PreviousTracksPersistenceMode.persistent;
   static final homeScreenConfiguration = FinampHomeScreenConfiguration(
     actions: [
@@ -450,6 +452,7 @@ class FinampSettings {
     this.duckOnAudioInterruption = DefaultSettings.duckOnAudioInterruption,
     this.forceAudioOffloadingOnAndroid = DefaultSettings.forceAudioOffloadingOnAndroid,
     this.verboseLogging = DefaultSettings.verboseLogging,
+    this.useEmbeddedTailscale = DefaultSettings.useEmbeddedTailscale,
     this.previousTracksPersistenceMode = DefaultSettings.previousTracksPersistenceMode,
     required this.homeScreenConfiguration,
     required this.gridImageSize,
@@ -948,6 +951,13 @@ class FinampSettings {
   /// release builds otherwise cap at INFO.
   @HiveField(153, defaultValue: DefaultSettings.verboseLogging)
   bool verboseLogging = DefaultSettings.verboseLogging;
+
+  /// When true, Jellyfin API HTTP goes through embedded Tailscale tsnet
+  /// (`package:tailscale`) instead of the default [HttpClient]. Opt-in so
+  /// LAN users are unaffected; enables MagicDNS reachability alongside a
+  /// system VPN such as ExpressVPN.
+  @HiveField(154, defaultValue: DefaultSettings.useEmbeddedTailscale)
+  bool useEmbeddedTailscale = DefaultSettings.useEmbeddedTailscale;
 
   static Future<FinampSettings> create() async {
     final downloadLocation = await DownloadLocation.create(

--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -438,6 +438,9 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
             ? false
             : fields[143] as bool,
         verboseLogging: fields[153] == null ? false : fields[153] as bool,
+        useEmbeddedTailscale: fields[154] == null
+            ? false
+            : fields[154] as bool,
         previousTracksPersistenceMode: fields[145] == null
             ? PreviousTracksPersistenceMode.persistent
             : fields[145] as PreviousTracksPersistenceMode,
@@ -473,7 +476,7 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
   @override
   void write(BinaryWriter writer, FinampSettings obj) {
     writer
-      ..writeByte(147)
+      ..writeByte(148)
       ..writeByte(0)
       ..write(obj.isOffline)
       ..writeByte(1)
@@ -767,7 +770,9 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       ..writeByte(152)
       ..write(obj.deviceId)
       ..writeByte(153)
-      ..write(obj.verboseLogging);
+      ..write(obj.verboseLogging)
+      ..writeByte(154)
+      ..write(obj.useEmbeddedTailscale);
   }
 
   @override

--- a/lib/screens/embedded_tailscale_settings_screen.dart
+++ b/lib/screens/embedded_tailscale_settings_screen.dart
@@ -1,0 +1,248 @@
+import 'dart:async';
+
+import 'package:finamp/components/finamp_app_bar_back_button.dart';
+import 'package:finamp/l10n/app_localizations.dart';
+import 'package:finamp/services/embedded_tailscale_service.dart';
+import 'package:finamp/services/finamp_settings_helper.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:tailscale/tailscale.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+/// Settings for in-process Tailscale (tsnet) used for Jellyfin MagicDNS.
+class EmbeddedTailscaleSettingsScreen extends ConsumerStatefulWidget {
+  const EmbeddedTailscaleSettingsScreen({super.key});
+
+  static const routeName = '/settings/embedded-tailscale';
+
+  @override
+  ConsumerState<EmbeddedTailscaleSettingsScreen> createState() =>
+      _EmbeddedTailscaleSettingsScreenState();
+}
+
+class _EmbeddedTailscaleSettingsScreenState
+    extends ConsumerState<EmbeddedTailscaleSettingsScreen> {
+  final _authKeyController = TextEditingController();
+  StreamSubscription<NodeState>? _stateSub;
+  TailscaleStatus? _status;
+  String? _error;
+  bool _busy = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _status = EmbeddedTailscaleService.lastStatus;
+    unawaited(_bootstrap());
+  }
+
+  Future<void> _bootstrap() async {
+    if (!FinampSettingsHelper.finampSettings.useEmbeddedTailscale) return;
+    try {
+      await EmbeddedTailscaleService.ensureInitialized();
+      _attachStateListener();
+      if (_status == null || _status!.state == NodeState.stopped) {
+        setState(() => _busy = true);
+        final status = await EmbeddedTailscaleService.up();
+        if (mounted) {
+          setState(() {
+            _status = status;
+            _busy = false;
+          });
+        }
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _error = e.toString();
+          _busy = false;
+        });
+      }
+    }
+  }
+
+  void _attachStateListener() {
+    _stateSub?.cancel();
+    _stateSub = EmbeddedTailscaleService.listenState((s) {
+      if (mounted) setState(() => _status = s);
+    });
+  }
+
+  @override
+  void dispose() {
+    _stateSub?.cancel();
+    _authKeyController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _onToggle(bool enabled) async {
+    FinampSetters.setUseEmbeddedTailscale(enabled);
+    setState(() {
+      _error = null;
+      _busy = true;
+    });
+    try {
+      if (enabled) {
+        await EmbeddedTailscaleService.ensureInitialized();
+        _attachStateListener();
+        final key = _authKeyController.text.trim();
+        final status = await EmbeddedTailscaleService.up(
+          authKey: key.isEmpty ? null : key,
+        );
+        if (mounted) setState(() => _status = status);
+      } else {
+        await EmbeddedTailscaleService.down();
+        if (mounted) {
+          setState(() => _status = EmbeddedTailscaleService.lastStatus);
+        }
+      }
+    } catch (e) {
+      if (mounted) setState(() => _error = e.toString());
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  Future<void> _connectWithKey() async {
+    setState(() {
+      _busy = true;
+      _error = null;
+    });
+    try {
+      await EmbeddedTailscaleService.ensureInitialized();
+      _attachStateListener();
+      final key = _authKeyController.text.trim();
+      final status = await EmbeddedTailscaleService.up(
+        authKey: key.isEmpty ? null : key,
+      );
+      if (mounted) setState(() => _status = status);
+    } catch (e) {
+      if (mounted) setState(() => _error = e.toString());
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  Future<void> _logout() async {
+    setState(() => _busy = true);
+    try {
+      await EmbeddedTailscaleService.logout();
+      if (mounted) {
+        setState(() {
+          _status = TailscaleStatus.stopped;
+          _error = null;
+        });
+      }
+    } catch (e) {
+      if (mounted) setState(() => _error = e.toString());
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  String _statusLabel(AppLocalizations l10n) {
+    final s = _status;
+    if (s == null || s.state == NodeState.stopped || s.state == NodeState.noState) {
+      return l10n.embeddedTailscaleStatusDisconnected;
+    }
+    if (s.isRunning) {
+      return l10n.embeddedTailscaleStatusRunning(s.ipv4 ?? '');
+    }
+    if (s.needsLogin) return l10n.embeddedTailscaleStatusNeedsLogin;
+    if (s.state == NodeState.needsMachineAuth) {
+      return l10n.embeddedTailscaleStatusNeedsApproval;
+    }
+    return l10n.embeddedTailscaleStatusOther(s.state.name);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final enabled = ref.watch(finampSettingsProvider.useEmbeddedTailscale);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(l10n.embeddedTailscaleSettingsTitle),
+        leading: const FinampAppBarBackButton(),
+      ),
+      body: ListView(
+        padding: const EdgeInsets.only(bottom: 200.0),
+        children: [
+          SwitchListTile.adaptive(
+            title: Text(l10n.embeddedTailscaleEnableTitle),
+            subtitle: Text(l10n.embeddedTailscaleEnableSubtitle),
+            value: enabled,
+            onChanged: _busy ? null : _onToggle,
+          ),
+          ListTile(
+            title: Text(l10n.embeddedTailscaleStatusTitle),
+            subtitle: Text(
+              _busy ? l10n.embeddedTailscaleStatusBusy : _statusLabel(l10n),
+            ),
+          ),
+          if (_error != null)
+            ListTile(
+              leading: Icon(
+                Icons.error_outline,
+                color: Theme.of(context).colorScheme.error,
+              ),
+              title: Text(l10n.embeddedTailscaleErrorTitle),
+              subtitle: Text(_error!),
+            ),
+          const Divider(),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: TextField(
+              controller: _authKeyController,
+              enabled: !_busy,
+              obscureText: true,
+              autocorrect: false,
+              enableSuggestions: false,
+              decoration: InputDecoration(
+                labelText: l10n.embeddedTailscaleAuthKeyLabel,
+                hintText: l10n.embeddedTailscaleAuthKeyHint,
+                border: const OutlineInputBorder(),
+              ),
+            ),
+          ),
+          ListTile(
+            title: Text(l10n.embeddedTailscaleConnectButton),
+            subtitle: Text(l10n.embeddedTailscaleConnectSubtitle),
+            trailing: const Icon(Icons.login),
+            enabled: !_busy && enabled,
+            onTap: _busy || !enabled ? null : _connectWithKey,
+          ),
+          if (_status?.needsLogin ?? false)
+            ListTile(
+              title: Text(l10n.embeddedTailscaleOpenLogin),
+              subtitle: Text(l10n.embeddedTailscaleOpenLoginSubtitle),
+              trailing: const Icon(Icons.open_in_browser),
+              onTap: () async {
+                final uri = _status?.authUrl;
+                if (uri != null) {
+                  await launchUrl(uri, mode: LaunchMode.externalApplication);
+                  return;
+                }
+                await Clipboard.setData(
+                  ClipboardData(text: l10n.embeddedTailscaleLoginClipboardHint),
+                );
+                if (context.mounted) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(content: Text(l10n.embeddedTailscaleLoginCopied)),
+                  );
+                }
+              },
+            ),
+          const Divider(),
+          ListTile(
+            title: Text(l10n.embeddedTailscaleLogoutTitle),
+            subtitle: Text(l10n.embeddedTailscaleLogoutSubtitle),
+            trailing: const Icon(Icons.logout),
+            enabled: !_busy && enabled,
+            onTap: _busy || !enabled ? null : _logout,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -8,6 +8,7 @@ import 'package:finamp/menus/server_sharing_menu.dart';
 import 'package:finamp/screens/accessibility_settings_screen.dart';
 import 'package:finamp/screens/audio_service_settings_screen.dart';
 import 'package:finamp/screens/downloads_settings_screen.dart';
+import 'package:finamp/screens/embedded_tailscale_settings_screen.dart';
 import 'package:finamp/screens/home_screen_settings_screen.dart';
 import 'package:finamp/screens/interaction_settings_screen.dart';
 import 'package:finamp/screens/language_selection_screen.dart';
@@ -154,6 +155,12 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             leading: const Icon(Icons.wifi),
             title: Text(AppLocalizations.of(context)!.networkSettingsTitle),
             onTap: () => Navigator.of(context).pushNamed(NetworkSettingsScreen.routeName),
+          ),
+          ListTile(
+            leading: const Icon(Icons.vpn_lock),
+            title: Text(AppLocalizations.of(context)!.embeddedTailscaleSettingsTitle),
+            onTap: () =>
+                Navigator.of(context).pushNamed(EmbeddedTailscaleSettingsScreen.routeName),
           ),
           ListTile(
             leading: const Icon(Icons.music_note),

--- a/lib/services/embedded_tailscale_service.dart
+++ b/lib/services/embedded_tailscale_service.dart
@@ -1,0 +1,119 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:logging/logging.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+import 'package:tailscale/tailscale.dart';
+
+/// Lifecycle wrapper around [package:tailscale] userspace tsnet.
+///
+/// Keeps the node state directory under application support and marks it
+/// excluded from iCloud backup on iOS (leaked WireGuard keys can impersonate
+/// the node).
+class EmbeddedTailscaleService {
+  EmbeddedTailscaleService._();
+
+  static final _log = Logger('EmbeddedTailscaleService');
+  static bool _initialized = false;
+  static TailscaleStatus? _lastStatus;
+  static Object? _lastError;
+
+  static TailscaleStatus? get lastStatus => _lastStatus;
+  static Object? get lastError => _lastError;
+  static bool get isRunning => _lastStatus?.isRunning ?? false;
+  static Uri? get authUrl => _lastStatus?.authUrl;
+
+  /// Ensure [Tailscale.init] has been called with a backup-excluded state dir.
+  static Future<void> ensureInitialized() async {
+    if (_initialized) return;
+    final support = await getApplicationSupportDirectory();
+    final stateDir = Directory(p.join(support.path, 'embedded_tailscale'));
+    if (!await stateDir.exists()) {
+      await stateDir.create(recursive: true);
+    }
+    await _excludeFromBackup(stateDir);
+    Tailscale.init(stateDir: stateDir.path);
+    _initialized = true;
+    _log.info('Initialized tsnet stateDir=${stateDir.path}');
+  }
+
+  /// Bring the node up. Prefer [authKey] for unattended join; otherwise an
+  /// interactive login URL may appear on [TailscaleStatus.authUrl].
+  static Future<TailscaleStatus> up({
+    String? authKey,
+    String hostname = 'finamp',
+    bool ephemeral = false,
+  }) async {
+    await ensureInitialized();
+    _lastError = null;
+    try {
+      final status = await Tailscale.instance.up(
+        hostname: hostname,
+        authKey: authKey,
+        ephemeral: ephemeral,
+      );
+      _lastStatus = status;
+      _log.info(
+        'up() → state=${status.state} ipv4=${status.ipv4} '
+        'needsLogin=${status.needsLogin}',
+      );
+      return status;
+    } catch (e, st) {
+      _lastError = e;
+      _log.severe('up() failed', e, st);
+      rethrow;
+    }
+  }
+
+  static Future<void> down() async {
+    if (!_initialized) return;
+    await Tailscale.instance.down();
+    _lastStatus = await Tailscale.instance.status();
+  }
+
+  /// Revoke the node with the control plane and wipe local state.
+  static Future<void> logout() async {
+    if (!_initialized) return;
+    await Tailscale.instance.logout();
+    _lastStatus = TailscaleStatus.stopped;
+  }
+
+  /// Refresh cached status from the native runtime.
+  static Future<TailscaleStatus> refreshStatus() async {
+    await ensureInitialized();
+    _lastStatus = await Tailscale.instance.status();
+    return _lastStatus!;
+  }
+
+  /// Listen for lifecycle state changes; refreshes [lastStatus] on each event.
+  static StreamSubscription<NodeState> listenState(
+    void Function(TailscaleStatus status) onData,
+  ) {
+    return Tailscale.instance.onStateChange.listen((_) async {
+      try {
+        final status = await Tailscale.instance.status();
+        _lastStatus = status;
+        onData(status);
+      } catch (e, st) {
+        _log.warning('status() after state change failed', e, st);
+      }
+    });
+  }
+
+  static Future<void> _excludeFromBackup(Directory dir) async {
+    if (kIsWeb || !Platform.isIOS) return;
+    try {
+      // NSURLIsExcludedFromBackupKey via xattr (same effect as Foundation API).
+      await Process.run('xattr', [
+        '-w',
+        'com.apple.MobileBackup',
+        '1',
+        dir.path,
+      ]);
+    } catch (e) {
+      _log.warning('Could not exclude Tailscale state from backup: $e');
+    }
+  }
+}

--- a/lib/services/finamp_http_client.dart
+++ b/lib/services/finamp_http_client.dart
@@ -1,0 +1,53 @@
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+import 'package:http/io_client.dart';
+import 'package:logging/logging.dart';
+import 'package:tailscale/tailscale.dart';
+
+import 'embedded_tailscale_service.dart';
+import 'finamp_settings_helper.dart';
+
+/// [http.Client] that optionally routes through embedded Tailscale tsnet.
+///
+/// Chopper keeps a single client for the process lifetime; this delegates each
+/// [send] to either the default [IOClient] or [Tailscale.instance.http.client]
+/// based on the current [FinampSettings.useEmbeddedTailscale] flag and whether
+/// tsnet is up.
+class FinampHttpClient extends http.BaseClient {
+  FinampHttpClient({Duration connectionTimeout = const Duration(seconds: 10)})
+    : _default = IOClient(
+        HttpClient()..connectionTimeout = connectionTimeout,
+      );
+
+  final http.Client _default;
+  final _log = Logger('FinampHttpClient');
+
+  http.Client get _active {
+    final useTs = FinampSettingsHelper.finampSettings.useEmbeddedTailscale;
+    if (!useTs) return _default;
+    if (!EmbeddedTailscaleService.isRunning) {
+      _log.warning(
+        'useEmbeddedTailscale is on but tsnet is not running; using default client',
+      );
+      return _default;
+    }
+    try {
+      return Tailscale.instance.http.client;
+    } catch (e) {
+      _log.warning('Tailscale http.client unavailable ($e); using default');
+      return _default;
+    }
+  }
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    return _active.send(request);
+  }
+
+  @override
+  void close() {
+    _default.close();
+    // Do not close Tailscale.instance.http.client — owned by the package.
+  }
+}

--- a/lib/services/finamp_settings_helper.g.dart
+++ b/lib/services/finamp_settings_helper.g.dart
@@ -1298,6 +1298,14 @@ extension FinampSetters on FinampSettingsHelper {
     ).put("FinampSettings", finampSettingsTemp);
   }
 
+  static void setUseEmbeddedTailscale(bool newUseEmbeddedTailscale) {
+    FinampSettings finampSettingsTemp = FinampSettingsHelper.finampSettings;
+    finampSettingsTemp.useEmbeddedTailscale = newUseEmbeddedTailscale;
+    Hive.box<FinampSettings>(
+      "FinampSettings",
+    ).put("FinampSettings", finampSettingsTemp);
+  }
+
   static void setBufferDuration(Duration newBufferDuration) {
     FinampSettings finampSettingsTemp = FinampSettingsHelper.finampSettings;
     finampSettingsTemp.bufferDuration = newBufferDuration;
@@ -1741,6 +1749,10 @@ extension FinampSettingsProviderSelectors on StreamProvider<FinampSettings> {
   ProviderListenable<bool> get verboseLogging => finampSettingsProvider.select(
     (value) => value.requireValue.verboseLogging,
   );
+  ProviderListenable<bool> get useEmbeddedTailscale =>
+      finampSettingsProvider.select(
+        (value) => value.requireValue.useEmbeddedTailscale,
+      );
   ProviderListenable<DownloadProfile> get downloadTranscodingProfile =>
       finampSettingsProvider.select(
         (value) => value.requireValue.downloadTranscodingProfile,

--- a/lib/services/jellyfin_api.dart
+++ b/lib/services/jellyfin_api.dart
@@ -1,5 +1,5 @@
 import 'dart:async';
-import 'dart:io' show HttpClient, Platform;
+import 'dart:io' show Platform;
 
 import 'package:chopper/chopper.dart';
 import 'package:device_info_plus/device_info_plus.dart';
@@ -7,10 +7,10 @@ import 'package:finamp/models/finamp_models.dart';
 import 'package:finamp/services/http_aggregate_logging_interceptor.dart';
 import 'package:flutter/foundation.dart';
 import 'package:get_it/get_it.dart';
-import 'package:http/io_client.dart' as http;
 import 'package:package_info_plus/package_info_plus.dart';
 
 import '../models/jellyfin_models.dart';
+import 'finamp_http_client.dart';
 import 'finamp_user_helper.dart';
 import 'jellyfin_api_helper.dart';
 
@@ -578,12 +578,10 @@ abstract class JellyfinApi extends ChopperService {
     final chopperHttpLogLevel = Level.body; //TODO allow changing the log level in settings (and a debug config file?)
 
     final client = ChopperClient(
-      client: http.IOClient(
-        HttpClient()
-          ..connectionTimeout = const Duration(
-            seconds: 10,
-          ), // if we don't get a response by then, it's probably not worth it to wait any longer. this prevents the server connection test from taking too long
-      ),
+      // When useEmbeddedTailscale is on and tsnet is up, FinampHttpClient
+      // delegates to package:tailscale's http.Client (MagicDNS / WireGuard
+      // in-process). Otherwise the default IOClient is used.
+      client: FinampHttpClient(),
       // The first part of the URL is now here
       services: [
         // The generated implementation

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1813,6 +1813,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.4.1+1"
+  tailscale:
+    dependency: "direct main"
+    description:
+      name: tailscale
+      sha256: adeb58eed87f733d749d889a577763b8b1d296649301f33f28de71e0831bf11c
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.0"
   term_glyph:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 version: 0.9.25+126
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.4
 
 dependencies:
   flutter:
@@ -30,6 +30,9 @@ dependencies:
   json_annotation: ^4.8.1
   chopper: ^8.0.0
   get_it: ^8.2.0
+  # Embedded Tailscale (userspace tsnet) for MagicDNS without a system VPN.
+  # Requires Go 1.25+ on PATH at build time (see docs/EMBEDDED_TAILSCALE.md).
+  tailscale: ^0.8.0
   # just_audio: ^0.10.5
   just_audio:
     # TODO switch back to official just_audio once https://github.com/ryanheise/just_audio/pull/1555 is merged


### PR DESCRIPTION
## Summary
- Embed userspace Tailscale via `package:tailscale` so Finamp can reach Jellyfin MagicDNS without the system Tailscale VPN (coexists with ExpressVPN).
- Opt-in Settings → Embedded Tailscale (toggle, auth key / interactive login URL, status, logout/reset); Hive `useEmbeddedTailscale` (`@HiveField(154)`).
- Chopper uses `FinampHttpClient`, which delegates to `Tailscale.instance.http.client` when enabled and running; auto-`up()` on launch when the toggle is on.
- Docs: `docs/EMBEDDED_TAILSCALE.md` (Go 1.25+, Dart ≥ 3.10.4, backup exclusion, streaming follow-up).

## Notes
- Music Finder is intentionally **not** on this branch (upstream-facing).
- Audio streaming via `just_audio` may still bypass tsnet — documented follow-up.
- Hive field 154 overlaps Music Finder’s field on `feat/music-finder-on-redesign` if those branches are stacked later.

## Test plan
- [ ] `go version` ≥ 1.25; Flutter from Development SDK (Dart ≥ 3.10.4)
- [ ] `flutter pub get` and build/run on device
- [ ] Enable Embedded Tailscale + auth key; status shows Running with a 100.x IP
- [ ] Jellyfin URL uses MagicDNS; API login/browse works with ExpressVPN active
- [ ] Toggle off; LAN/public Jellyfin URL still works
- [ ] Relaunch with toggle on; node reconnects without reopening Settings
- [ ] Confirm media streaming behavior (known possible gap)